### PR TITLE
Option to sync sites when sites not available on current site

### DIFF
--- a/src/popup/app/current/currentController.js
+++ b/src/popup/app/current/currentController.js
@@ -2,7 +2,7 @@ angular
     .module('bit.current')
 
     .controller('currentController', function ($scope, siteService, tldjs, toastr, $q, $window, $state, autofillService,
-        $analytics) {
+        $analytics, syncService) {
         var pageDetails = null,
             tabId = null,
             url = null,
@@ -10,6 +10,7 @@ angular
             canAutofill = false;
 
         $scope.loaded = false;
+        $scope.syncingSites = false;
 
         loadVault();
         function loadVault() {
@@ -88,6 +89,14 @@ angular
                 toastr.error('Unable to auto-fill the selected site on this page. ' +
                     'Copy/paste your username and/or password instead.');
             }
+        };
+
+        $scope.syncSites = function () {
+            $scope.syncingSites = true;
+            syncService.fullSync(function () {
+                $scope.syncingSites = false;
+                toastr.success('Syncing complete');
+            });
         };
 
         $scope.$on('syncCompleted', function (event, successfully) {

--- a/src/popup/app/current/views/current.html
+++ b/src/popup/app/current/views/current.html
@@ -32,6 +32,10 @@
         <p>
             There are no sites available to auto-fill for the current browser tab.
             <button ng-click="addSite()" style="margin-top: 20px;" class="btn btn-link btn-block">Add a Site</button>
+            <button ng-click="syncSites()" style="margin-top: 20px;" class="btn btn-link btn-block">Sync Vault</button>
+            <span ng-show="syncingSites" style="display: block; margin-top: 20px;">
+                <i class="text-muted fa fa-lg fa-spinner fa-spin"></i>
+            </span>
         </p>
     </div>
     <div class="page-loading" ng-if="!loaded">


### PR DESCRIPTION
I find myself wanting to sync when I add a site in one tab and open another before the 5 minute refresh hits.  The current manual sync is buried in settings. This lets me quickly sync when I expect to find a new site but it is not yet there.
