### PR TITLE
Changed translation for "submit" & "lost2FAApp"

### DIFF
--- a/src/_locales/fi/messages.json
+++ b/src/_locales/fi/messages.json
@@ -32,7 +32,7 @@
     "description": "Close"
   },
   "submit": {
-    "message": "Lähetä",
+    "message": "Jatka",
     "description": "Submit"
   },
   "emailAddress": {
@@ -600,7 +600,7 @@
     "description": "Are you sure you want to overwrite the current password?"
   },
   "lost2FAApp": {
-    "message": "Ei pääsyä tunnistautumispalveluun?",
+    "message": "Etkö pääse tunnistautumispalveluun?",
     "description": "Lost authenticator app?"
   },
   "credits": {


### PR DESCRIPTION
The "submit" meaning was okay in the Create Account screen, but not quite when the re-entering the master password (when the vault has been locked). Now it fits both.

Made the "lost2FAApp" translation less "clunky", more friendlier towards the user.