### PR TITLE
Fix password generation's handling of the ambiguous option.

### DIFF
--- a/src/popup/app/tools/views/toolsPasswordGenerator.html
+++ b/src/popup/app/tools/views/toolsPasswordGenerator.html
@@ -70,7 +70,9 @@
             <div class="list-section-items">
                 <div class="list-section-item list-section-item-checkbox">
                     <label for="ambiguous">{{i18n.avoidAmbChar}}</label>
-                    <input id="ambiguous" type="checkbox" ng-model="options.ambiguous" ng-change="saveOptions(options)">
+                    <input id="ambiguous" type="checkbox" ng-model="options.ambiguous"
+                           ng-true-value="false" ng-false-value="true"
+                           ng-change="saveOptions(options)">
                 </div>
             </div>
         </div>

--- a/src/services/passwordGenerationService.js
+++ b/src/services/passwordGenerationService.js
@@ -67,15 +67,15 @@ function initPasswordGenerationService() {
         var allCharSet = '';
 
         var lowercaseCharSet = 'abcdefghijkmnopqrstuvwxyz';
-        if (!o.ambiguous) lowercaseCharSet += 'l';
+        if (o.ambiguous) lowercaseCharSet += 'l';
         if (o.lowercase) allCharSet += lowercaseCharSet;
 
         var uppercaseCharSet = 'ABCDEFGHIJKLMNPQRSTUVWXYZ';
-        if (!o.ambiguous) uppercaseCharSet += 'O';
+        if (o.ambiguous) uppercaseCharSet += 'O';
         if (o.uppercase) allCharSet += uppercaseCharSet;
 
         var numberCharSet = '23456789';
-        if (!o.ambiguous) numberCharSet += '01';
+        if (o.ambiguous) numberCharSet += '01';
         if (o.number) allCharSet += numberCharSet;
 
         var specialCharSet = '!@#$%^&*';

--- a/src/services/passwordGenerationService.js
+++ b/src/services/passwordGenerationService.js
@@ -67,15 +67,15 @@ function initPasswordGenerationService() {
         var allCharSet = '';
 
         var lowercaseCharSet = 'abcdefghijkmnopqrstuvwxyz';
-        if (o.ambiguous) lowercaseCharSet += 'l';
+        if (!o.ambiguous) lowercaseCharSet += 'l';
         if (o.lowercase) allCharSet += lowercaseCharSet;
 
         var uppercaseCharSet = 'ABCDEFGHIJKLMNPQRSTUVWXYZ';
-        if (o.ambiguous) uppercaseCharSet += 'O';
+        if (!o.ambiguous) uppercaseCharSet += 'O';
         if (o.uppercase) allCharSet += uppercaseCharSet;
 
         var numberCharSet = '23456789';
-        if (o.ambiguous) numberCharSet += '01';
+        if (!o.ambiguous) numberCharSet += '01';
         if (o.number) allCharSet += numberCharSet;
 
         var specialCharSet = '!@#$%^&*';
@@ -103,7 +103,7 @@ function initPasswordGenerationService() {
     // ref https://github.com/EFForg/OpenWireless/blob/master/app/js/diceware.js
     function randomInt(min, max) {
         var rval = 0;
-        var range = max - min;
+        var range = max - min + 1;
 
         var bits_needed = Math.ceil(Math.log2(range));
         if (bits_needed > 53) {


### PR DESCRIPTION
i see two problems here - the ``options.ambiguous`` boolean is set to ``true`` when "avoid ambiguous" is checked, however the code has:
```
var numberCharSet = '23456789';
if (o.ambiguous) numberCharSet += '01'; 
```

this logic is reversed, it should be ``if (!o.ambiguous) ...``.  i guess the meaning of that boolean is.. ambiguous.

--

second issue appears to be the max bound of ``randomInt(min, max)``.

it returns results between ``min`` and ``max - 1``.  you can see this easily by running ``randomInt(0, 1)`` in a loop; the current implementation only returns 0.  (note this bug effectively disables the "shuffle" block).

the fix should be to increase the range by 1: ``var range = max - min + 1;``

Fixes issue #97