### PR TITLE
Remove tab character from Italian translation

### DIFF
--- a/src/_locales/it/messages.json
+++ b/src/_locales/it/messages.json
@@ -132,7 +132,7 @@
     "description": "Verification Code"
   },
   "enterTwoStepVerCode": {
-    "message": "Inserisci il codice	di verifica in due passaggi.",
+    "message": "Inserisci il codice di verifica in due passaggi.",
     "description": "Enter your two-step verification code."
   },
   "account": {


### PR DESCRIPTION
When running master on a local Firefox, about:debugging refused to load it with the following error:

> 1489377078449   addons.webextension.<unknown>   ERROR   Loading extension 'null': Loading locale file _locales/it/messages.json: SyntaxError: JSON.parse: bad control character in string literal at line 135 column 36 of the JSON data

It turns out that is a tab character - this patch replaces it with a space.