### PR TITLE
Show exact matches for the URL at the top of the matching sites list

### DIFF
--- a/src/popup/app/current/currentController.js
+++ b/src/popup/app/current/currentController.js
@@ -106,6 +106,11 @@ angular
             });
         };
 
+        $scope.sortUriMatch = function(login) {
+            // exact matches should sort earlier.
+            return url && url.startsWith(login.uri) ? 0 : 1;
+        }
+
         $scope.$on('syncCompleted', function (event, successfully) {
             if ($scope.loaded) {
                 setTimeout(loadVault, 500);

--- a/src/popup/app/current/views/current.html
+++ b/src/popup/app/current/views/current.html
@@ -10,7 +10,7 @@
             <div class="list-grouped">
                 <a href="javascript:void(0)" ng-click="fillLogin(login)" class="list-grouped-item condensed"
                    title="{{i18n.autoFill}} {{login.name}}"
-                   ng-repeat="login in theLogins = (logins | orderBy: ['name', 'username']) track by $index">
+                   ng-repeat="login in theLogins = (logins | orderBy: [sortUriMatch, 'name', 'username']) track by $index">
                     <span class="btn-list" href="" ng-click="$event.stopPropagation()" title="{{i18n.copyPassword}}"
                           ngclipboard ngclipboard-error="clipboardError(e)"
                           ngclipboard-success="clipboardSuccess(e, i18n.password)"


### PR DESCRIPTION
For some sites I have over 10 "matching" sites because the matching is done on the TLD and ignores subdomains, making it difficult to find the single login I need to use.

This patch sorts the list of logins so exact matches (of which there will typically be zero or 1) appear at the top of the list. Issue #77 also suggested this as a short-term solution to fully featured sub-domain support.