### PR TITLE
PasswordGenerator: Increase max length from 64 to 128

### DIFF
--- a/src/popup/app/tools/toolsPasswordGeneratorController.js
+++ b/src/popup/app/tools/toolsPasswordGeneratorController.js
@@ -16,7 +16,7 @@
             value: 12,
             options: {
                 floor: 5,
-                ceil: 64,
+                ceil: 128,
                 step: 1,
                 hideLimitLabels: true,
                 hidePointerLabels: true,


### PR DESCRIPTION
LastPass lets me generate passwords up to 100 chars in length, so only having 64 chars to play with is a bit of a regression for me.

<img width="329" alt="screen shot 2017-03-21 at 20 57 16" src="https://cloud.githubusercontent.com/assets/1525809/24170652/777ff3d6-0e79-11e7-9330-2d65faa5d55a.png">
