### PR TITLE
Fix issue #271, popup window drawing cropped

### DIFF
--- a/src/popup/app/global/mainController.js
+++ b/src/popup/app/global/mainController.js
@@ -6,9 +6,11 @@ angular
         var self = this;
         self.currentYear = new Date().getFullYear();
         self.animation = '';
-        self.xsBody = $window.screen.availHeight < 600;
-        self.smBody = !self.xsBody && $window.screen.availHeight <= 800;
-        self.lgBody = !self.xsBody && !self.smBody && utilsService && !utilsService.isFirefox() && !utilsService.isEdge();
+        setTimeout(function() {        
+            self.xsBody = $window.screen.availHeight < 600;
+            self.smBody = !self.xsBody && $window.screen.availHeight <= 800;
+            self.lgBody = !self.xsBody && !self.smBody && utilsService && !utilsService.isFirefox() && !utilsService.isEdge();
+        }, 0);
         self.disableSearch = utilsService && utilsService.isEdge();
         self.inSidebar = utilsService && utilsService.inSidebar($window);
 

--- a/src/popup/less/popup.less
+++ b/src/popup/less/popup.less
@@ -12,15 +12,15 @@ html {
 }
 
 body {
-    width: 320px !important;
-    height: 568px !important;
+    width: 375px !important;
+    height: 500px !important;
     background-color: @background-color;
     overflow: hidden;
 }
 
 body.lg {
     width: 375px !important;
-    height: 667px !important;
+    height: 600px !important;
 }
 
 body.sm {


### PR DESCRIPTION
@kspearrin I can constantly reproduce this, this doesn't happen every time the popup opens, but often enough.

Basically what happens is the popup is created with the dimensions of 320x568 (The default dimensions for `body`) and then angular applies either the `lg`, `sm` or `xs` class to the `body` element. In the case of @Briansbum it's `lg` and for @tjohnell-handy it's `sm`.

Chrome tries to animate the popup based on the initial size, but changing the size while it's doing it causes it to stop. Wrapping it around a timer resolves it. (Thread? Event loop?)

This will always look off on Chrome. To minimize impact I changed the default body size to 375x500 to match what most users will see. The large size seems to be only relevant for Chrome, but it was also too wide. Chrome limits popups to 800x600.

@kspearrin Maybe consider removing the lg size at this point since the difference between sm and lg is 100px.