### PR TITLE
firefox: show popup when click "vault is locked"

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -197,8 +197,10 @@ var bg_isBackground = true,
                     bg_passwordGenerationService.addHistory(password);
                 });
             }
-            else if (info.menuItemId === 'vault-locked') {
-                chrome.browserAction.openPopup();
+            else if (info.menuItemId === 'autofill_noop') {
+                if (bg_utilsService.isFirefox() && chrome.browserAction.openPopup) {
+                    chrome.browserAction.openPopup();
+                }
             }
             else if (info.parentMenuItemId === 'autofill' || info.parentMenuItemId === 'copy-username' ||
                 info.parentMenuItemId === 'copy-password') {
@@ -487,17 +489,7 @@ var bg_isBackground = true,
             setSidebarActionText(theText, tabId);
         }, function () {
             if (contextMenuEnabled) {
-                if (bg_utilsService.isFirefox() && chrome.browserAction.openPopup) {
-                    chrome.contextMenus.create({
-                        type: 'normal',
-                        id: 'vault-locked',
-                        parentId: 'autofill',
-                        contexts: ['all'],
-                        title: bg_i18nService.vaultLocked
-                    });
-                } else {
-                    loadNoLoginsContextMenuOptions(bg_i18nService.vaultLocked);
-                }
+                loadNoLoginsContextMenuOptions(bg_i18nService.vaultLocked);
             }
             setBrowserActionText('', tabId);
             setSidebarActionText('', tabId);

--- a/src/background.js
+++ b/src/background.js
@@ -197,6 +197,9 @@ var bg_isBackground = true,
                     bg_passwordGenerationService.addHistory(password);
                 });
             }
+            else if (info.menuItemId === 'vault-locked') {
+                chrome.browserAction.openPopup();
+            }
             else if (info.parentMenuItemId === 'autofill' || info.parentMenuItemId === 'copy-username' ||
                 info.parentMenuItemId === 'copy-password') {
                 var id = info.menuItemId.split('_')[1];
@@ -484,7 +487,17 @@ var bg_isBackground = true,
             setSidebarActionText(theText, tabId);
         }, function () {
             if (contextMenuEnabled) {
-                loadNoLoginsContextMenuOptions(bg_i18nService.vaultLocked);
+                if (bg_utilsService.isFirefox() && chrome.browserAction.openPopup) {
+                    chrome.contextMenus.create({
+                        type: 'normal',
+                        id: 'vault-locked',
+                        parentId: 'autofill',
+                        contexts: ['all'],
+                        title: bg_i18nService.vaultLocked
+                    });
+                } else {
+                    loadNoLoginsContextMenuOptions(bg_i18nService.vaultLocked);
+                }
             }
             setBrowserActionText('', tabId);
             setSidebarActionText('', tabId);

--- a/src/services/cryptoService.js
+++ b/src/services/cryptoService.js
@@ -31,7 +31,7 @@ function initCryptoService(constantsService) {
             }
 
             return self.utilsService.saveObjToStorage(keyKey, key.keyB64);
-        })
+        });
     };
 
     CryptoService.prototype.setKeyHash = function (keyHash, callback) {


### PR DESCRIPTION
#272

officially supported by only firefox so far: [openPopup](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/browserAction/openPopup).

This function also exist on Chromium as I tested but it is not in the docs so I guess I shouldn't include it.