### PR TITLE
Minor improvements to Typescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ The bitwarden browser extension is written using the Chrome Web Extension API an
 By default the extension is targeting the production API. If you are running the [Core](https://github.com/bitwarden/core) API locally, you'll need to switch the extension to target your local instance. Open `src/services/apiService.js` and set `self.baseUrl` and `self.identityBaseUrl` to your local API instance (ex. `http://localhost:5000`).
 
 Then run the following commands:
-
-- `npm install`
-- `gulp build`
-- `npm run dev:watch`
+```bash
+npm install
+npm run dev:watch
+```
 
 You can now load the extension into your browser through the browser's extension tools page:
 
@@ -41,6 +41,17 @@ You can now load the extension into your browser through the browser's extension
 - Firefox
   1. Type `about:debugging` in your address bar to bring up the add-ons page.
   2. Click the `Load Temporary Add-on` button, navigate to the `dist/manifest.json` file, and "Open".
+
+### Release
+
+To build the the extension for production the following commands should be run:
+
+```bash
+npm run prod
+gulp dist:[browser]
+```
+
+Where `[browser]` is the web browser to target. Currently the following web browsers are supported: `chrome`, `edge`, `firefox` and `opera`. 
 
 # Contribute
 

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.0.0",
   "scripts": {
     "start:firefox": "web-ext run --source-dir ./dist/",
-    "dev": "webpack --config webpack.dev.js",
-    "dev:watch": "webpack --config webpack.dev.js --watch",
-    "prod": "webpack --config webpack.prod.js"
+    "dev": "gulp build && webpack --config webpack.dev.js",
+    "dev:watch": "gulp build && webpack --config webpack.dev.js --watch",
+    "prod": "gulp build && webpack --config webpack.prod.js"
   },
   "devDependencies": {
     "angular": "1.6.6",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -73,7 +73,11 @@ module.exports = {
         new CopyWebpackPlugin([
             // Temporarily copy the whole app folder, can be removed once
             // the templates uses template rather than using templateUrl.
-            { from: './src/popup/app', to: 'popup/app' },
+            {
+                context: 'src/popup/app',
+                from: '**/*.html',
+                to: 'popup/app'
+            },
             './src/manifest.json',
             { from: './src/_locales', to: '_locales' },
             { from: './src/edge', to: 'edge' },


### PR DESCRIPTION
Changed the npm scripts to also run `gulp build` and changed webpack to only copy html files for the popup application. The readme has also been updated with the proper commands and an additional section on how to build the extension for production was added.