### PR TITLE
[Typescript] Convert tools page to TS 

### DIFF
--- a/src/popup/app/app.js
+++ b/src/popup/app/app.js
@@ -28,6 +28,7 @@ require('../less/libs.less');
 require('../less/popup.less');
 
 import ComponentsModule from './components/components.module';
+import ToolsModule from './tools/tools.module';
 
 // Model imports
 import { AttachmentData } from '../../models/data/attachmentData';
@@ -80,7 +81,7 @@ angular
         'bit.current',
         'bit.vault',
         'bit.settings',
-        'bit.tools',
+        ToolsModule,
         'bit.lock'
     ]);
 
@@ -126,8 +127,6 @@ require('./settings/settingsAddFolderController.js');
 require('./settings/settingsEditFolderController.js');
 require('./settings/settingsPremiumController.js');
 require('./settings/settingsEnvironmentController.js');
-require('./tools/toolsModule.js');
-require('./tools/toolsController.js');
 require('./tools/toolsPasswordGeneratorController.js');
 require('./tools/toolsPasswordGeneratorHistoryController.js');
 require('./tools/toolsExportController.js');

--- a/src/popup/app/components/componentsModule.js
+++ b/src/popup/app/components/componentsModule.js
@@ -1,2 +1,0 @@
-angular
-    .module('bit.components', []);

--- a/src/popup/app/config.js
+++ b/src/popup/app/config.js
@@ -124,9 +124,8 @@
             })
             .state('tabs.tools', {
                 url: '/tools',
-                templateUrl: 'app/tools/views/tools.html',
-                controller: 'toolsController',
-                controllerAs: '$ctrl'
+                //component: 'tools',
+                template: '<tools></tools>'
             })
 
             .state('viewFolder', {

--- a/src/popup/app/config.js
+++ b/src/popup/app/config.js
@@ -125,7 +125,8 @@
             .state('tabs.tools', {
                 url: '/tools',
                 templateUrl: 'app/tools/views/tools.html',
-                controller: 'toolsController'
+                controller: 'toolsController',
+                controllerAs: '$ctrl'
             })
 
             .state('viewFolder', {

--- a/src/popup/app/tools/tools.component.ts
+++ b/src/popup/app/tools/tools.component.ts
@@ -1,6 +1,7 @@
 ﻿import UtilsService from '../../../services/utils.service';
+import * as template from './views/tools.html';
 
-export class ToolsController {
+class ToolsController {
     showExport: boolean;
     i18n: any;
 
@@ -41,3 +42,9 @@ export class ToolsController {
         });
     };
 }
+
+export const ToolsComponent = {
+    bindings: {},
+    controller: ToolsController,
+    template,
+};

--- a/src/popup/app/tools/tools.controller.ts
+++ b/src/popup/app/tools/tools.controller.ts
@@ -1,36 +1,39 @@
-﻿angular
-    .module('bit.tools')
+﻿import UtilsService from '../../../services/utils.service';
 
-    .controller('toolsController', function ($scope, SweetAlert, i18nService, $analytics, utilsService) {
+export class ToolsController {
+    constructor(private $scope: any, private SweetAlert: any, private i18nService: any,
+        private $analytics: any, private utilsService: UtilsService) {
+
         $scope.i18n = i18nService;
         $scope.showExport = !utilsService.isEdge();
-        $scope.launchWebVault = function (createOrg) {
+        $scope.launchWebVault = (createOrg: any) => {
             $analytics.eventTrack('Launch Web Vault' + (createOrg ? ' For Share' : ''));
             chrome.tabs.create({ url: 'https://vault.bitwarden.com/#/' + (createOrg ? '?org=free' : '') });
         };
 
-        $scope.launchiOS = function () {
+        $scope.launchiOS = () => {
             $analytics.eventTrack('Launch iOS');
             chrome.tabs.create({ url: 'https://itunes.apple.com/us/app/bitwarden-free-password-manager/id1137397744?mt=8' });
         };
 
-        $scope.launchAndroid = function () {
+        $scope.launchAndroid = () => {
             $analytics.eventTrack('Launch Android');
             chrome.tabs.create({ url: 'https://play.google.com/store/apps/details?id=com.x8bit.bitwarden' });
         };
 
-        $scope.launchImport = function () {
+        $scope.launchImport = () => {
             SweetAlert.swal({
                 title: i18nService.importItems,
                 text: i18nService.importItemsConfirmation,
                 showCancelButton: true,
                 confirmButtonText: i18nService.yes,
                 cancelButtonText: i18nService.cancel
-            }, function (confirmed) {
+            }, function (confirmed: boolean) {
                 if (confirmed) {
                     $analytics.eventTrack('Launch Web Vault For Import');
                     chrome.tabs.create({ url: 'https://help.bitwarden.com/article/import-data/' });
                 }
             });
         };
-    });
+    }
+}

--- a/src/popup/app/tools/tools.controller.ts
+++ b/src/popup/app/tools/tools.controller.ts
@@ -1,39 +1,43 @@
 ﻿import UtilsService from '../../../services/utils.service';
 
 export class ToolsController {
-    constructor(private $scope: any, private SweetAlert: any, private i18nService: any,
+    showExport: boolean;
+    i18n: any;
+
+    constructor(private SweetAlert: any, private i18nService: any,
         private $analytics: any, private utilsService: UtilsService) {
 
-        $scope.i18n = i18nService;
-        $scope.showExport = !utilsService.isEdge();
-        $scope.launchWebVault = (createOrg: any) => {
-            $analytics.eventTrack('Launch Web Vault' + (createOrg ? ' For Share' : ''));
-            chrome.tabs.create({ url: 'https://vault.bitwarden.com/#/' + (createOrg ? '?org=free' : '') });
-        };
-
-        $scope.launchiOS = () => {
-            $analytics.eventTrack('Launch iOS');
-            chrome.tabs.create({ url: 'https://itunes.apple.com/us/app/bitwarden-free-password-manager/id1137397744?mt=8' });
-        };
-
-        $scope.launchAndroid = () => {
-            $analytics.eventTrack('Launch Android');
-            chrome.tabs.create({ url: 'https://play.google.com/store/apps/details?id=com.x8bit.bitwarden' });
-        };
-
-        $scope.launchImport = () => {
-            SweetAlert.swal({
-                title: i18nService.importItems,
-                text: i18nService.importItemsConfirmation,
-                showCancelButton: true,
-                confirmButtonText: i18nService.yes,
-                cancelButtonText: i18nService.cancel
-            }, function (confirmed: boolean) {
-                if (confirmed) {
-                    $analytics.eventTrack('Launch Web Vault For Import');
-                    chrome.tabs.create({ url: 'https://help.bitwarden.com/article/import-data/' });
-                }
-            });
-        };
+        this.i18n = i18nService;
+        this.showExport = !utilsService.isEdge();
     }
+
+    launchWebVault(createOrg: any) {
+        this.$analytics.eventTrack('Launch Web Vault' + (createOrg ? ' For Share' : ''));
+        chrome.tabs.create({ url: 'https://vault.bitwarden.com/#/' + (createOrg ? '?org=free' : '') });
+    }
+
+    launchAndroid() {
+        this.$analytics.eventTrack('Launch Android');
+        chrome.tabs.create({ url: 'https://play.google.com/store/apps/details?id=com.x8bit.bitwarden' });
+    }
+
+    launchiOS() {
+        this.$analytics.eventTrack('Launch iOS');
+        chrome.tabs.create({ url: 'https://itunes.apple.com/us/app/bitwarden-free-password-manager/id1137397744?mt=8' });
+    }
+
+    launchImport() {
+        this.SweetAlert.swal({
+            title: this.i18nService.importItems,
+            text: this.i18nService.importItemsConfirmation,
+            showCancelButton: true,
+            confirmButtonText: this.i18nService.yes,
+            cancelButtonText: this.i18nService.cancel
+        }, (confirmed: boolean) => {
+            if (confirmed) {
+                this.$analytics.eventTrack('Launch Web Vault For Import');
+                chrome.tabs.create({ url: 'https://help.bitwarden.com/article/import-data/' });
+            }
+        });
+    };
 }

--- a/src/popup/app/tools/tools.module.ts
+++ b/src/popup/app/tools/tools.module.ts
@@ -1,7 +1,7 @@
 import * as angular from 'angular';
-import { ToolsController } from './tools.controller';
+import { ToolsComponent } from './tools.component';
 
 export default angular
     .module('bit.tools', ['ngAnimate', 'ngclipboard', 'toastr', 'oitozero.ngSweetAlert'])
-    .controller('toolsController', ToolsController) 
+    .component('tools', ToolsComponent) 
     .name;

--- a/src/popup/app/tools/tools.module.ts
+++ b/src/popup/app/tools/tools.module.ts
@@ -1,0 +1,7 @@
+import * as angular from 'angular';
+import { ToolsController } from './tools.controller';
+
+export default angular
+    .module('bit.tools', ['ngAnimate', 'ngclipboard', 'toastr', 'oitozero.ngSweetAlert'])
+    .controller('toolsController', ToolsController) 
+    .name;

--- a/src/popup/app/tools/toolsModule.js
+++ b/src/popup/app/tools/toolsModule.js
@@ -1,2 +1,0 @@
-﻿angular
-    .module('bit.tools', ['ngAnimate', 'ngclipboard', 'toastr', 'oitozero.ngSweetAlert']);

--- a/src/popup/app/tools/views/tools.html
+++ b/src/popup/app/tools/views/tools.html
@@ -2,7 +2,7 @@
     <div class="left">
         <a href="" ng-click="main.expandVault()"><i class="fa fa-external-link fa-rotate-270 fa-lg"></i></a>
     </div>
-    <div class="title">{{i18n.tools}}</div>
+    <div class="title">{{$ctrl.i18n.tools}}</div>
 </div>
 <div class="content content-tabs">
     <div class="list">
@@ -10,38 +10,38 @@
             <div class="list-section-items">
                 <a class="list-section-item wrap" ui-sref="passwordGenerator({animation: 'in-slide-up'})">
                     <span class="leading-icon" style="color: #eba776;"><i class="fa fa-refresh fa-fw"></i></span>
-                    <span class="text">{{i18n.passGen}}</span>
-                    <span class="detail">{{i18n.passGenInfo}}</span>
+                    <span class="text">{{$ctrl.i18n.passGen}}</span>
+                    <span class="detail">{{$ctrl.i18n.passGenInfo}}</span>
                 </a>
-                <a class="list-section-item wrap" href="" ng-click="launchWebVault()">
+                <a class="list-section-item wrap" href="" ng-click="$ctrl.launchWebVault()">
                     <span class="leading-icon" style="color: #5bb630;"><i class="fa fa-globe fa-fw"></i></span>
-                    <span class="text">{{i18n.bitWebVault}}</span>
-                    <span class="detail">{{i18n.bitWebVaultInfo}}</span>
+                    <span class="text">{{$ctrl.i18n.bitWebVault}}</span>
+                    <span class="detail">{{$ctrl.i18n.bitWebVaultInfo}}</span>
                 </a>
-                <a class="list-section-item wrap" href="" ng-click="launchiOS()">
+                <a class="list-section-item wrap" href="" ng-click="$ctrl.launchiOS()">
                     <span class="leading-icon" style="color: #999999;"><i class="fa fa-apple fa-fw"></i></span>
-                    <span class="text">{{i18n.bitIosVault}}</span>
-                    <span class="detail">{{i18n.bitIosVaultInfo}}</span>
+                    <span class="text">{{$ctrl.i18n.bitIosVault}}</span>
+                    <span class="detail">{{$ctrl.i18n.bitIosVaultInfo}}</span>
                 </a>
-                <a class="list-section-item wrap" href="" ng-click="launchAndroid()">
+                <a class="list-section-item wrap" href="" ng-click="$ctrl.launchAndroid()">
                     <span class="leading-icon" style="color: #a4c639;"><i class="fa fa-android fa-fw"></i></span>
-                    <span class="text">{{i18n.bitAndrVault}}</span>
-                    <span class="detail">{{i18n.bitAndrVaultInfo}}</span>
+                    <span class="text">{{$ctrl.i18n.bitAndrVault}}</span>
+                    <span class="detail">{{$ctrl.i18n.bitAndrVaultInfo}}</span>
                 </a>
-                <a class="list-section-item wrap" href="" ng-click="launchWebVault(true)">
+                <a class="list-section-item wrap" href="" ng-click="$ctrl.launchWebVault(true)">
                     <span class="leading-icon" style="color: #8977af;"><i class="fa fa-share-alt fa-fw"></i></span>
-                    <span class="text">{{i18n.shareVault}}</span>
-                    <span class="detail">{{i18n.shareVaultInfo}}</span>
+                    <span class="text">{{$ctrl.i18n.shareVault}}</span>
+                    <span class="detail">{{$ctrl.i18n.shareVaultInfo}}</span>
                 </a>
-                <a class="list-section-item wrap" href="" ng-click="launchImport()">
+                <a class="list-section-item wrap" href="" ng-click="$ctrl.launchImport()">
                     <span class="leading-icon" style="color: #6fc2ff;"><i class="fa fa-cloud-upload fa-fw"></i></span>
-                    <span class="text">{{i18n.importItems}}</span>
-                    <span class="detail">{{i18n.importItemsInfo}}</span>
+                    <span class="text">{{$ctrl.i18n.importItems}}</span>
+                    <span class="detail">{{$ctrl.i18n.importItemsInfo}}</span>
                 </a>
                 <a class="list-section-item wrap" ui-sref="export({animation: 'in-slide-up'})" ng-if="showExport">
                     <span class="leading-icon" style="color: #ff6f6f;"><i class="fa fa-cloud-download fa-fw"></i></span>
-                    <span class="text">{{i18n.exportVault}}</span>
-                    <span class="detail">{{i18n.exportVaultInfo}}</span>
+                    <span class="text">{{$ctrl.i18n.exportVault}}</span>
+                    <span class="detail">{{$ctrl.i18n.exportVaultInfo}}</span>
                 </a>
             </div>
         </div>


### PR DESCRIPTION
I decided to split this PR in three commits.

1. In the first commit https://github.com/Hinton/browser/commit/1e6ffbbbaca6d0e2970fa32ace0983f22ccee130, I convert the controller into TypeScript.
2. Afterwards in https://github.com/Hinton/browser/commit/1e63ad623bfe75345f7badd0a37a1ae0cd4d351b, I removed `$scope`, moved functions out into the class, and updated the template to use `$ctrl`.
3. Lastly in https://github.com/Hinton/browser/commit/f12b1d10c21bf33175a1a939e57e75e673a1534f, I changed the Controller into a Component.

For now we have to use a work-around in ui-router and set a template string to create the component, however version 1.0 or ui-router has native support for components which should improve support for variables and more.