### PR TITLE
Fix checkbox toggling

### DIFF
--- a/src/popup/app/settings/options.component.html
+++ b/src/popup/app/settings/options.component.html
@@ -9,8 +9,8 @@
         <div class="list-section">
             <div class="list-section-items">
                 <div class="list-section-item list-section-item-checkbox">
-                    <label for="totp-copy">{{$ctrl.i18n.enableAutoFillOnPageLoad}}</label>
-                    <input id="totp-copy" type="checkbox" ng-model="$ctrl.enableAutoFillOnPageLoad"
+                    <label for="auto-fill">{{$ctrl.i18n.enableAutoFillOnPageLoad}}</label>
+                    <input id="auto-fill" type="checkbox" ng-model="$ctrl.enableAutoFillOnPageLoad"
                            ng-change="$ctrl.updateAutoFillOnPageLoad()">
                 </div>
             </div>
@@ -69,8 +69,8 @@
         <div class="list-section">
             <div class="list-section-items">
                 <div class="list-section-item list-section-item-checkbox">
-                    <label for="context-menu">{{$ctrl.i18n.disableFavicon}}</label>
-                    <input id="context-menu" type="checkbox" ng-model="$ctrl.disableFavicon"
+                    <label for="favicon">{{$ctrl.i18n.disableFavicon}}</label>
+                    <input id="favicon" type="checkbox" ng-model="$ctrl.disableFavicon"
                            ng-change="$ctrl.updateDisableFavicon()">
                 </div>
             </div>


### PR DESCRIPTION
The options component had conflicting/duplicate id attributes. This caused problems when toggling checkboxes by clicking on their corresponding labels. The following GIF demonstrates this behavior.

![behaviour](https://user-images.githubusercontent.com/3844674/34060350-88835bee-e1e3-11e7-8976-02439240dcf0.gif)
