### PR TITLE
add the ability to search for ciphers by folder name

### DIFF
--- a/src/popup/app/vault/vaultController.js
+++ b/src/popup/app/vault/vaultController.js
@@ -66,6 +66,7 @@ angular
             $q.all([folderPromise, collectionPromise, cipherPromise]).then(function () {
                 $scope.loaded = true;
                 $rootScope.vaultFolders = decFolders;
+                $rootScope.vaultFoldersById = {};
                 $rootScope.vaultCollections = decCollections;
                 $rootScope.vaultCiphers = decCiphers;
 
@@ -96,6 +97,7 @@ angular
 
                     $rootScope.vaultFolders.forEach((folder) => {
                         folder.itemCount = folderCounts[folder.id || 'none'] || 0;
+                        $rootScope.vaultFoldersById[folder.id] = folder;
                     });
 
                     $rootScope.vaultCollections.forEach((collection) => {
@@ -139,6 +141,13 @@ angular
                 return true;
             }
             if (cipher.login && cipher.login.uri && cipher.login.uri.toLowerCase().indexOf(searchTerm) !== -1) {
+                return true;
+            }
+            if (
+                cipher.folderId &&
+                $rootScope.vaultFoldersById.hasOwnProperty(cipher.folderId) &&
+                $rootScope.vaultFoldersById[cipher.folderId].name.toLowerCase().indexOf(searchTerm) !== -1
+            ) {
                 return true;
             }
 


### PR DESCRIPTION
I also had the idea of using a prefix character to search using only the folder name.  For example to find ciphers that are in the folder "shopping" you might search `@shopping`.  Let me know if you think the current way is best or if a prefix should be required.