### PR TITLE
Integration with Have I been pwned

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -980,5 +980,14 @@
   },
   "twoStepNewWindowMessage": {
     "message": "Complete your two-step login request using the new tab."
+  },
+  "checkPassword": {
+    "message": "Check if the password have been previously exposed."
+  },
+  "passwordExposed": {
+    "message": "This password have been previously exposed in data breaches!"
+  },
+  "passwordSafe": {
+    "message": "This password was not found in a current data breach! It should be safe to use."
   }
 }

--- a/src/popup/app/services/services.module.ts
+++ b/src/popup/app/services/services.module.ts
@@ -4,6 +4,7 @@ import { PopupUtilsService } from './popupUtils.service';
 import { StateService } from './state.service';
 import { ValidationService } from './validation.service';
 
+import { AuditService } from 'jslib/services/audit.service';
 import { AuthService } from 'jslib/services/auth.service';
 
 import BrowserMessagingService from '../../../services/browserMessaging.service';
@@ -43,5 +44,6 @@ export default angular
     .factory('totpService', backgroundServices.totpService)
     .factory('environmentService', backgroundServices.environmentService)
     .factory('collectionService', backgroundServices.collectionService)
+    .factory('auditService', AuditService)
 
     .name;

--- a/src/popup/app/vault/vaultAddCipherController.js
+++ b/src/popup/app/vault/vaultAddCipherController.js
@@ -2,7 +2,7 @@ angular
     .module('bit.vault')
 
     .controller('vaultAddCipherController', function ($scope, $state, $stateParams, cipherService, folderService,
-        cryptoService, toastr, popupUtilsService, $analytics, i18nService, constantsService, $timeout) {
+        cryptoService, toastr, popupUtilsService, $analytics, i18nService, constantsService, $timeout, auditService) {
         $scope.i18n = i18nService;
         $scope.constants = constantsService;
         $scope.addFieldType = constantsService.fieldType.text.toString();
@@ -92,6 +92,20 @@ angular
         $scope.togglePassword = function () {
             $analytics.eventTrack('Toggled Password');
             $scope.showPassword = !$scope.showPassword;
+        };
+
+        $scope.checkPassword = () => {
+            $analytics.eventTrack('Check Password');
+
+            auditService
+                .passwordLeaked($scope.cipher.login.password)
+                .then((matches) => {
+                    if (matches != 0) {
+                        toastr.error(i18nService.passwordExposed, i18nService.errorsOccurred);
+                    } else {
+                        toastr.success(i18nService.passwordSafe)
+                    }
+                })
         };
 
         $scope.addField = function (type) {

--- a/src/popup/app/vault/vaultEditCipherController.js
+++ b/src/popup/app/vault/vaultEditCipherController.js
@@ -1,11 +1,9 @@
-import * as forge from 'node-forge';
-
 angular
     .module('bit.vault')
 
     .controller('vaultEditCipherController', function ($scope, $state, $stateParams, cipherService, folderService,
         cryptoService, toastr, SweetAlert, platformUtilsService, $analytics, i18nService, constantsService, $timeout,
-        popupUtilsService, $http) {
+        popupUtilsService, auditService) {
         $timeout(function () {
             popupUtilsService.initListSectionItemListeners(document, angular);
             document.getElementById('name').focus();
@@ -117,31 +115,15 @@ angular
         $scope.checkPassword = () => {
             $analytics.eventTrack('Check Password');
 
-            const md = forge.md.sha1.create();
-            md.update($scope.cipher.login.password);
-
-            const hash = md.digest().toHex().toUpperCase();
-            $http
-                .get('https://api.pwnedpasswords.com/range/' + hash.substr(0, 5))
-                .then((resp) => {
-                    const data = resp.data.split(/\r?\n/);
-                    const remaining = hash.substr(5);
-
-                    let matches = 0;
-                    data.forEach(element => {
-                        const d = element.split(':');
-                        if (d[0] == remaining) {
-                            console.log(d);
-                            matches = d[1];
-                        }
-                    });
-
+            auditService
+                .passwordLeaked($scope.cipher.login.password)
+                .then((matches) => {
                     if (matches != 0) {
                         toastr.error(i18nService.passwordExposed, i18nService.errorsOccurred);
                     } else {
-                        toastr.success(i18nService.passwordSafe);
+                        toastr.success(i18nService.passwordSafe)
                     }
-                });
+                })
         };
 
         $scope.addField = function (type) {

--- a/src/popup/app/vault/views/vaultAddCipher.html
+++ b/src/popup/app/vault/views/vaultAddCipher.html
@@ -44,6 +44,9 @@
                                 <input id="loginPassword" type="{{showPassword ? 'text' : 'password'}}" name="Login.Password" ng-model="cipher.login.password">
                             </div>
                             <div class="action-buttons">
+                                <a class="btn-list" href="" title="{{i18n.checkPassword}}" ng-click="checkPassword()">
+                                    <i class="fa fa-lg fa-check-circle"></i>
+                                </a>
                                 <a class="btn-list" href="" title="{{i18n.togglePassword}}" ng-click="togglePassword()">
                                     <i class="fa fa-lg" ng-class="[{'fa-eye': !showPassword}, {'fa-eye-slash': showPassword}]"></i>
                                 </a>

--- a/src/popup/app/vault/views/vaultEditCipher.html
+++ b/src/popup/app/vault/views/vaultEditCipher.html
@@ -37,6 +37,9 @@
                                 <input id="loginPassword" type="{{showPassword ? 'text' : 'password'}}" name="Login.Password" ng-model="cipher.login.password">
                             </div>
                             <div class="action-buttons">
+                                <a class="btn-list" href="" title="{{i18n.checkPassword}}" ng-click="checkPassword()">
+                                    <i class="fa fa-lg fa-check-circle"></i>
+                                </a>
                                 <a class="btn-list" href="" title="{{i18n.togglePassword}}" ng-click="togglePassword()">
                                     <i class="fa fa-lg" ng-class="[{'fa-eye': !showPassword}, {'fa-eye-slash': showPassword}]"></i>
                                 </a>


### PR DESCRIPTION
This PR implements an initial proof of concept password check using the https://haveibeenpwned.com/Passwords API.

![Animation of the password check in action](https://dl.dropboxusercontent.com/s/7etqdu5qjlbj3dh/2018-02-23_23-37-34.gif)

## How it works

Instead of sending the password to an external service, the first 5 characters of the SHA-1 hash gets sent. The service returns all known hashes beginning with that combination. Allowing the client application to lookup if the password exists in the response and determine if it has been previously leaked.

The approach is explained in more detail at: https://www.troyhunt.com/ive-just-launched-pwned-passwords-version-2/#cloudflareprivacyandkanonymity

## Remaining work

~~The initial PoC puts all of the logic inside the editCipher controller, a more logical place would be inside a new service. I would also want to explore if it's possible to return the amount of times it has been leaked inside the i18n message, @kspearrin is this doable?~~

Finally it would be nice to have a "security audit" page, from which all passwords could be checked and/or warnings could be given for in-secure passwords. (length and leaks)
