### PR TITLE
Don't leak password length through mask

### DIFF
--- a/src/popup/app/vault/vaultViewCipherController.js
+++ b/src/popup/app/vault/vaultViewCipherController.js
@@ -94,10 +94,7 @@ angular
                 return value;
             }
 
-            var masked = '';
-            for (var i = 0; i < value.length; i++) {
-                masked += '•';
-            }
+            var masked = '••••••••';
             return masked;
         };
 


### PR DESCRIPTION
This is a pretty simple PR. I'm migrating from 1Password to Bitwarden, and I noticed that while 1Password has a constant-length password mask, Bitwarden's leaks the length of the password even when it's masked. This commit simply changes to a constant-length mask.