### PR TITLE
Add some other french tags for credit card.

### DIFF
--- a/src/services/autofill.service.ts
+++ b/src/services/autofill.service.ts
@@ -431,9 +431,9 @@ export default class AutofillService implements AutofillServiceInterface {
                     fillFields.cardholderName = f;
                 } else if (!fillFields.number && this.isFieldMatch(f[attr],
                     ['cc-number', 'cc-num', 'card-number', 'card-num', 'number', 'cc', 'cc-no', 'card-no',
-                        'credit-card', 'numero-carte', 'carte', 'carte-credit'],
+                        'credit-card', 'numero-carte', 'carte', 'carte-credit', 'num-carte'],
                     ['cc-number', 'cc-num', 'card-number', 'card-num', 'cc-no', 'card-no', 'credit-card',
-                        'carte-credit', 'numero-carte'])) {
+                        'carte-credit', 'numero-carte', 'num-carte'])) {
                     fillFields.number = f;
                 } else if (!fillFields.exp && this.isFieldMatch(f[attr],
                     ['cc-exp', 'card-exp', 'cc-expiration', 'card-expiration', 'cc-ex', 'card-ex', 'card-expire',
@@ -456,7 +456,7 @@ export default class AutofillService implements AutofillServiceInterface {
                     fillFields.expYear = f;
                 } else if (!fillFields.code && this.isFieldMatch(f[attr],
                     ['cvv', 'cvc', 'cvv2', 'cc-csc', 'cc-cvv', 'card-csc', 'card-cvv', 'cvd', 'cid', 'cvc2', 'cnv',
-                        'cvn2', 'cc-code', 'card-code'])) {
+                        'cvn2', 'cc-code', 'card-code', 'code-securite'])) {
                     fillFields.code = f;
                 } else if (!fillFields.brand && this.isFieldMatch(f[attr],
                     ['cc-type', 'card-type', 'card-brand', 'cc-brand'])) {


### PR DESCRIPTION
I encountered these tags on oui.sncf, the french train company :
- `numCarte` (credit card number)
- `EXPIRATION_MONTH`
- `EXPIRATION_YEAR`
- `codeSecurite` (CVV)