### PR TITLE
Disable all text-replacements and substitutions

### DIFF
--- a/src/popup/app/accounts/views/accountsLogin.html
+++ b/src/popup/app/accounts/views/accountsLogin.html
@@ -16,7 +16,8 @@
                     <div class="list-section-item list-section-item-icon-input">
                         <i class="fa fa-envelope fa-lg fa-fw"></i>
                         <label for="email" class="sr-only">{{i18n.emailAddress}}</label>
-                        <input id="email" type="text" name="Email" placeholder="{{i18n.emailAddress}}" ng-model="model.email">
+                        <input id="email" type="email" name="Email" placeholder="{{i18n.emailAddress}}" ng-model="model.email"
+                               autocapitalize="none" autocomplete="none" autocorrect="none" inputmode="verbatim" spellcheck="false">
                     </div>
                     <div class="list-section-item list-section-item-icon-input">
                         <i class="fa fa-lock fa-lg fa-fw"></i>


### PR DESCRIPTION
Prevents spellchecking and text-substitutions from interfering with username input.

Pressing Esc in the extension pop-out in Safari closes the extension pop-out instead of dismissing the text-substitution. This change lets users type their email address verbatim without the browser interfering.