### PR TITLE
Precaution against iframe creating blank space on the page

### DIFF
--- a/src/content/notificationBar.ts
+++ b/src/content/notificationBar.ts
@@ -387,7 +387,7 @@ document.addEventListener('DOMContentLoaded', (event) => {
         const barPageUrl: string = isSafari ? (safari.extension.baseURI + barPage) : chrome.extension.getURL(barPage);
 
         const iframe = document.createElement('iframe');
-        iframe.style.cssText = 'height: 42px; width: 100%; border: 0;';
+        iframe.style.cssText = 'height: 42px; width: 100%; border: 0; min-height: initial;';
         iframe.id = 'bit-notification-bar-iframe';
 
         const frameDiv = document.createElement('div');


### PR DESCRIPTION
Since the notification bar is added inside of the active page, page specific styles may override how the iframe is rendered in an undesirable way.

I came across this when logging in an internal corporate web-app we're using which for some reason has a global css setting of `iframe { min-height: 349px }` because nobody anticipated that 3rd party DOM elements would be injected to the page.

This modification should have no impact other than negating these global styles.

![screen shot 2018-06-05 at 17 44 54](https://user-images.githubusercontent.com/9551921/40983551-9b88740e-68e8-11e8-8a37-386a09374fc1.png)
