### PR TITLE
Masking Card Security Code in browser extension

### DIFF
--- a/src/popup/vault/view.component.html
+++ b/src/popup/vault/view.component.html
@@ -111,9 +111,15 @@
                 <div class="box-content-row box-content-row-flex" *ngIf="cipher.card.code">
                     <div class="row-main">
                         <span class="row-label">{{'securityCode' | i18n}}</span>
-                        {{cipher.card.code}}
+                        <span [hidden]="showCardCode" >{{cipher.card.maskedCode}}</span>
+                        <span [hidden]="!showCardCode" >{{cipher.card.code}}</span>
                     </div>
                     <div class="action-buttons">
+                        <a class="row-btn" href="#" appStopClick title="{{'toggleVisibility' | i18n}}"
+                           (click)="toggleCardCode()">
+                            <i class="fa fa-lg"
+                               [ngClass]="{'fa-eye': !showCardCode, 'fa-eye-slash': showCardCode}"></i>
+                        </a>
                         <a class="row-btn" href="#" appStopClick title="{{'copySecurityCode' | i18n}}"
                            (click)="copy(cipher.card.code, 'securityCode', 'Security Code')">
                             <i class="fa fa-lg fa-clipboard"></i>


### PR DESCRIPTION
By default shows Card Security Code masked in the same way as Passwords.  ([bitwarden/desktop issue 78](bitwarden/desktop/issues/78))

Depends on [bitwarden/jslib#5](bitwarden/jslib/pull/5)