### PR TITLE
Fetch image from bitwarden/brand

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 The Bitwarden browser extension is written using the Web Extension API and Angular.
 
-![Alt text](https://i.imgur.com/EmGMZX1.png "My Vault")
+![](https://raw.githubusercontent.com/bitwarden/brand/master/screenshots/browser-chrome.png "My Vault")
 
 # Build/Run
 


### PR DESCRIPTION
This makes the image fetch from https://github.com/bitwarden/brand instead of using imgur, this means that you just need to update the screenshot there and this updates automatically.