### PR TITLE
Remove leading www. from name on saveAddLogin

### DIFF
--- a/src/background/runtime.background.ts
+++ b/src/background/runtime.background.ts
@@ -215,7 +215,11 @@ export default class RuntimeBackground {
             loginModel.username = queueMessage.username;
             loginModel.password = queueMessage.password;
             const model = new CipherView();
-            model.name = Utils.getHostname(queueMessage.uri) || queueMessage.domain;
+
+            let name = Utils.getHostname(queueMessage.uri) || queueMessage.domain;
+            name = name.replace(/^www./, '');
+
+            model.name = name;
             model.type = CipherType.Login;
             model.login = loginModel;
 


### PR DESCRIPTION
Hello,

Currently when you save a new login while being prompted after a login, it uses the full domain. By removing the leading `www.` I would find it to be easier  to manage multiple records from the same domain that uses both `www` and `non-www`, when sorted.

Thank you.