### PR TITLE
Fix match the character . literally

### DIFF
--- a/src/background/runtime.background.ts
+++ b/src/background/runtime.background.ts
@@ -216,7 +216,7 @@ export default class RuntimeBackground {
             loginModel.password = queueMessage.password;
             const model = new CipherView();
             model.name = Utils.getHostname(queueMessage.uri) || queueMessage.domain;
-            model.name = model.name.replace(/^www./, '');
+            model.name = model.name.replace(/^www\./, '');
             model.type = CipherType.Login;
             model.login = loginModel;
 


### PR DESCRIPTION
In the last PR I introduced a bug, which would match `www` and any character after it. This fixes the match only with a literal `.`

Sorry about that.
