### PR TITLE
Update natives package to fix build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7723,9 +7723,9 @@
       }
     },
     "natives": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.4.tgz",
-      "integrity": "sha512-Q29yeg9aFKwhLVdkTAejM/HvYG0Y1Am1+HUkFQGn5k2j8GS+v60TVmZh6nujpEAj/qql+wGUrlryO8bF+b1jEg==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
+      "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==",
       "dev": true
     },
     "negotiator": {


### PR DESCRIPTION
Upon cloning the repo, I was unable to build due to [this error](https://pastebin.com/VLZS4bXd).
As found [here](https://stackoverflow.com/questions/53146394/), updating the "natives" package to 1.1.6 fixes this issue.