### PR TITLE
Fix disapearing uri #847

### DIFF
--- a/src/popup/vault/add-edit.component.html
+++ b/src/popup/vault/add-edit.component.html
@@ -215,7 +215,7 @@
                         </a>
                         <div class="row-main">
                             <label for="loginUri{{i}}">{{'uriPosition' | i18n : (i + 1)}}</label>
-                            <input id="loginUri{{i}}" type="text" name="Login.Uris[{{i}}].Uri" [(ngModel)]="u.uri"
+                            <input id="loginUri{{i}}" type="text" name="Login.Uris[{{i}}].Uri" [(ngModel)]="u._uri"
                                    placeholder="{{'ex' | i18n}} https://google.com" inputmode="url"
                                    appInputVerbatim>
                             <label for="loginUriMatch{{i}}" class="sr-only">


### PR DESCRIPTION
This close #847 
The data is called `_uri` not `uri` so I think that when Angular reload the view from the model, the uri is always empty (because we look at the wrong place)