### PR TITLE
Fix overlapping of close button with scrollbar

### DIFF
--- a/src/notification/bar.scss
+++ b/src/notification/bar.scss
@@ -52,6 +52,7 @@ img {
     height: 15px;
     display: block;
     padding: 5px 0;
+    margin-right: 10px;
 }
 
 button:not(.link) {


### PR DESCRIPTION
In Mac OS there is a wider variant of scrollbar on hover. Commit fixes overlapping of close button with scrollbar in chrome.

example of overlay:
<img width="176" alt="snimek obrazovky 2019-02-27 v 13 57 31" src="https://user-images.githubusercontent.com/16785319/53491916-d59fc080-3a97-11e9-8f23-2ac3c9ddf5e0.png">



 