### PR TITLE
Fix text selection of generated password

### DIFF
--- a/src/popup/generator/password-generator-history.component.html
+++ b/src/popup/generator/password-generator-history.component.html
@@ -20,7 +20,7 @@
             <div class="box-content-row box-content-row-flex" *ngFor="let h of history">
                 <div class="row-main">
                     <div class="row-main-content">
-                        <div class="text monospaced password-wrapper no-ellipsis" appFlexCopy
+                        <div class="password-block monospaced" appFlexCopy
                             [innerHTML]="h.password | colorPassword"></div>
                         <span class="detail">{{h.date | date:'medium'}}</span>
                     </div>

--- a/src/popup/generator/password-generator.component.html
+++ b/src/popup/generator/password-generator.component.html
@@ -11,7 +11,7 @@
     </div>
 </header>
 <content>
-    <div class="password-block password-wrapper" [innerHTML]="password | colorPassword" appFlexCopy></div>
+    <div class="password-block generated-password monospaced" [innerHTML]="password | colorPassword" appFlexCopy></div>
     <div class="box list">
         <div class="box-content single-line">
             <a class="box-content-row text-primary" href="#" appStopClick appBlurClick

--- a/src/popup/scss/box.scss
+++ b/src/popup/scss/box.scss
@@ -116,8 +116,11 @@
                 margin-left: 10px;
             }
 
+            // 1. Stops main content from pushing other content off-screen.
+            // This allows long passwords to wrap properly (e.g. in the “View item” dialog).
             .row-main {
                 flex-grow: 1;
+                min-width: 0; /* 1. */
             }
 
             &.box-content-row-flex, .box-content-row-flex, &.box-content-row-checkbox,
@@ -141,7 +144,7 @@
                 > a {
                     padding: 8px 8px 8px 4px;
                     margin: 0;
-                
+
                     @include themify($themes) {
                         color: themed('dangerColor');
                     }
@@ -159,7 +162,7 @@
                     display: block;
                     width: initial;
                     margin-bottom: 0;
-                
+
                     @include themify($themes) {
                         color: themed('textColor');
                     }
@@ -233,7 +236,7 @@
                 width: 100%;
                 border: 1px solid #000000;
                 border-radius: $border-radius;
-                
+
                 @include themify($themes) {
                     border-color: themed('inputBorderColor');
                 }
@@ -248,7 +251,7 @@
                     padding: 10px 8px;
                     background: none;
                     border: none;
-                    
+
                     @include themify($themes) {
                         color: themed('boxRowButtonColor');
                     }
@@ -296,7 +299,7 @@
             .row-sub-label {
                 margin: 0 15px;
                 white-space: nowrap;
-                
+
                 @include themify($themes) {
                     color: themed('mutedColor');
                 }

--- a/src/popup/scss/misc.scss
+++ b/src/popup/scss/misc.scss
@@ -145,15 +145,6 @@ p.lead {
     border: 0 !important;
 }
 
-.password-wrapper {
-    display: flex !important;
-    flex-wrap: wrap;
-
-    span {
-        white-space: pre;
-    }
-}
-
 .password-number {
     @include themify($themes) {
         color: themed('passwordNumberColor');

--- a/src/popup/scss/pages.scss
+++ b/src/popup/scss/pages.scss
@@ -8,16 +8,19 @@ app-sync {
     }
 }
 
-app-password-generator .password-block {
-    font-size: $font-size-large;
-    font-family: $font-family-monospace;
-    text-align: center;
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    justify-content: center;
-    text-align: center;
+/*
+1. Using `white-space: pre` is not sufficient because lines would not be broken to fill line boxes.
+   See: https://developer.mozilla.org/en-US/docs/Web/CSS/white-space
+*/
+.password-block {
+    word-break: break-all;
+    white-space: pre-wrap; /* 1. */
+}
+
+.generated-password {
     margin: 20px;
+    font-size: $font-size-large;
+    text-align: center;
 }
 
 app-home {

--- a/src/popup/vault/view.component.html
+++ b/src/popup/vault/view.component.html
@@ -36,9 +36,9 @@
                 <div class="box-content-row box-content-row-flex" *ngIf="cipher.login.password">
                     <div class="row-main">
                         <span class="row-label">{{'password' | i18n}}</span>
-                        <div [hidden]="showPassword" class="monospaced password-wrapper" appFlexCopy>
+                        <div [hidden]="showPassword" class="password-block monospaced" appFlexCopy>
                             {{cipher.login.maskedPassword}}</div>
-                        <div [hidden]="!showPassword" class="monospaced password-wrapper" appFlexCopy
+                        <div [hidden]="!showPassword" class="password-block monospaced" appFlexCopy
                             [innerHTML]="cipher.login.password | colorPassword"></div>
                     </div>
                     <div class="action-buttons">


### PR DESCRIPTION
This pull request addresses #896.

- **Before**: double-clicking or triple-clicking a generated password selects individual characters of a generated password.
- **After**: The common algorithm for text selection is used.

Initially, I believed the cause of this unexpected selection behavior to be the single characters in a generated password being marked up as individual `span` elements. This is not the case. It turns out that using `display: flex` on the containing element creates the current selection behavior. Luckily, using `flex` or `inline-flex` there is not necessary. The wrapping behavior of the characters can be achieved with `word-break: break-all`. 

