### PR TITLE
Capping length of Autofilled Passwords when necessary

### DIFF
--- a/src/services/autofill.service.ts
+++ b/src/services/autofill.service.ts
@@ -392,7 +392,8 @@ export default class AutofillService implements AutofillServiceInterface {
             filledFields[p.opid] = p;
             fillScript.script.push(['click_on_opid', p.opid]);
             fillScript.script.push(['focus_by_opid', p.opid]);
-            fillScript.script.push(['fill_by_opid', p.opid, login.password]);
+            const passwordLength: number = p.maxLength && p.maxLength > 0 ? p.maxLength : login.password.length;
+            fillScript.script.push(['fill_by_opid', p.opid, login.password.substring(0, passwordLength)]);
         });
 
         fillScript = this.setFillScriptForFocus(filledFields, fillScript);


### PR DESCRIPTION
When using autofill on certain websites (such as [this website](https://www.mybenefitscalwin.org/)), the autofill feature will put the user's entire password, even if said password is longer than the specified limit. I created a password for this website (20+ characters), and I was unable to login until I only used the first 20 characters.

This PR simply caps the length of a password when selecting to autofill a password field, if the form field restricts the length of the password

<img width="599" alt="Screen Shot 2019-04-19 at 3 53 19 PM" src="https://user-images.githubusercontent.com/24380457/56447334-95510780-62bc-11e9-87a1-19854b29039f.png">