### PR TITLE
Update idle.background.ts

### DIFF
--- a/src/background/idle.background.ts
+++ b/src/background/idle.background.ts
@@ -15,7 +15,7 @@ export default class IdleBackground {
 
     constructor(private lockService: LockService, private storageService: StorageService,
         private notificationsService: NotificationsService) {
-        this.idle = chrome.idle || browser.idle;
+        this.idle = chrome.idle || (browser && browser.idle);
     }
 
     async init() {


### PR DESCRIPTION
Handle cases where `chrome.idle` doesn't exist and there is no `browser` object either. 

Fixes #960