### PR TITLE
Add copy action button for TOTP code

### DIFF
--- a/src/popup/components/action-buttons.component.html
+++ b/src/popup/components/action-buttons.component.html
@@ -14,6 +14,10 @@
         (click)="copy(cipher.login.password, 'password', 'Password')" [ngClass]="{disabled: !cipher.login.password}">
         <i class="fa fa-lg fa-key"></i>
     </span>
+    <span class="row-btn" appStopClick appStopProp title="{{'copyVerificationCode' | i18n}}"
+        (click)="copy(cipher.login.totp, 'verificationCodeTotp', 'TOTP')" [ngClass]="{disabled: !cipher.login.totp}">
+        <i class="fa fa-lg fa-clipboard"></i>
+    </span>
 </ng-container>
 <ng-container *ngIf="cipher.type === cipherType.Card">
     <span class="row-btn" appStopClick appStopProp title="{{'copyNumber' | i18n}}"

--- a/src/popup/components/action-buttons.component.ts
+++ b/src/popup/components/action-buttons.component.ts
@@ -16,6 +16,7 @@ import { CipherView } from 'jslib/models/view/cipherView';
 
 import { I18nService } from 'jslib/abstractions/i18n.service';
 import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
+import { TotpService } from 'jslib/abstractions/totp.service';
 
 import { PopupUtilsService } from '../services/popup-utils.service';
 
@@ -32,7 +33,7 @@ export class ActionButtonsComponent {
 
     constructor(private analytics: Angulartics2, private toasterService: ToasterService,
         private i18nService: I18nService, private platformUtilsService: PlatformUtilsService,
-        private popupUtilsService: PopupUtilsService) { }
+        private totpService: TotpService, private popupUtilsService: PopupUtilsService) { }
 
     launch() {
         if (this.cipher.type !== CipherType.Login || !this.cipher.login.canLaunch) {
@@ -46,9 +47,14 @@ export class ActionButtonsComponent {
         }
     }
 
-    copy(value: string, typeI18nKey: string, aType: string) {
+    async copy(value: string, typeI18nKey: string, aType: string) {
         if (value == null) {
             return;
+        }
+
+        if (aType === 'TOTP') {
+            const totpCode = await this.totpService.getCode(value);
+            value = totpCode;
         }
 
         this.analytics.eventTrack.next({ action: 'Copied ' + aType });


### PR DESCRIPTION
Adds support for quickly copying the TOTP code for use when logging in to a site that utilizes 2FA.

![image](https://user-images.githubusercontent.com/2197883/60918124-7b421800-a260-11e9-9935-b0503dc96fb3.png)
