### PR TITLE
Enabled drag of username, password and totp in browser extension

### DIFF
--- a/src/popup/scss/misc.scss
+++ b/src/popup/scss/misc.scss
@@ -218,3 +218,7 @@ app-vault-icon {
 [hidden] {
     display: none !important;
 }
+
+.draggable {
+    cursor: move;
+}

--- a/src/popup/vault/view.component.html
+++ b/src/popup/vault/view.component.html
@@ -22,7 +22,7 @@
             <!-- Login -->
             <div *ngIf="cipher.login">
                 <div class="box-content-row box-content-row-flex" *ngIf="cipher.login.username">
-                    <div class="row-main">
+                    <div class="row-main" draggable="true" (dragstart)="setTextDataOnDrag($event, cipher.login.username)">
                         <span class="row-label">{{'username' | i18n}}</span>
                         {{cipher.login.username}}
                     </div>
@@ -34,7 +34,7 @@
                     </div>
                 </div>
                 <div class="box-content-row box-content-row-flex" *ngIf="cipher.login.password">
-                    <div class="row-main">
+                    <div class="row-main" draggable="true" (dragstart)="setTextDataOnDrag($event, cipher.login.password)">
                         <span class="row-label">{{'password' | i18n}}</span>
                         <div [hidden]="showPassword" class="monospaced">
                             {{cipher.login.maskedPassword}}</div>
@@ -62,7 +62,8 @@
                     </div>
                 </div>
                 <div class="box-content-row box-content-row-flex totp" [ngClass]="{'low': totpLow}"
-                    *ngIf="cipher.login.totp && totpCode">
+                    *ngIf="cipher.login.totp && totpCode"
+                    draggable="true" (dragstart)="setTextDataOnDrag($event, totpCode)">
                     <div class="row-main">
                         <span class="row-label">{{'verificationCodeTotp' | i18n}}</span>
                         <span class="totp-code">{{totpCodeFormatted}}</span>

--- a/src/popup/vault/view.component.html
+++ b/src/popup/vault/view.component.html
@@ -22,8 +22,9 @@
             <!-- Login -->
             <div *ngIf="cipher.login">
                 <div class="box-content-row box-content-row-flex" *ngIf="cipher.login.username">
-                    <div class="row-main" draggable="true" (dragstart)="setTextDataOnDrag($event, cipher.login.username)">
-                        <span class="row-label">{{'username' | i18n}}</span>
+                    <div class="row-main">
+                        <span class="row-label draggable" draggable="true"
+                            (dragstart)="setTextDataOnDrag($event, cipher.login.username)">{{'username' | i18n}}</span>
                         {{cipher.login.username}}
                     </div>
                     <div class="action-buttons">
@@ -34,8 +35,9 @@
                     </div>
                 </div>
                 <div class="box-content-row box-content-row-flex" *ngIf="cipher.login.password">
-                    <div class="row-main" draggable="true" (dragstart)="setTextDataOnDrag($event, cipher.login.password)">
-                        <span class="row-label">{{'password' | i18n}}</span>
+                    <div class="row-main">
+                        <span class="row-label draggable" draggable="true"
+                            (dragstart)="setTextDataOnDrag($event, cipher.login.password)">{{'password' | i18n}}</span>
                         <div [hidden]="showPassword" class="monospaced">
                             {{cipher.login.maskedPassword}}</div>
                         <div [hidden]="!showPassword" class="monospaced password-wrapper" appSelectCopy
@@ -62,10 +64,10 @@
                     </div>
                 </div>
                 <div class="box-content-row box-content-row-flex totp" [ngClass]="{'low': totpLow}"
-                    *ngIf="cipher.login.totp && totpCode"
-                    draggable="true" (dragstart)="setTextDataOnDrag($event, totpCode)">
+                    *ngIf="cipher.login.totp && totpCode">
                     <div class="row-main">
-                        <span class="row-label">{{'verificationCodeTotp' | i18n}}</span>
+                        <span class="row-label draggable" draggable="true"
+                            (dragstart)="setTextDataOnDrag($event, totpCode)">{{'verificationCodeTotp' | i18n}}</span>
                         <span class="totp-code">{{totpCodeFormatted}}</span>
                     </div>
                     <span class="totp-countdown">


### PR DESCRIPTION
In collaboration with the [pullrequest 51 at jslib](https://github.com/bitwarden/jslib/pull/51) this enables the possibilty to drag the username, password and totp from the extension into fields on the website or anywhere else a drag can reach.
A possible use case for avoiding the clipboard here are clipboard synchronization apps, where a password should not appear.