### PR TITLE
Hide save password notification bar when printing the page

### DIFF
--- a/src/notification/bar.scss
+++ b/src/notification/bar.scss
@@ -90,3 +90,9 @@ body[class*='lang-en'] .add-buttons {
         width: 320px;
     }
 }
+
+@media (print) {
+    body {
+        display: none;
+    }
+}


### PR DESCRIPTION
The save password prompt is no longer shown in print views.

Fixes #1034 