### PR TITLE
Replace 'login id' by 'login' in username field names

### DIFF
--- a/src/services/autofill.service.ts
+++ b/src/services/autofill.service.ts
@@ -31,7 +31,7 @@ const IdentityAttributes: string[] = ['autoCompleteType', 'data-stripe', 'htmlNa
 const UsernameFieldNames: string[] = [
     // English
     'username', 'user name', 'email', 'email address', 'e-mail', 'e-mail address', 'userid', 'user id',
-    'customer id', 'login id',
+    'customer id', 'login'
     // German
     'benutzername', 'benutzer name', 'email adresse', 'e-mail adresse', 'benutzerid', 'benutzer id'];
 


### PR DESCRIPTION
Fixes username auto-fill for [Fortuneo](https://mabanque.fortuneo.fr/fr/identification.jsp) website