### PR TITLE
Added ability to disable the lock icon

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1232,5 +1232,11 @@
   },
   "selectOneCollection": {
     "message": "You must select at least one collection."
+  },
+  "disableLockIcon": {
+    "message": "Disable Lock Icon"
+  },
+  "disableLockIconDesc": {
+    "message": "A lock icon is displayed when you are logged in, but your vault is locked. With the lock icon disabled, a gray icon will be shown instead."
   }
 }

--- a/src/background/main.background.ts
+++ b/src/background/main.background.ts
@@ -255,7 +255,7 @@ export default class MainBackground {
         const locked = await this.lockService.isLocked();
 
         let suffix = '';
-        if (!isAuthenticated) {
+        if (!isAuthenticated || (await this.storageService.get<boolean>(ConstantsService.disableLockIcon) && locked)) {
             suffix = '_gray';
         } else if (locked) {
             suffix = '_locked';

--- a/src/popup/services/services.module.ts
+++ b/src/popup/services/services.module.ts
@@ -85,6 +85,9 @@ export function initFactory(i18nService: I18nService, storageService: StorageSer
             stateService.save(ConstantsService.disableFaviconKey,
                 await storageService.get<boolean>(ConstantsService.disableFaviconKey));
 
+            stateService.save(ConstantsService.disableLockIcon,
+                await storageService.get<boolean>(ConstantsService.disableLockIcon));
+
             let theme = await storageService.get<string>(ConstantsService.themeKey);
             if (theme == null) {
                 theme = 'light';

--- a/src/popup/settings/options.component.html
+++ b/src/popup/settings/options.component.html
@@ -117,6 +117,15 @@
     </div>
     <div class="box">
         <div class="box-content">
+            <div class="box-content-row box-content-row-checkbox" appBoxRow>
+                <label for="favicon">{{'disableLockIcon' | i18n}}</label>
+                <input id="favicon" type="checkbox" (change)="updateDisableLockIcon()" [(ngModel)]="disableLockIcon">
+            </div>
+        </div>
+        <div class="box-footer">{{'disableLockIconDesc' | i18n}}</div>
+    </div>
+    <div class="box">
+        <div class="box-content">
             <div class="box-content-row" appBoxRow>
                 <label for="theme">{{'theme' | i18n}}</label>
                 <select id="theme" name="Theme" [(ngModel)]="theme" (change)="saveTheme()">

--- a/src/popup/settings/options.component.ts
+++ b/src/popup/settings/options.component.ts
@@ -37,6 +37,7 @@ export class OptionsComponent implements OnInit {
     uriMatchOptions: any[];
     clearClipboard: number;
     clearClipboardOptions: any[];
+    disableLockIcon = false;
 
     constructor(private analytics: Angulartics2, private messagingService: MessagingService,
         private platformUtilsService: PlatformUtilsService, private storageService: StorageService,
@@ -89,6 +90,8 @@ export class OptionsComponent implements OnInit {
 
         this.disableFavicon = await this.storageService.get<boolean>(ConstantsService.disableFaviconKey);
 
+        this.disableLockIcon = await this.storageService.get<boolean>(ConstantsService.disableLockIcon);
+
         this.theme = await this.storageService.get<string>(ConstantsService.themeKey);
 
         const defaultUriMatch = await this.storageService.get<UriMatchType>(ConstantsService.defaultUriMatch);
@@ -130,6 +133,12 @@ export class OptionsComponent implements OnInit {
         await this.storageService.save(ConstantsService.disableFaviconKey, this.disableFavicon);
         await this.stateService.save(ConstantsService.disableFaviconKey, this.disableFavicon);
         this.callAnalytics('Favicon', !this.disableFavicon);
+    }
+
+    async updateDisableLockIcon() {
+        await this.storageService.save(ConstantsService.disableLockIcon, this.disableLockIcon);
+        await this.stateService.save(ConstantsService.disableLockIcon, this.disableLockIcon);
+        this.callAnalytics('LockIcon', !this.disableFavicon);
     }
 
     async updateShowCards() {


### PR DESCRIPTION
It will show the gray icon instead.

The red lock icon bothers me as it feels like it is a notification. So, this PR just adds an option to disable it.

![image](https://user-images.githubusercontent.com/12688112/71287482-7cf72800-2336-11ea-9ca5-25e0555ac9c8.png)

![image](https://user-images.githubusercontent.com/12688112/71483676-ee235900-27d6-11ea-92d1-a3d01e37ceaf.png)


Depends on https://github.com/bitwarden/jslib/pull/54