### PR TITLE
Remove @angular/http dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -621,14 +621,6 @@
         "tslib": "^1.9.0"
       }
     },
-    "@angular/http": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/@angular/http/-/http-7.2.1.tgz",
-      "integrity": "sha512-3xfdN2bmCbzATwRGUEZQVkGn3IN6tMX/whLWGWgcEV3CENJqTUjfjn1+nSHASQLUnmOr5T7yTiWK5P7bDrHYzw==",
-      "requires": {
-        "tslib": "^1.9.0"
-      }
-    },
     "@angular/platform-browser": {
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-7.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "@angular/compiler": "7.2.1",
     "@angular/core": "7.2.1",
     "@angular/forms": "7.2.1",
-    "@angular/http": "7.2.1",
     "@angular/platform-browser": "7.2.1",
     "@angular/platform-browser-dynamic": "7.2.1",
     "@angular/router": "7.2.1",


### PR DESCRIPTION
@angular/http module has been deprecated. HTTP requests should now be done with the @angular/common/http module.

See here:
https://angular.io/guide/deprecations#angularhttp

It looks like there were no usages of this dependency in the project so removing it was pretty simple 👍