### PR TITLE
Remove gulp global install step from Azure pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,9 +21,6 @@ steps:
     versionSpec: '10.x'
   displayName: 'Install Node.js'
 
-- script: npm install -g gulp
-  displayName: 'Global install gulp'
-
 - powershell: |
     choco install cloc --no-progress
     cloc --include-lang TypeScript,JavaScript,HTML,Sass,CSS --vcs git

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,11 +28,11 @@ steps:
 
 - script: |
     node --version
-    npm --version
+    call npm --version
   displayName: 'Version checks'
 
-- script: npm install
+- script: call npm install
   displayName: 'npm install'
 
-- script: npm run build
+- script: call npm run build
   displayName: 'npm run build'


### PR DESCRIPTION
This step may be redundant since Gulp is already included as a devDependency for the project. The step is currently causing builds to fail so it's probably best just to remove it