### PR TITLE
Implement personal item cloning capability

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "sub:init": "git submodule update --init --recursive",
     "sub:update": "git submodule update --remote",
-    "sub:pull": "git submodule foreach git pull",
+    "sub:pull": "git submodule foreach git pull origin master",
     "postinstall": "npm run sub:init && gulp postinstall",
     "symlink:win": "rm -rf ./jslib && cmd /c mklink /J .\\jslib ..\\jslib",
     "symlink:mac": "npm run symlink:lin",

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1238,5 +1238,11 @@
   },
   "selectOneCollection": {
     "message": "You must select at least one collection."
+  },
+  "cloneItem": {
+    "message": "Clone Item"
+  },
+  "clone": {
+    "message": "Clone"
   }
 }

--- a/src/popup/app-routing.animations.ts
+++ b/src/popup/app-routing.animations.ts
@@ -106,14 +106,16 @@ export function ciphersToView(fromState: string, toState: string) {
     if (fromState == null || toState === null) {
         return false;
     }
-    return fromState.indexOf('ciphers_') === 0 && (toState === 'view-cipher' || toState === 'add-cipher' || toState === 'clone-cipher');
+    return fromState.indexOf('ciphers_') === 0 &&
+        (toState === 'view-cipher' || toState === 'add-cipher' || toState === 'clone-cipher');
 }
 
 export function viewToCiphers(fromState: string, toState: string) {
     if (fromState == null || toState === null) {
         return false;
     }
-    return (fromState === 'view-cipher' || fromState === 'add-cipher' || fromState === 'clone-cipher') && toState.indexOf('ciphers_') === 0;
+    return (fromState === 'view-cipher' || fromState === 'add-cipher' || fromState === 'clone-cipher') &&
+        toState.indexOf('ciphers_') === 0;
 }
 
 export const routerTransition = trigger('routerTransition', [
@@ -142,8 +144,11 @@ export const routerTransition = trigger('routerTransition', [
     transition('tabs => view-cipher', inSlideUp),
     transition('view-cipher => tabs', outSlideDown),
 
-    transition('view-cipher => edit-cipher, view-cipher => cipher-password-history, view-cipher => clone-cipher', inSlideUp),
-    transition('edit-cipher => view-cipher, clone-cipher => view-cipher, cipher-password-history => view-cipher, edit-cipher => tabs, clone-cipher => tabs', outSlideDown),
+    transition('view-cipher => edit-cipher, view-cipher => cipher-password-history', inSlideUp),
+    transition('edit-cipher => view-cipher, cipher-password-history => view-cipher, edit-cipher => tabs', outSlideDown),
+
+    transition('view-cipher => clone-cipher', inSlideUp),
+    transition('clone-cipher => view-cipher, clone-cipher => tabs', outSlideDown),
 
     transition('tabs => add-cipher', inSlideUp),
     transition('add-cipher => tabs', outSlideDown),

--- a/src/popup/app-routing.animations.ts
+++ b/src/popup/app-routing.animations.ts
@@ -106,14 +106,14 @@ export function ciphersToView(fromState: string, toState: string) {
     if (fromState == null || toState === null) {
         return false;
     }
-    return fromState.indexOf('ciphers_') === 0 && (toState === 'view-cipher' || toState === 'add-cipher');
+    return fromState.indexOf('ciphers_') === 0 && (toState === 'view-cipher' || toState === 'add-cipher' || toState === 'clone-cipher');
 }
 
 export function viewToCiphers(fromState: string, toState: string) {
     if (fromState == null || toState === null) {
         return false;
     }
-    return (fromState === 'view-cipher' || fromState === 'add-cipher') && toState.indexOf('ciphers_') === 0;
+    return (fromState === 'view-cipher' || fromState === 'add-cipher' || fromState === 'clone-cipher') && toState.indexOf('ciphers_') === 0;
 }
 
 export const routerTransition = trigger('routerTransition', [
@@ -142,8 +142,8 @@ export const routerTransition = trigger('routerTransition', [
     transition('tabs => view-cipher', inSlideUp),
     transition('view-cipher => tabs', outSlideDown),
 
-    transition('view-cipher => edit-cipher, view-cipher => cipher-password-history', inSlideUp),
-    transition('edit-cipher => view-cipher, cipher-password-history => view-cipher, edit-cipher => tabs', outSlideDown),
+    transition('view-cipher => edit-cipher, view-cipher => cipher-password-history, view-cipher => clone-cipher', inSlideUp),
+    transition('edit-cipher => view-cipher, clone-cipher => view-cipher, cipher-password-history => view-cipher, edit-cipher => tabs, clone-cipher => tabs', outSlideDown),
 
     transition('tabs => add-cipher', inSlideUp),
     transition('add-cipher => tabs', outSlideDown),
@@ -151,14 +151,17 @@ export const routerTransition = trigger('routerTransition', [
     transition('generator => generator-history, tabs => generator-history', inSlideLeft),
     transition('generator-history => generator, generator-history => tabs', outSlideRight),
 
-    transition('add-cipher => generator, edit-cipher => generator', inSlideUp),
-    transition('generator => add-cipher, generator => edit-cipher', outSlideDown),
+    transition('add-cipher => generator, edit-cipher => generator, clone-cipher => generator', inSlideUp),
+    transition('generator => add-cipher, generator => edit-cipher, generator => clone-cipher', outSlideDown),
 
     transition('edit-cipher => share-cipher', inSlideUp),
     transition('share-cipher => edit-cipher, share-cipher => view-cipher', outSlideDown),
 
     transition('edit-cipher => attachments, edit-cipher => collections', inSlideLeft),
     transition('attachments => edit-cipher, collections => edit-cipher', outSlideRight),
+
+    transition('clone-cipher => attachments, clone-cipher => collections', inSlideLeft),
+    transition('attachments => clone-cipher, collections => clone-cipher', outSlideRight),
 
     transition('tabs => export', inSlideLeft),
     transition('export => tabs', outSlideRight),

--- a/src/popup/app-routing.module.ts
+++ b/src/popup/app-routing.module.ts
@@ -244,7 +244,7 @@ const routes: Routes = [
                 component: SettingsComponent,
                 canActivate: [AuthGuardService],
                 data: { state: 'tabs_settings' },
-            }
+            },
         ],
     },
 ];

--- a/src/popup/app-routing.module.ts
+++ b/src/popup/app-routing.module.ts
@@ -205,6 +205,12 @@ const routes: Routes = [
         data: { state: 'private-mode' },
     },
     {
+        path: 'clone-cipher',
+        component: AddEditComponent,
+        canActivate: [AuthGuardService],
+        data: { state: 'clone-cipher' },
+    },
+    {
         path: 'tabs',
         component: TabsComponent,
         data: { state: 'tabs' },
@@ -238,7 +244,7 @@ const routes: Routes = [
                 component: SettingsComponent,
                 canActivate: [AuthGuardService],
                 data: { state: 'tabs_settings' },
-            },
+            }
         ],
     },
 ];

--- a/src/popup/vault/add-edit.component.html
+++ b/src/popup/vault/add-edit.component.html
@@ -256,7 +256,7 @@
                     <i class="fa fa-chevron-right row-sub-icon" aria-hidden="true"></i>
                 </a>
                 <a class="box-content-row box-content-row-flex text-default" href="#" appStopClick appBlurClick
-                    (click)="editCollections()" *ngIf="editMode && cipher.organizationId">
+                    (click)="editCollections()" *ngIf="editMode && cipher.organizationId && !cloneMode">
                     <div class="row-main">{{'collections' | i18n}}</div>
                     <i class="fa fa-chevron-right row-sub-icon" aria-hidden="true"></i>
                 </a>
@@ -320,7 +320,7 @@
                 </div>
             </div>
         </div>
-        <div class="box" *ngIf="!editMode && ownershipOptions && ownershipOptions.length > 1">
+        <div class="box" *ngIf="(!editMode || cloneMode) && ownershipOptions && ownershipOptions.length > 1">
             <div class="box-header">
                 {{'ownership' | i18n}}
             </div>
@@ -334,7 +334,7 @@
                 </div>
             </div>
         </div>
-        <div class="box" *ngIf="!editMode && cipher.organizationId">
+        <div class="box" *ngIf="(!editMode || cloneMode )&& cipher.organizationId">
             <div class="box-header">
                 {{'collections' | i18n}}
             </div>
@@ -352,7 +352,7 @@
                 </div>
             </div>
         </div>
-        <div class="box list" *ngIf="editMode">
+        <div class="box list" *ngIf="editMode && !cloneMode">
             <div class="box-content single-line">
                 <a class="box-content-row" href="#" appStopClick appBlurClick (click)="share()"
                     *ngIf="!cipher.organizationId">

--- a/src/popup/vault/add-edit.component.ts
+++ b/src/popup/vault/add-edit.component.ts
@@ -61,7 +61,7 @@ export class AddEditComponent extends BaseAddEditComponent {
 
             if (params.cloneMode != null) {
                 this.cloneMode = params.cloneMode === true;
-            } 
+            }
             await this.load();
 
             if (!this.editMode) {

--- a/src/popup/vault/add-edit.component.ts
+++ b/src/popup/vault/add-edit.component.ts
@@ -58,6 +58,10 @@ export class AddEditComponent extends BaseAddEditComponent {
                 this.type = type;
             }
             this.editMode = !params.cipherId;
+
+            if (params.cloneMode != null) {
+                this.cloneMode = params.cloneMode;
+            } 
             await this.load();
 
             if (!this.editMode) {
@@ -86,7 +90,11 @@ export class AddEditComponent extends BaseAddEditComponent {
 
     async submit(): Promise<boolean> {
         if (await super.submit()) {
-            this.location.back();
+            if (this.cloneMode) {
+                this.router.navigate(['/tabs/vault']);
+            } else {
+                this.location.back();
+            }
             return true;
         }
 

--- a/src/popup/vault/add-edit.component.ts
+++ b/src/popup/vault/add-edit.component.ts
@@ -60,7 +60,7 @@ export class AddEditComponent extends BaseAddEditComponent {
             this.editMode = !params.cipherId;
 
             if (params.cloneMode != null) {
-                this.cloneMode = params.cloneMode;
+                this.cloneMode = params.cloneMode === true;
             } 
             await this.load();
 

--- a/src/popup/vault/view.component.html
+++ b/src/popup/vault/view.component.html
@@ -260,17 +260,17 @@
         </div>
     </div>
     <div class="box list" *ngIf="!cipher.organizationId">
-            <div class="box-content single-line">
-                <a class="box-content-row" href="#" appStopClick appBlurClick (click)="clone()">
-                    <div class="row-main text-primary">
-                        <div class="icon text-primary" aria-hidden="true">
-                            <i class="fa fa-clone fa-lg fa-fw"></i>
-                        </div>
-                        <span>{{'cloneItem' | i18n}}</span>
+        <div class="box-content single-line">
+            <a class="box-content-row" href="#" appStopClick appBlurClick (click)="clone()">
+                <div class="row-main text-primary">
+                    <div class="icon text-primary" aria-hidden="true">
+                        <i class="fa fa-clone fa-lg fa-fw"></i>
                     </div>
-                </a>
-            </div>
+                    <span>{{'cloneItem' | i18n}}</span>
+                </div>
+            </a>
         </div>
+    </div>
     <div class="box">
         <div class="box-footer">
             <div>

--- a/src/popup/vault/view.component.html
+++ b/src/popup/vault/view.component.html
@@ -259,6 +259,18 @@
             </a>
         </div>
     </div>
+    <div class="box list" *ngIf="!cipher.organizationId">
+            <div class="box-content single-line">
+                <a class="box-content-row" href="#" appStopClick appBlurClick (click)="clone()">
+                    <div class="row-main text-primary">
+                        <div class="icon text-primary" aria-hidden="true">
+                            <i class="fa fa-clone fa-lg fa-fw"></i>
+                        </div>
+                        <span>{{'cloneItem' | i18n}}</span>
+                    </div>
+                </a>
+            </div>
+        </div>
     <div class="box">
         <div class="box-footer">
             <div>

--- a/src/popup/vault/view.component.ts
+++ b/src/popup/vault/view.component.ts
@@ -64,6 +64,15 @@ export class ViewComponent extends BaseViewComponent {
         this.router.navigate(['/edit-cipher'], { queryParams: { cipherId: this.cipher.id } });
     }
 
+    clone() {
+        super.clone();
+        this.router.navigate(['/clone-cipher'], 
+        { queryParams: { 
+            cloneMode: true,
+            cipherId: this.cipher.id 
+        } });
+    }
+
     close() {
         this.location.back();
     }

--- a/src/popup/vault/view.component.ts
+++ b/src/popup/vault/view.component.ts
@@ -69,8 +69,8 @@ export class ViewComponent extends BaseViewComponent {
         this.router.navigate(['/clone-cipher'], {
             queryParams: {
                 cloneMode: true,
-                cipherId: this.cipher.id
-            }
+                cipherId: this.cipher.id,
+            },
         });
     }
 

--- a/src/popup/vault/view.component.ts
+++ b/src/popup/vault/view.component.ts
@@ -66,11 +66,12 @@ export class ViewComponent extends BaseViewComponent {
 
     clone() {
         super.clone();
-        this.router.navigate(['/clone-cipher'], 
-        { queryParams: { 
+        this.router.navigate(['/clone-cipher'], { 
+            queryParams: { 
             cloneMode: true,
             cipherId: this.cipher.id 
-        } });
+            } 
+        });
     }
 
     close() {

--- a/src/popup/vault/view.component.ts
+++ b/src/popup/vault/view.component.ts
@@ -66,11 +66,11 @@ export class ViewComponent extends BaseViewComponent {
 
     clone() {
         super.clone();
-        this.router.navigate(['/clone-cipher'], { 
-            queryParams: { 
-            cloneMode: true,
-            cipherId: this.cipher.id 
-            } 
+        this.router.navigate(['/clone-cipher'], {
+            queryParams: {
+                cloneMode: true,
+                cipherId: this.cipher.id
+            }
         });
     }
 


### PR DESCRIPTION
> Allow cloning of personal items within the browser extensions. Cloning of organizational items should be restricted.

- **package.json**: Update sub:pull script to include target branches
- **messages.json**: Added "Clone" and "Clone Item" strings
- **app-routing.animations**: Added "clone-cipher" routing animations for views in/around clone item flow
- **app-routing.module**: Added "clone-cipher" routing information
- **add-edit.component.html**: Enabled/disabled fields based on clone mode
- **add-edit.component.ts**: Set cloneMode before loading shared add-edit component and adjusted back navigation
- **view.component.html**: Added "clone item" row
- **view.component.ts**:  Added clone method callback and adjusted cloneMode query parameter

<img width="377" alt="0-view-item" src="https://user-images.githubusercontent.com/26154748/73689391-bdff8d80-4693-11ea-86ce-153c8c9be577.png">
<img width="377" alt="1-clone-item" src="https://user-images.githubusercontent.com/26154748/73689392-bdff8d80-4693-11ea-8396-a3b75194d68b.png">
<img width="377" alt="2-clone-item-ownership" src="https://user-images.githubusercontent.com/26154748/73689393-be982400-4693-11ea-8a13-1e7ce4fd1584.png">
<img width="377" alt="3-clone-item-collection" src="https://user-images.githubusercontent.com/26154748/73689394-be982400-4693-11ea-99ce-c0abf30ee77d.png">
<img width="377" alt="4-clone-item-success" src="https://user-images.githubusercontent.com/26154748/73689395-be982400-4693-11ea-9015-a92ae7e3f4c8.png">
<img width="377" alt="5-restrict-org-clone" src="https://user-images.githubusercontent.com/26154748/73689396-be982400-4693-11ea-9fbf-e5dda8767098.png">
