### PR TITLE
detect new edge browser hack for rate url

### DIFF
--- a/src/popup/settings/settings.component.ts
+++ b/src/popup/settings/settings.component.ts
@@ -280,10 +280,8 @@ export class SettingsComponent implements OnInit {
         this.analytics.eventTrack.next({ action: 'Rate Extension' });
         let device = this.platformUtilsService.getDevice();
         // Hack for detecting new Chromium Edge browser
-        if (device == DeviceType.ChromeExtension) {
-            if (window.navigator.userAgent.indexOf(' Edg/') > -1) {
-                device = DeviceType.EdgeExtension;
-            }
+        if (device == DeviceType.ChromeExtension && window.navigator.userAgent.indexOf(' Edg/') > -1) {
+            device = DeviceType.EdgeExtension;
         }
         BrowserApi.createNewTab((RateUrls as any)[device]);
     }

--- a/src/popup/settings/settings.component.ts
+++ b/src/popup/settings/settings.component.ts
@@ -32,7 +32,7 @@ const RateUrls = {
     [DeviceType.OperaExtension]:
         'https://addons.opera.com/en/extensions/details/bitwarden-free-password-manager/#feedback-container',
     [DeviceType.EdgeExtension]:
-        'https://www.microsoft.com/store/p/bitwarden-free-password-manager/9p6kxl0svnnl',
+        'https://microsoftedge.microsoft.com/addons/detail/jbkfoedolllekgbhcbcoahefnbanhhlh',
     [DeviceType.VivaldiExtension]:
         'https://chrome.google.com/webstore/detail/bitwarden-free-password-m/nngceckbapebfimnlniiiahkandclblb/reviews',
     [DeviceType.SafariExtension]:
@@ -278,6 +278,13 @@ export class SettingsComponent implements OnInit {
 
     rate() {
         this.analytics.eventTrack.next({ action: 'Rate Extension' });
-        BrowserApi.createNewTab((RateUrls as any)[this.platformUtilsService.getDevice()]);
+        let device = this.platformUtilsService.getDevice();
+        // Hack for detecting new Chromium Edge browser
+        if (device == DeviceType.ChromeExtension) {
+            if (window.navigator.userAgent.indexOf(' Edg/') > -1) {
+                device = DeviceType.EdgeExtension;
+            }
+        }
+        BrowserApi.createNewTab((RateUrls as any)[device]);
     }
 }


### PR DESCRIPTION
Microsoft recently released a new Chromium-based Edge browser for desktop ("new edge"). Since this browser has a different user agent than the "old edge", we are incorrectly detecting it as Chrome browser throughout. This is fine for now, since it doesn't really hurt anything. However, Microsoft rejected our latest update since we link to the chrome web store whenever a user clicks the "rate our app" button:

>  1.1.2  Distinct Function & Value; Accurate Representation
The product promotes another browser. Please remove the references.   Steps to reproduce: 1. Select the extension icon. 2. Log in with Bitwarden account. 3. Go to 'Rate the extension' in Settings. 4. Notice that the extension makes a reference to other browsers by redirecting the user to Chrome Web Store. 

This temporary fix should allow us to pass review.