### PR TITLE
Add in ability to auto-logout after time-out

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -324,6 +324,9 @@
   "lockOptions": {
     "message": "Lock Options"
   },
+  "lockOptionsLogout": {
+    "message": "Log Out after locking"
+  },
   "lockNow": {
     "message": "Lock Now"
   },

--- a/src/background/main.background.ts
+++ b/src/background/main.background.ts
@@ -168,7 +168,7 @@ export default class MainBackground {
                     this.systemService.startProcessReload();
                     await this.systemService.clearPendingClipboard();
                 }
-            });
+            }, async () => this.logout(true));
         this.syncService = new SyncService(this.userService, this.apiService, this.settingsService,
             this.folderService, this.cipherService, this.cryptoService, this.collectionService,
             this.storageService, this.messagingService, this.policyService,

--- a/src/popup/settings/settings.component.html
+++ b/src/popup/settings/settings.component.html
@@ -32,6 +32,10 @@
                 </select>
             </div>
             <div class="box-content-row box-content-row-checkbox" appBoxRow>
+                <label for="lockOptionsLogout">{{'lockOptionsLogout' | i18n}}</label>
+                <input id="lockOptionsLogout" type="checkbox" (change)="updateLockOptionsLogout()" [(ngModel)]="lockOptionsLogout">
+            </div>
+            <div class="box-content-row box-content-row-checkbox" appBoxRow>
                 <label for="pin">{{'unlockWithPin' | i18n}}</label>
                 <input id="pin" type="checkbox" (change)="updatePin()" [(ngModel)]="pin">
             </div>

--- a/src/popup/settings/settings.component.ts
+++ b/src/popup/settings/settings.component.ts
@@ -48,6 +48,7 @@ export class SettingsComponent implements OnInit {
     lockOptions: any[];
     lockOption: number = null;
     pin: boolean = null;
+    lockOptionsLogout: boolean = null;
     previousLockOption: number = null;
 
     constructor(private platformUtilsService: PlatformUtilsService, private i18nService: I18nService,
@@ -91,6 +92,8 @@ export class SettingsComponent implements OnInit {
 
         const pinSet = await this.lockService.isPinLockSet();
         this.pin = pinSet[0] || pinSet[1];
+
+        this.lockOptionsLogout = await this.lockService.isLogoutInstead();
     }
 
     async saveLockOption(newValue: number) {
@@ -113,6 +116,12 @@ export class SettingsComponent implements OnInit {
         if (this.previousLockOption == null) {
             this.messagingService.send('bgReseedStorage');
         }
+    }
+
+    async updateLockOptionsLogout() {
+        // if (this.lockOptionsLogout) {
+            await this.storageService.save(ConstantsService.lockOptionLogout, this.lockOptionsLogout)
+        // }
     }
 
     async updatePin() {


### PR DESCRIPTION
Hi all,

After setting up 2FA with security keys on my bitwarden account last night, I realized that it's not frequently asking for two factor authorization, since the default for 'locking' is to simply require the master password, and 2FA is only required after 'log out'. There have been discussions about this in the past (#91 and https://community.bitwarden.com/t/2fa-when-unlocking/353). I decided to mess around with the browser extension, and I've started working on somewhat of a work around.

This pull request (as well as one I will submit for the jslib repo shortly) adds in an option that allows users to choose to have the account logged out after the lock timer is up, so that 2FA can be required more frequently. 