### PR TITLE
Enforce Password Generator Policy Options

### DIFF
--- a/src/background/commands.background.ts
+++ b/src/background/commands.background.ts
@@ -57,7 +57,7 @@ export default class CommandsBackground {
             return;
         }
 
-        const options = await this.passwordGenerationService.getOptions();
+        const options = (await this.passwordGenerationService.getOptions())[0];
         const password = await this.passwordGenerationService.generatePassword(options);
         this.platformUtilsService.copyToClipboard(password, { window: window });
         this.passwordGenerationService.addHistory(password);

--- a/src/background/contextMenus.background.ts
+++ b/src/background/contextMenus.background.ts
@@ -37,7 +37,7 @@ export default class ContextMenusBackground {
     }
 
     private async generatePasswordToClipboard() {
-        const options = await this.passwordGenerationService.getOptions();
+        const options = (await this.passwordGenerationService.getOptions())[0];
         const password = await this.passwordGenerationService.generatePassword(options);
         this.platformUtilsService.copyToClipboard(password, { window: window });
         this.passwordGenerationService.addHistory(password);

--- a/src/background/main.background.ts
+++ b/src/background/main.background.ts
@@ -175,7 +175,8 @@ export default class MainBackground {
             async (expired: boolean) => await this.logout(expired));
         this.eventService = new EventService(this.storageService, this.apiService, this.userService,
             this.cipherService);
-        this.passwordGenerationService = new PasswordGenerationService(this.cryptoService, this.storageService);
+        this.passwordGenerationService = new PasswordGenerationService(this.cryptoService, this.storageService,
+            this.policyService);
         this.totpService = new TotpService(this.storageService, cryptoFunctionService);
         this.autofillService = new AutofillService(this.cipherService, this.userService, this.totpService,
             this.eventService);

--- a/src/popup/generator/password-generator.component.html
+++ b/src/popup/generator/password-generator.component.html
@@ -78,19 +78,23 @@
                 </div>
                 <div class="box-content-row box-content-row-checkbox" appBoxRow>
                     <label for="uppercase">A-Z</label>
-                    <input id="uppercase" type="checkbox" (change)="saveOptions()" [(ngModel)]="options.uppercase">
+                    <input id="uppercase" type="checkbox" (change)="saveOptions()"
+                        [disabled]="enforcedPolicyOptions.useUppercase" [(ngModel)]="options.uppercase">
                 </div>
                 <div class="box-content-row box-content-row-checkbox" appBoxRow>
                     <label for="lowercase">a-z</label>
-                    <input id="lowercase" type="checkbox" (change)="saveOptions()" [(ngModel)]="options.lowercase">
+                    <input id="lowercase" type="checkbox" (change)="saveOptions()"
+                        [disabled]="enforcedPolicyOptions.useLowercase" [(ngModel)]="options.lowercase">
                 </div>
                 <div class="box-content-row box-content-row-checkbox" appBoxRow>
                     <label for="numbers">0-9</label>
-                    <input id="numbers" type="checkbox" (change)="saveOptions()" [(ngModel)]="options.number">
+                    <input id="numbers" type="checkbox" (change)="saveOptions()"
+                        [disabled]="enforcedPolicyOptions.useNumbers" [(ngModel)]="options.number">
                 </div>
                 <div class="box-content-row box-content-row-checkbox" appBoxRow>
                     <label for="special">!@#$%^&*</label>
-                    <input id="special" type="checkbox" (change)="saveOptions()" [(ngModel)]="options.special">
+                    <input id="special" type="checkbox" (change)="saveOptions()"
+                        [disabled]="enforcedPolicyOptions.useSpecial" [(ngModel)]="options.special">
                 </div>
             </div>
         </div>
@@ -98,12 +102,12 @@
             <div class="box-content">
                 <div class="box-content-row box-content-row-input" appBoxRow>
                     <label for="min-number">{{'minNumbers' | i18n}}</label>
-                    <input id="min-number" type="number" min="0" max="9" (input)="saveOptions()"
+                    <input id="min-number" type="number" min="0" max="9" (blur)="saveOptions()"
                         [(ngModel)]="options.minNumber">
                 </div>
                 <div class="box-content-row box-content-row-input" appBoxRow>
                     <label for="min-special">{{'minSpecial' | i18n}}</label>
-                    <input id="min-special" type="number" min="0" max="9" (input)="saveOptions()"
+                    <input id="min-special" type="number" min="0" max="9" (blur)="saveOptions()"
                         [(ngModel)]="options.minSpecial">
                 </div>
                 <div class="box-content-row box-content-row-checkbox" appBoxRow>


### PR DESCRIPTION
## Objective
>Make sure the Password Generator enforces the specific rules set by an Organization for password generation. In the case of multiple Organizational rules, apply the stricter option.

## Code Changes
- **commands.background.ts**: Updated call to `getOptions` to handle tuple return object
- **contextMenus.background.ts**: Updated call to `getOptions` to handle tuple return object
- **main.background.ts**: Added `policyService` to `passwordGeneratorService` constructor
- **password-generator.component.html**: Added `disabled` logic to all of the policy-tracked checkboxes. Adjusted the number count and special count input fields to `saveOptions` on `blur`. `input` changes weren't properly being tracked.

## Screenshots
<img width="449" alt="Screen Shot 2020-02-27 at 12 40 20 PM" src="https://user-images.githubusercontent.com/26154748/75476100-9bddf000-595f-11ea-8372-22b140357e78.png">
<img width="379" alt="Screen Shot 2020-02-27 at 12 39 33 PM" src="https://user-images.githubusercontent.com/26154748/75476098-9b455980-595f-11ea-8839-47b33170746e.png">

