### PR TITLE
Add 12/24 hour lock options

### DIFF
--- a/src/_locales/be/messages.json
+++ b/src/_locales/be/messages.json
@@ -360,6 +360,12 @@
   "fourHours": {
     "message": "4 гадзіны"
   },
+  "twelveHours": {
+    "message": "12 гадзіны"
+  },
+  "twentyfourHours": {
+    "message": "24 гадзіны"
+  },
   "onLocked": {
     "message": "Разам з камп'ютарам"
   },

--- a/src/_locales/bg/messages.json
+++ b/src/_locales/bg/messages.json
@@ -360,6 +360,12 @@
   "fourHours": {
     "message": "4 часа"
   },
+  "twelveHours": {
+    "message": "12 часа"
+  },
+  "twentyfourHours": {
+    "message": "24 часа"
+  },
   "onLocked": {
     "message": "При заключване на системата"
   },

--- a/src/_locales/ca/messages.json
+++ b/src/_locales/ca/messages.json
@@ -360,6 +360,12 @@
   "fourHours": {
     "message": "4 hores"
   },
+  "twelveHours": {
+    "message": "12 hores"
+  },
+  "twentyfourHours": {
+    "message": "24 hores"
+  },
   "onLocked": {
     "message": "En bloquejar el sistema"
   },

--- a/src/_locales/cs/messages.json
+++ b/src/_locales/cs/messages.json
@@ -360,6 +360,12 @@
   "fourHours": {
     "message": "Po 4 hodinách"
   },
+  "twelveHours": {
+    "message": "Po 12 hodinách"
+  },
+  "twentyfourHours": {
+    "message": "Po 24 hodinách"
+  },
   "onLocked": {
     "message": "Při uzamknutí systému"
   },

--- a/src/_locales/da/messages.json
+++ b/src/_locales/da/messages.json
@@ -360,6 +360,12 @@
   "fourHours": {
     "message": "4 timer"
   },
+  "twelveHours": {
+    "message": "12 timer"
+  },
+  "twentyfourHours": {
+    "message": "24 timer"
+  },
   "onLocked": {
     "message": "Når systemet låses"
   },

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -360,6 +360,12 @@
   "fourHours": {
     "message": "4 Stunde"
   },
+  "twelveHours": {
+    "message": "12 Stunde"
+  },
+  "twentyfourHours": {
+    "message": "24 Stunde"
+  },
   "onLocked": {
     "message": "Wenn System gesperrt"
   },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -360,6 +360,12 @@
   "fourHours": {
     "message": "4 hours"
   },
+  "twelveHours": {
+    "message": "12 hours"
+  },
+  "twentyfourHours": {
+    "message": "24 hours"
+  },
   "onLocked": {
     "message": "On System Lock"
   },

--- a/src/_locales/en_GB/messages.json
+++ b/src/_locales/en_GB/messages.json
@@ -360,6 +360,12 @@
   "fourHours": {
     "message": "4 hours"
   },
+  "twelveHours": {
+    "message": "12 hours"
+  },
+  "twentyfourHours": {
+    "message": "24 hours"
+  },
   "onLocked": {
     "message": "On system lock"
   },

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -360,6 +360,12 @@
   "fourHours": {
     "message": "4 horas"
   },
+  "twelveHours": {
+    "message": "12 horas"
+  },
+  "twentyfourHours": {
+    "message": "24 horas"
+  },
   "onLocked": {
     "message": "Al bloquear el sistema"
   },

--- a/src/_locales/et/messages.json
+++ b/src/_locales/et/messages.json
@@ -360,6 +360,12 @@
   "fourHours": {
     "message": "4 tunni pärast"
   },
+  "twelveHours": {
+    "message": "12 tunni pärast"
+  },
+  "twentyfourHours": {
+    "message": "24 tunni pärast"
+  },
   "onLocked": {
     "message": "Arvutist väljalogimisel"
   },

--- a/src/_locales/fa/messages.json
+++ b/src/_locales/fa/messages.json
@@ -360,6 +360,12 @@
   "fourHours": {
     "message": "4 ساعت"
   },
+  "twelveHours": {
+    "message": "12 ساعت"
+  },
+  "twentyfourHours": {
+    "message": "24 ساعت"
+  },
   "onLocked": {
     "message": "هنگام قفل سیستم"
   },

--- a/src/_locales/fi/messages.json
+++ b/src/_locales/fi/messages.json
@@ -360,6 +360,12 @@
   "fourHours": {
     "message": "4 tuntia"
   },
+  "twelveHours": {
+    "message": "12 tuntia"
+  },
+  "twentyfourHours": {
+    "message": "24 tuntia"
+  },
   "onLocked": {
     "message": "Tietokoneen lukitsemisen yhteydessä"
   },

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -360,6 +360,12 @@
   "fourHours": {
     "message": "4 heures"
   },
+  "twelveHours": {
+    "message": "12 heures"
+  },
+  "twentyfourHours": {
+    "message": "24 heures"
+  },
   "onLocked": {
     "message": "Au verrouillage du système"
   },

--- a/src/_locales/he/messages.json
+++ b/src/_locales/he/messages.json
@@ -360,6 +360,12 @@
   "fourHours": {
     "message": "4 שעות"
   },
+  "twelveHours": {
+    "message": "12 שעות"
+  },
+  "twentyfourHours": {
+    "message": "24 שעות"
+  },
   "onLocked": {
     "message": "בזמן נעילת המערכת"
   },

--- a/src/_locales/hi/messages.json
+++ b/src/_locales/hi/messages.json
@@ -360,6 +360,12 @@
   "fourHours": {
     "message": "4 hours"
   },
+  "twelveHours": {
+    "message": "12 hours"
+  },
+  "twentyfourHours": {
+    "message": "24 hours"
+  },
   "onLocked": {
     "message": "On Locked"
   },

--- a/src/_locales/hr/messages.json
+++ b/src/_locales/hr/messages.json
@@ -360,6 +360,12 @@
   "fourHours": {
     "message": "4 sata"
   },
+  "twelveHours": {
+    "message": "12 sata"
+  },
+  "twentyfourHours": {
+    "message": "24 sata"
+  },
   "onLocked": {
     "message": "Kod zaključavanja sustava"
   },

--- a/src/_locales/hu/messages.json
+++ b/src/_locales/hu/messages.json
@@ -360,6 +360,12 @@
   "fourHours": {
     "message": "4 óra"
   },
+  "twelveHours": {
+    "message": "12 óra"
+  },
+  "twentyfourHours": {
+    "message": "24 óra"
+  },
   "onLocked": {
     "message": "Rendszerzároláskor"
   },

--- a/src/_locales/id/messages.json
+++ b/src/_locales/id/messages.json
@@ -360,6 +360,12 @@
   "fourHours": {
     "message": "4 jam"
   },
+  "twelveHours": {
+    "message": "12 jam"
+  },
+  "twentyfourHours": {
+    "message": "24 jam"
+  },
   "onLocked": {
     "message": "Saat Komputer Terkunci"
   },

--- a/src/_locales/it/messages.json
+++ b/src/_locales/it/messages.json
@@ -360,6 +360,12 @@
   "fourHours": {
     "message": "4 ore"
   },
+  "twelveHours": {
+    "message": "12 ore"
+  },
+  "twentyfourHours": {
+    "message": "24 ore"
+  },
   "onLocked": {
     "message": "Al Blocco Computer"
   },

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -360,6 +360,12 @@
   "fourHours": {
     "message": "4時間"
   },
+  "twelveHours": {
+    "message": "12時間"
+  },
+  "twentyfourHours": {
+    "message": "24時間"
+  },
   "onLocked": {
     "message": "ロック時"
   },

--- a/src/_locales/ko/messages.json
+++ b/src/_locales/ko/messages.json
@@ -360,6 +360,12 @@
   "fourHours": {
     "message": "4시간"
   },
+  "twelveHours": {
+    "message": "12시간"
+  },
+  "twentyfourHours": {
+    "message": "24시간"
+  },
   "onLocked": {
     "message": "시스템 잠금 시"
   },

--- a/src/_locales/nb/messages.json
+++ b/src/_locales/nb/messages.json
@@ -360,6 +360,12 @@
   "fourHours": {
     "message": "4 timer"
   },
+  "twelveHours": {
+    "message": "12 timer"
+  },
+  "twentyfourHours": {
+    "message": "24 timer"
+  },
   "onLocked": {
     "message": "Ved maskinlåsing"
   },

--- a/src/_locales/nl/messages.json
+++ b/src/_locales/nl/messages.json
@@ -360,6 +360,12 @@
   "fourHours": {
     "message": "4 uur"
   },
+  "twelveHours": {
+    "message": "12 uur"
+  },
+  "twentyfourHours": {
+    "message": "24 uur"
+  },
   "onLocked": {
     "message": "Bij systeemvergrendeling"
   },

--- a/src/_locales/pl/messages.json
+++ b/src/_locales/pl/messages.json
@@ -360,6 +360,12 @@
   "fourHours": {
     "message": "po 4 godzinach"
   },
+  "twelveHours": {
+    "message": "po 12 godzinach"
+  },
+  "twentyfourHours": {
+    "message": "po 24 godzinach"
+  },
   "onLocked": {
     "message": "Gdy zablokujesz komputer"
   },

--- a/src/_locales/pt_BR/messages.json
+++ b/src/_locales/pt_BR/messages.json
@@ -360,6 +360,12 @@
   "fourHours": {
     "message": "4 horas"
   },
+  "twelveHours": {
+    "message": "12 horas"
+  },
+  "twentyfourHours": {
+    "message": "24 horas"
+  },
   "onLocked": {
     "message": "Quando o Sistema for Bloqueado"
   },

--- a/src/_locales/pt_PT/messages.json
+++ b/src/_locales/pt_PT/messages.json
@@ -360,6 +360,12 @@
   "fourHours": {
     "message": "4 horas"
   },
+  "twelveHours": {
+    "message": "12 horas"
+  },
+  "twentyfourHours": {
+    "message": "24 horas"
+  },
   "onLocked": {
     "message": "Quando o sistema está bloqueado"
   },

--- a/src/_locales/ro/messages.json
+++ b/src/_locales/ro/messages.json
@@ -360,6 +360,12 @@
   "fourHours": {
     "message": "4 ore"
   },
+  "twelveHours": {
+    "message": "12 ore"
+  },
+  "twentyfourHours": {
+    "message": "24 ore"
+  },
   "onLocked": {
     "message": "La blocarea computerului"
   },

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -360,6 +360,12 @@
   "fourHours": {
     "message": "4 часа"
   },
+  "twelveHours": {
+    "message": "12 часа"
+  },
+  "twentyfourHours": {
+    "message": "24 часа"
+  },
   "onLocked": {
     "message": "Вместе с компьютером"
   },

--- a/src/_locales/sk/messages.json
+++ b/src/_locales/sk/messages.json
@@ -360,6 +360,12 @@
   "fourHours": {
     "message": "4 hodiny"
   },
+  "twelveHours": {
+    "message": "12 hodiny"
+  },
+  "twentyfourHours": {
+    "message": "24 hodiny"
+  },
   "onLocked": {
     "message": "Pri uzamknutí"
   },

--- a/src/_locales/sv/messages.json
+++ b/src/_locales/sv/messages.json
@@ -360,6 +360,12 @@
   "fourHours": {
     "message": "4 timmar"
   },
+  "twelveHours": {
+    "message": "12 timmar"
+  },
+  "twentyfourHours": {
+    "message": "24 timmar"
+  },
   "onLocked": {
     "message": "Vid låsning av datorn"
   },

--- a/src/_locales/th/messages.json
+++ b/src/_locales/th/messages.json
@@ -360,6 +360,12 @@
   "fourHours": {
     "message": "4 ชั่วโมง"
   },
+  "twelveHours": {
+    "message": "12 ชั่วโมง"
+  },
+  "twentyfourHours": {
+    "message": "24 ชั่วโมง"
+  },
   "onLocked": {
     "message": "On Locked"
   },

--- a/src/_locales/tr/messages.json
+++ b/src/_locales/tr/messages.json
@@ -360,6 +360,12 @@
   "fourHours": {
     "message": "4 saat"
   },
+  "twelveHours": {
+    "message": "12 saat"
+  },
+  "twentyfourHours": {
+    "message": "24 saat"
+  },
   "onLocked": {
     "message": "Sistem Kilitliyken"
   },

--- a/src/_locales/uk/messages.json
+++ b/src/_locales/uk/messages.json
@@ -360,6 +360,12 @@
   "fourHours": {
     "message": "4 години"
   },
+  "twelveHours": {
+    "message": "12 години"
+  },
+  "twentyfourHours": {
+    "message": "24 години"
+  },
   "onLocked": {
     "message": "При блокуванні системи"
   },

--- a/src/_locales/vi/messages.json
+++ b/src/_locales/vi/messages.json
@@ -360,6 +360,12 @@
   "fourHours": {
     "message": "4 giờ"
   },
+  "twelveHours": {
+    "message": "12 giờ"
+  },
+  "twentyfourHours": {
+    "message": "24 giờ"
+  },
   "onLocked": {
     "message": "Mỗi khi khóa"
   },

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -360,6 +360,12 @@
   "fourHours": {
     "message": "4 小时"
   },
+  "twelveHours": {
+    "message": "12 小时"
+  },
+  "twentyfourHours": {
+    "message": "24 小时"
+  },
   "onLocked": {
     "message": "系统锁定时"
   },

--- a/src/_locales/zh_TW/messages.json
+++ b/src/_locales/zh_TW/messages.json
@@ -360,6 +360,12 @@
   "fourHours": {
     "message": "4 小時"
   },
+  "twelveHours": {
+    "message": "12 小時"
+  },
+  "twentyfourHours": {
+    "message": "24 小時"
+  },
   "onLocked": {
     "message": "系統鎖定時"
   },

--- a/src/popup/settings/settings.component.ts
+++ b/src/popup/settings/settings.component.ts
@@ -69,6 +69,8 @@ export class SettingsComponent implements OnInit {
             { name: this.i18nService.t('thirtyMinutes'), value: 30 },
             { name: this.i18nService.t('oneHour'), value: 60 },
             { name: this.i18nService.t('fourHours'), value: 240 },
+            { name: this.i18nService.t('twelveHours'), value: 720 },
+            { name: this.i18nService.t('twentyfourHours'), value: 1440 },
             // { name: i18nService.t('onIdle'), value: -4 },
             // { name: i18nService.t('onSleep'), value: -3 },
         ];


### PR DESCRIPTION
Hi! I recently converted from lastpass and noticed the maximum lock duration was 4 hours. This results in needing to re-login over the course of a single work day (which can be a minor annoyance) but was noticeable when trying to make the move. 

I've added 12 and 24 hours here and updated locales, if you think this is too much clutter for the UI I would be more than happy to just use one or the other.