### PR TITLE
Enforce Passphrase Policy

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1247,14 +1247,5 @@
   },
   "passwordGeneratorPolicyInEffect": {
     "message": "One or more organization policies are affecting your generator settings."
-  },
-  "minimumNumberOfWords": {
-    "message": "Minimum Number of Words"
-  },
-  "passwordGeneratorPolicyDefaultType": {
-    "message": "Default Type"
-  },
-  "passwordGeneratorPolicyUserPreference": {
-    "message": "User Preference"
   }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1247,5 +1247,14 @@
   },
   "passwordGeneratorPolicyInEffect": {
     "message": "One or more organization policies are affecting your generator settings."
+  },
+  "minimumNumberOfWords": {
+    "message": "Minimum Number of Words"
+  },
+  "passwordGeneratorPolicyDefaultType": {
+    "message": "Default Type"
+  },
+  "passwordGeneratorPolicyUserPreference": {
+    "message": "User Preference"
   }
 }

--- a/src/popup/generator/password-generator.component.html
+++ b/src/popup/generator/password-generator.component.html
@@ -51,7 +51,7 @@
         <div class="box-content">
             <div class="box-content-row box-content-row-input" appBoxRow>
                 <label for="num-words">{{'numWords' | i18n}}</label>
-                <input id="num-words" type="number" min="3" max="20" (change)="saveOptions()"
+                <input id="num-words" type="number" min="3" max="20" (blur)="saveOptions()"
                     [(ngModel)]="options.numWords">
             </div>
             <div class="box-content-row box-content-row-input" appBoxRow>

--- a/src/popup/generator/password-generator.component.html
+++ b/src/popup/generator/password-generator.component.html
@@ -11,7 +11,7 @@
     </div>
 </header>
 <content>
-    <app-callout type="info" *ngIf="policyInEffect">
+    <app-callout type="info" *ngIf="enforcedPolicyOptions?.inEffect()">
         {{'passwordGeneratorPolicyInEffect' | i18n}}
     </app-callout>
     <div class="password-block">
@@ -61,11 +61,13 @@
             </div>
             <div class="box-content-row box-content-row-checkbox" appBoxRow>
                 <label for="capitalize">{{'capitalize' | i18n}}</label>
-                <input id="capitalize" type="checkbox" (change)="saveOptions()" [(ngModel)]="options.capitalize">
+                <input id="capitalize" type="checkbox" (change)="saveOptions()" [(ngModel)]="options.capitalize"
+                    [disabled]="enforcedPolicyOptions?.capitalize">
             </div>
             <div class="box-content-row box-content-row-checkbox" appBoxRow>
                 <label for="include-number">{{'includeNumber' | i18n}}</label>
-                <input id="include-number" type="checkbox" (change)="saveOptions()" [(ngModel)]="options.includeNumber">
+                <input id="include-number" type="checkbox" (change)="saveOptions()" [(ngModel)]="options.includeNumber"
+                    [disabled]="enforcedPolicyOptions?.includeNumber">
             </div>
         </div>
     </div>

--- a/src/popup/generator/password-generator.component.html
+++ b/src/popup/generator/password-generator.component.html
@@ -51,7 +51,7 @@
         <div class="box-content">
             <div class="box-content-row box-content-row-input" appBoxRow>
                 <label for="num-words">{{'numWords' | i18n}}</label>
-                <input id="num-words" type="number" min="3" max="20" (input)="saveOptions()"
+                <input id="num-words" type="number" min="3" max="20" (change)="saveOptions()"
                     [(ngModel)]="options.numWords">
             </div>
             <div class="box-content-row box-content-row-input" appBoxRow>


### PR DESCRIPTION
## Objective
> Add missing components for passphrase policy. Use existing data structures/patterns to implement a shared password generator (password/passphrase)

## Code Changes
- **jslib**: Updated from 44b86f5 -> 36241e9
- **password-generator.component.html**: Updated existing fields to respect potentially enforced options for passphrase generation

## Screenshots
<img width="388" alt="0-pgp-passphrase" src="https://user-images.githubusercontent.com/26154748/76436099-d4c98c00-6385-11ea-8c64-075ad50346c6.png">
