### PR TITLE
Fixed Windows Symlink command in package.json for npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "sub:update": "git submodule update --remote",
     "sub:pull": "git submodule foreach git pull origin master",
     "postinstall": "npm run sub:init",
-    "symlink:win": "rm -rf ./jslib && cmd /c mklink /J .\\jslib ..\\jslib",
+    "symlink:win": "rmdir /S /Q ./jslib && cmd /c mklink /J .\\jslib ..\\jslib",
     "symlink:mac": "npm run symlink:lin",
     "symlink:lin": "rm -rf ./jslib && ln -s ../jslib ./jslib",
     "build": "gulp build && webpack",


### PR DESCRIPTION
Tried setting up the symlink on Windows and noticed the npm script failed with unknown command... fixed the script to get that working.

rmdir vs. rm, /S /Q vs. -rf.