### PR TITLE
Add context menu entry sanitation for ampersands (&)

### DIFF
--- a/src/background/main.background.ts
+++ b/src/background/main.background.ts
@@ -560,7 +560,7 @@ export default class MainBackground {
                 id: 'autofill_' + idSuffix,
                 parentId: 'autofill',
                 contexts: ['all'],
-                title: title,
+                title: this.sanitizeContextMenuTitle(title),
             });
         }
 
@@ -570,7 +570,7 @@ export default class MainBackground {
                 id: 'copy-username_' + idSuffix,
                 parentId: 'copy-username',
                 contexts: ['all'],
-                title: title,
+                title: this.sanitizeContextMenuTitle(title),
             });
         }
 
@@ -580,7 +580,7 @@ export default class MainBackground {
                 id: 'copy-password_' + idSuffix,
                 parentId: 'copy-password',
                 contexts: ['all'],
-                title: title,
+                title: this.sanitizeContextMenuTitle(title),
             });
         }
 
@@ -590,9 +590,13 @@ export default class MainBackground {
                 id: 'copy-totp_' + idSuffix,
                 parentId: 'copy-totp',
                 contexts: ['all'],
-                title: title,
+                title: this.sanitizeContextMenuTitle(title),
             });
         }
+    }
+
+    private sanitizeContextMenuTitle(title: string): string {
+        return title.replace(/&/g, '&&');
     }
 
     private cleanupNotificationQueue() {


### PR DESCRIPTION
Fixes a bug where a context menu entry (auto-fill, copy password, etc.) would display incorrectly when it included an ampersand (&). I fixed it by doubling every occurring ampersand, as that produces one *single* ampersand in menus.
**I have only verified this behavior in Firefox 74.0.1 for Linux; I have not tried any other version or browser.**
Here is a screenshot from before the fix: ![](https://files.catbox.moe/xe8frk.png)
Here is how it looks after the fix: ![](https://files.catbox.moe/wy8xlr.png)

### A note on the implementation
On line 599 I used a Regular Expression to achieve a way to replace *all* occurrences of a substring within a string.
Online I could find [one other implementation that didn’t use RegEx](https://stackoverflow.com/a/17606289), but according to [a provided benchmark](https://jsben.ch/LFfWA), the approach I used is most efficient.