### PR TITLE
[Auto-Logout] Updated Context Menu State

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -91,6 +91,9 @@
   "vaultLocked": {
     "message": "Vault is locked."
   },
+  "vaultLoggedOut": {
+    "message": "Vault is logged out."
+  },
   "autoFillInfo": {
     "message": "There are no logins available to auto-fill for the current browser tab."
   },

--- a/src/background/main.background.ts
+++ b/src/background/main.background.ts
@@ -286,7 +286,7 @@ export default class MainBackground {
         }
 
         if (forLocked) {
-            await this.loadMenuAndUpdateBadgeForLockedState(!menuDisabled);
+            await this.loadMenuAndUpdateBadgeForNoAccessState(!menuDisabled);
             this.onUpdatedRan = this.onReplacedRan = false;
             return;
         }
@@ -513,12 +513,19 @@ export default class MainBackground {
             } catch { }
         }
 
-        await this.loadMenuAndUpdateBadgeForLockedState(contextMenuEnabled);
+        await this.loadMenuAndUpdateBadgeForNoAccessState(contextMenuEnabled);
     }
 
-    private async loadMenuAndUpdateBadgeForLockedState(contextMenuEnabled: boolean) {
+    private async loadMenuAndUpdateBadgeForNoAccessState(contextMenuEnabled: boolean) {
         if (contextMenuEnabled) {
-            await this.loadNoLoginsContextMenuOptions(this.i18nService.t('vaultLocked'));
+            const authed = await this.userService.isAuthenticated();
+            let title: string = null;
+            if (!authed) {
+                title = this.i18nService.t('vaultLoggedOut');
+            } else {
+                title = this.i18nService.t('vaultLocked');
+            }
+            await this.loadNoLoginsContextMenuOptions(title);
         }
 
         const tabs = await BrowserApi.getActiveTabs();

--- a/src/background/main.background.ts
+++ b/src/background/main.background.ts
@@ -519,13 +519,7 @@ export default class MainBackground {
     private async loadMenuAndUpdateBadgeForNoAccessState(contextMenuEnabled: boolean) {
         if (contextMenuEnabled) {
             const authed = await this.userService.isAuthenticated();
-            let title: string = null;
-            if (!authed) {
-                title = this.i18nService.t('vaultLoggedOut');
-            } else {
-                title = this.i18nService.t('vaultLocked');
-            }
-            await this.loadNoLoginsContextMenuOptions(title);
+            await this.loadNoLoginsContextMenuOptions(this.i18nService.t(authed ? 'vaultLocked' : 'vaultLoggedOut'));
         }
 
         const tabs = await BrowserApi.getActiveTabs();


### PR DESCRIPTION
## Objective
> Update the context menu "locked" state to also look for the user being logged out. Update the context message accordingly.

## Code Changes
- **messages.json**:  Added vault logged out string
- **main.background.ts**: Changed function name to better suit its use cases. Added conditional for determining which string to use based on lock vs log out state.

## Screenshots
<img width="716" alt="0-auto-logout-context" src="https://user-images.githubusercontent.com/26154748/78709564-7ab2dc80-78d9-11ea-93d1-888350c7ebbd.png">
