### PR TITLE
[Soft delete] - Ads trash bin to browser extension

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1257,5 +1257,30 @@
   "lock": {
     "message": "Lock",
     "description": "Verb form: to make secure or inaccesible by"
+  },
+  "trash": {
+    "message": "Trash",
+    "description": "Noun: a special folder to hold deleted items"
+  },
+  "searchTrash": {
+    "message": "Search trash"
+  },
+  "permanentlyDeleteItem": {
+    "message": "Permanently Delete Item"
+  },
+  "permanentlyDeleteItemConfirmation": {
+    "message": "Are you sure you want to permanently delete this item?"
+  },
+  "permanentlyDeletedItem": {
+    "message": "Permanently Deleted item"
+  },
+  "restoreItem": {
+    "message": "Restore Item"
+  },
+  "restoreItemConfirmation": {
+    "message": "Are you sure you want to restore this item?"
+  },
+  "restoredItem": {
+    "message": "Restored Item"
   }
 }

--- a/src/popup/vault/ciphers.component.ts
+++ b/src/popup/vault/ciphers.component.ts
@@ -79,7 +79,11 @@ export class CiphersComponent extends BaseCiphersComponent implements OnInit, On
                 }
             }
 
-            if (params.type) {
+            if (params.deleted) {
+                this.groupingTitle = this.i18nService.t('trash');
+                this.searchPlaceholder = this.i18nService.t('searchTrash');
+                await this.load(null, true);
+            } else if (params.type) {
                 this.searchPlaceholder = this.i18nService.t('searchType');
                 this.type = parseInt(params.type, null);
                 switch (this.type) {
@@ -198,6 +202,9 @@ export class CiphersComponent extends BaseCiphersComponent implements OnInit, On
     }
 
     addCipher() {
+        if (this.deleted) {
+            return false;
+        }
         super.addCipher();
         this.router.navigate(['/add-cipher'], {
             queryParams: {

--- a/src/popup/vault/groupings.component.html
+++ b/src/popup/vault/groupings.component.html
@@ -121,6 +121,23 @@
                     (onSelected)="selectCipher($event)" (onDoubleSelected)="launchCipher($event)"></app-ciphers-list>
             </div>
         </div>
+        <div class="box list" *ngIf="deletedCount">
+            <div class="box-header">
+                {{'trash' | i18n}}
+                <span class="flex-right">{{deletedCount}}</span>
+            </div>
+            <div class="box-content single-line">
+                <a href="#" class="box-content-row" appStopClick appBlurClick
+                    (click)="selectTrash()">
+                    <div class="row-main">
+                        <div class="icon"><i class="fa fa-fw fa-lg fa-trash-o"></i></div>
+                        <span class="text">{{'trash' | i18n}}</span>
+                    </div>
+                    <span class="row-sub-label">{{deletedCount}}</span>
+                    <span><i class="fa fa-chevron-right fa-lg row-sub-icon"></i></span>
+                </a>
+            </div>
+        </div>
     </ng-container>
     <ng-container *ngIf="showSearching()">
         <div class="no-items" *ngIf="!ciphers || !ciphers.length">

--- a/src/popup/vault/groupings.component.ts
+++ b/src/popup/vault/groupings.component.ts
@@ -57,7 +57,7 @@ export class GroupingsComponent extends BaseGroupingsComponent implements OnInit
     showLeftHeader = true;
     searchPending = false;
     searchTypeSearch = false;
-    deletedCount: number = 0;
+    deletedCount = 0;
 
     private loadedTimeout: number;
     private selectedTimeout: number;

--- a/src/popup/vault/groupings.component.ts
+++ b/src/popup/vault/groupings.component.ts
@@ -57,6 +57,7 @@ export class GroupingsComponent extends BaseGroupingsComponent implements OnInit
     showLeftHeader = true;
     searchPending = false;
     searchTypeSearch = false;
+    deletedCount: number = 0;
 
     private loadedTimeout: number;
     private selectedTimeout: number;
@@ -167,6 +168,7 @@ export class GroupingsComponent extends BaseGroupingsComponent implements OnInit
         if (!this.hasLoadedAllCiphers) {
             this.hasLoadedAllCiphers = !this.searchService.isSearchable(this.searchText);
         }
+        this.deletedCount = this.allCiphers.filter((c) => c.isDeleted).length;
         await this.search(null);
         let favoriteCiphers: CipherView[] = null;
         let noFolderCiphers: CipherView[] = null;
@@ -175,6 +177,9 @@ export class GroupingsComponent extends BaseGroupingsComponent implements OnInit
         const typeCounts = new Map<CipherType, number>();
 
         this.ciphers.forEach((c) => {
+            if (c.isDeleted) {
+                return;
+            }
             if (c.favorite) {
                 if (favoriteCiphers == null) {
                     favoriteCiphers = [];
@@ -224,9 +229,10 @@ export class GroupingsComponent extends BaseGroupingsComponent implements OnInit
         if (this.searchTimeout != null) {
             clearTimeout(this.searchTimeout);
         }
+        const filterDeleted = (c: CipherView) => !c.isDeleted;
         if (timeout == null) {
             this.hasSearched = this.searchService.isSearchable(this.searchText);
-            this.ciphers = await this.searchService.searchCiphers(this.searchText, null, this.allCiphers);
+            this.ciphers = await this.searchService.searchCiphers(this.searchText, filterDeleted, this.allCiphers);
             return;
         }
         this.searchPending = true;
@@ -235,7 +241,7 @@ export class GroupingsComponent extends BaseGroupingsComponent implements OnInit
             if (!this.hasLoadedAllCiphers && !this.hasSearched) {
                 await this.loadCiphers();
             } else {
-                this.ciphers = await this.searchService.searchCiphers(this.searchText, null, this.allCiphers);
+                this.ciphers = await this.searchService.searchCiphers(this.searchText, filterDeleted, this.allCiphers);
             }
             this.searchPending = false;
         }, timeout);
@@ -254,6 +260,11 @@ export class GroupingsComponent extends BaseGroupingsComponent implements OnInit
     async selectCollection(collection: CollectionView) {
         super.selectCollection(collection);
         this.router.navigate(['/ciphers'], { queryParams: { collectionId: collection.id } });
+    }
+
+    async selectTrash() {
+        super.selectTrash();
+        this.router.navigate(['/ciphers'], { queryParams: { deleted: true } });
     }
 
     async selectCipher(cipher: CipherView) {
@@ -305,6 +316,7 @@ export class GroupingsComponent extends BaseGroupingsComponent implements OnInit
             typeCounts: this.typeCounts,
             folders: this.folders,
             collections: this.collections,
+            deletedCount: this.deletedCount,
         };
         await this.stateService.save(ScopeStateId, this.scopeState);
     }
@@ -338,6 +350,9 @@ export class GroupingsComponent extends BaseGroupingsComponent implements OnInit
         }
         if (this.scopeState.collections != null) {
             this.collections = this.scopeState.collections;
+        }
+        if (this.scopeState.deletedCiphers != null) {
+            this.deletedCount = this.scopeState.deletedCount;
         }
 
         return true;

--- a/src/popup/vault/view.component.html
+++ b/src/popup/vault/view.component.html
@@ -6,7 +6,7 @@
         <span class="title">{{'viewItem' | i18n}}</span>
     </div>
     <div class="right">
-        <button type="button" appBlurClick (click)="edit()">{{'edit' | i18n}}</button>
+        <button type="button" appBlurClick (click)="edit()" *ngIf="!cipher.isDeleted">{{'edit' | i18n}}</button>
     </div>
 </header>
 <content *ngIf="cipher">
@@ -259,14 +259,34 @@
             </a>
         </div>
     </div>
-    <div class="box list" *ngIf="!cipher.organizationId">
-        <div class="box-content single-line">
+    <div class="box list">
+        <div class="box-content single-line" *ngIf="!cipher.organizationId && !cipher.isDeleted">
             <a class="box-content-row" href="#" appStopClick appBlurClick (click)="clone()">
                 <div class="row-main text-primary">
                     <div class="icon text-primary" aria-hidden="true">
                         <i class="fa fa-clone fa-lg fa-fw"></i>
                     </div>
                     <span>{{'cloneItem' | i18n}}</span>
+                </div>
+            </a>
+        </div>
+        <div class="box-content single-line" *ngIf="cipher.isDeleted">
+            <a class="box-content-row" href="#" appStopClick appBlurClick (click)="restore()">
+                <div class="row-main text-primary">
+                    <div class="icon text-primary" aria-hidden="true">
+                        <i class="fa fa-undo fa-lg fa-fw"></i>
+                    </div>
+                    <span>{{'restoreItem' | i18n}}</span>
+                </div>
+            </a>
+        </div>
+        <div class="box-content single-line">
+            <a class="box-content-row" href="#" appStopClick appBlurClick (click)="delete()">
+                <div class="row-main text-danger">
+                    <div class="icon text-danger" aria-hidden="true">
+                        <i class="fa fa-trash-o fa-lg fa-fw"></i>
+                    </div>
+                    <span>{{(cipher.isDeleted ? 'permanentlyDeleteItem' : 'deleteItem') | i18n}}</span>
                 </div>
             </a>
         </div>

--- a/src/popup/vault/view.component.html
+++ b/src/popup/vault/view.component.html
@@ -260,8 +260,9 @@
         </div>
     </div>
     <div class="box list">
-        <div class="box-content single-line" *ngIf="!cipher.organizationId && !cipher.isDeleted">
-            <a class="box-content-row" href="#" appStopClick appBlurClick (click)="clone()">
+        <div class="box-content single-line">
+            <a class="box-content-row" href="#" appStopClick appBlurClick (click)="clone()" 
+                *ngIf="!cipher.organizationId && !cipher.isDeleted">
                 <div class="row-main text-primary">
                     <div class="icon text-primary" aria-hidden="true">
                         <i class="fa fa-clone fa-lg fa-fw"></i>
@@ -269,9 +270,7 @@
                     <span>{{'cloneItem' | i18n}}</span>
                 </div>
             </a>
-        </div>
-        <div class="box-content single-line" *ngIf="cipher.isDeleted">
-            <a class="box-content-row" href="#" appStopClick appBlurClick (click)="restore()">
+            <a class="box-content-row" href="#" appStopClick appBlurClick (click)="restore()" *ngIf="cipher.isDeleted">
                 <div class="row-main text-primary">
                     <div class="icon text-primary" aria-hidden="true">
                         <i class="fa fa-undo fa-lg fa-fw"></i>
@@ -279,8 +278,6 @@
                     <span>{{'restoreItem' | i18n}}</span>
                 </div>
             </a>
-        </div>
-        <div class="box-content single-line">
             <a class="box-content-row" href="#" appStopClick appBlurClick (click)="delete()">
                 <div class="row-main text-danger">
                     <div class="icon text-danger" aria-hidden="true">

--- a/src/popup/vault/view.component.ts
+++ b/src/popup/vault/view.component.ts
@@ -60,11 +60,17 @@ export class ViewComponent extends BaseViewComponent {
     }
 
     edit() {
+        if (this.cipher.isDeleted) {
+            return false;
+        }
         super.edit();
         this.router.navigate(['/edit-cipher'], { queryParams: { cipherId: this.cipher.id } });
     }
 
     clone() {
+        if (this.cipher.isDeleted) {
+            return false;
+        }
         super.clone();
         this.router.navigate(['/clone-cipher'], {
             queryParams: {
@@ -72,6 +78,25 @@ export class ViewComponent extends BaseViewComponent {
                 cipherId: this.cipher.id,
             },
         });
+    }
+
+    async restore() {
+        if (!this.cipher.isDeleted) {
+            return false;
+        }
+        if (await super.restore()) {
+            this.close();
+            return true;
+        }
+        return false;
+    }
+
+    async delete() {
+        if (await super.delete()) {
+            this.close();
+            return true;
+        }
+        return false;
     }
 
     close() {

--- a/src/services/browserPlatformUtils.service.spec.ts
+++ b/src/services/browserPlatformUtils.service.spec.ts
@@ -24,8 +24,7 @@ describe('Browser Utils Service', () => {
         it('should detect chrome', () => {
             Object.defineProperty(navigator, 'userAgent', {
                 configurable: true,
-                value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) ' +
-                    'Chrome / 62.0.3202.94 Safari/ 537.36',
+                value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.94 Safari/537.36',
             });
 
             const browserPlatformUtilsService = new BrowserPlatformUtilsService(null, null);
@@ -45,8 +44,7 @@ describe('Browser Utils Service', () => {
         it('should detect opera', () => {
             Object.defineProperty(navigator, 'userAgent', {
                 configurable: true,
-                value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) ' +
-                    'Chrome / 62.0.3175.3 Safari/ 537.36 OPR / 49.0.2695.0(Edition developer)',
+                value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3175.3 Safari/537.36 OPR/49.0.2695.0 (Edition developer)',
             });
 
             Object.defineProperty(window, 'opr', {
@@ -61,8 +59,7 @@ describe('Browser Utils Service', () => {
         it('should detect edge', () => {
             Object.defineProperty(navigator, 'userAgent', {
                 configurable: true,
-                value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; ServiceUI 9) AppleWebKit/537.36 (KHTML, like Gecko)' +
-                    'Chrome / 52.0.2743.116 Safari/ 537.36 Edge / 15.15063',
+                value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; ServiceUI 9) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/15.15063',
             });
 
             const browserPlatformUtilsService = new BrowserPlatformUtilsService(null, null);
@@ -72,8 +69,7 @@ describe('Browser Utils Service', () => {
         it('should detect safari', () => {
             Object.defineProperty(navigator, 'userAgent', {
                 configurable: true,
-                value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/602.4.8 (KHTML, like Gecko) ' +
-                    'Version / 10.0.3 Safari / 602.4.8',
+                value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/602.4.8 (KHTML, like Gecko) Version/10.0.3 Safari/602.4.8',
             });
 
             Object.defineProperty(window, 'safariAppExtension', {
@@ -93,8 +89,7 @@ describe('Browser Utils Service', () => {
         it('should detect vivaldi', () => {
             Object.defineProperty(navigator, 'userAgent', {
                 configurable: true,
-                value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) ' +
-                    'Chrome / 62.0.3202.97 Safari/ 537.36 Vivaldi / 1.94.1008.40',
+                value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.97 Safari/537.36 Vivaldi/1.94.1008.40',
             });
 
             const browserPlatformUtilsService = new BrowserPlatformUtilsService(null, null);

--- a/src/services/browserPlatformUtils.service.spec.ts
+++ b/src/services/browserPlatformUtils.service.spec.ts
@@ -24,7 +24,8 @@ describe('Browser Utils Service', () => {
         it('should detect chrome', () => {
             Object.defineProperty(navigator, 'userAgent', {
                 configurable: true,
-                value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.94 Safari/537.36'
+                value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) ' +
+                    'Chrome / 62.0.3202.94 Safari/ 537.36',
             });
 
             const browserPlatformUtilsService = new BrowserPlatformUtilsService(null, null);
@@ -34,7 +35,7 @@ describe('Browser Utils Service', () => {
         it('should detect firefox', () => {
             Object.defineProperty(navigator, 'userAgent', {
                 configurable: true,
-                value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:58.0) Gecko/20100101 Firefox/58.0'
+                value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:58.0) Gecko/20100101 Firefox/58.0',
             });
 
             const browserPlatformUtilsService = new BrowserPlatformUtilsService(null, null);
@@ -44,12 +45,13 @@ describe('Browser Utils Service', () => {
         it('should detect opera', () => {
             Object.defineProperty(navigator, 'userAgent', {
                 configurable: true,
-                value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3175.3 Safari/537.36 OPR/49.0.2695.0 (Edition developer)'
+                value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) ' +
+                    'Chrome / 62.0.3175.3 Safari/ 537.36 OPR / 49.0.2695.0(Edition developer)',
             });
 
             Object.defineProperty(window, 'opr', {
                 configurable: true,
-                value: {}
+                value: {},
             });
 
             const browserPlatformUtilsService = new BrowserPlatformUtilsService(null, null);
@@ -59,7 +61,8 @@ describe('Browser Utils Service', () => {
         it('should detect edge', () => {
             Object.defineProperty(navigator, 'userAgent', {
                 configurable: true,
-                value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; ServiceUI 9) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/15.15063'
+                value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; ServiceUI 9) AppleWebKit/537.36 (KHTML, like Gecko)' +
+                    'Chrome / 52.0.2743.116 Safari/ 537.36 Edge / 15.15063',
             });
 
             const browserPlatformUtilsService = new BrowserPlatformUtilsService(null, null);
@@ -69,7 +72,8 @@ describe('Browser Utils Service', () => {
         it('should detect safari', () => {
             Object.defineProperty(navigator, 'userAgent', {
                 configurable: true,
-                value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/602.4.8 (KHTML, like Gecko) Version/10.0.3 Safari/602.4.8'
+                value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/602.4.8 (KHTML, like Gecko) ' +
+                    'Version / 10.0.3 Safari / 602.4.8',
             });
 
             Object.defineProperty(window, 'safariAppExtension', {
@@ -89,7 +93,8 @@ describe('Browser Utils Service', () => {
         it('should detect vivaldi', () => {
             Object.defineProperty(navigator, 'userAgent', {
                 configurable: true,
-                value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.97 Safari/537.36 Vivaldi/1.94.1008.40'
+                value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) ' +
+                    'Chrome / 62.0.3202.97 Safari/ 537.36 Vivaldi / 1.94.1008.40',
             });
 
             const browserPlatformUtilsService = new BrowserPlatformUtilsService(null, null);


### PR DESCRIPTION
## Objective
This change adds the soft-delete and restore actions to the browser extension client, as well as the trash view.

## Code Changes

- **messages.json**: Added appropriate message/UI strings for display and i18n localization
- **ciphers.component.ts**: Add handler for "trash" view and prevention of adding new ciphers into trash
- **groupings.component.html**: Added trash grouping and trash "folder" to bottom of groupings component for navigation to the trash bin
- **groupings.component.ts**: Gather count for deleted items for consistency of display (small perf hit), but handle the deleted item count in state. Added handler for navigation to trash and prevented soft-deleted ciphers from showing in other folders, search or counts in primary `.forEach()`
- **view.component.html**: Add delete button for all views, permanently for trash item view, and added restore button and hide clone button for trash item view
- **view.component.ts**: Event handlers and super-type wrappers around delete and restore operations specific to the browser extension
- **browserPlatformUtils.service.spec.ts**: tslint errors corrected (trailing comma rules + line-length rules)

## Screenshots
### Groupings View
The groupings view, at the bottom, now shows a category for Trash if there are any deleted items for that user/admin'd org. The count of the number of items in Trash is also shown.
![image](https://user-images.githubusercontent.com/3904944/79130336-cbf91b00-7d74-11ea-9da0-e55794b4d023.png)

### Trash View
The trash view shows items that have been soft-deleted and now exist in the users/orgs trash bin. These items are still actionable (copy password, username, etc.) but **do not** show up in All Items search or on the "Tab" view for available auto-fill suggestions (and will not auto-fill).
![image](https://user-images.githubusercontent.com/3904944/79130395-e632f900-7d74-11ea-9e36-b05edb07555f.png)

### Deleted Item View
The following shows the view item page for an item in the Trash (soft-deleted) with the new options of "Restore" and "Permanently Delete Item". Notice the "Edit" option has been hidden from view as well as the "Clone" button removed.
![image](https://user-images.githubusercontent.com/3904944/79130450-fc40b980-7d74-11ea-82dd-c03f37e3a05d.png)

### Normal Item View
The following is the view item page showing a new "Delete" button just below the clone option.
![image](https://user-images.githubusercontent.com/3904944/79130521-17abc480-7d75-11ea-9635-2534f5d4edc5.png)

### Fixed Padding and Border (buttons)
Update: commited fix for padding and borders when showing multiple buttons.
![image](https://user-images.githubusercontent.com/3904944/79135855-fef3dc80-7d7d-11ea-9686-b7c0319f0550.png)
