### PR TITLE
[Soft Delete] - Deleted toast message trash

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -498,7 +498,7 @@
     "message": "Are you sure you want to delete this item?"
   },
   "deletedItem": {
-    "message": "Deleted item"
+    "message": "Sent item to trash"
   },
   "overwritePassword": {
     "message": "Overwrite Password"


### PR DESCRIPTION
Updated the deleted item toast message to indicate sent to trash (vs. deleted).