### PR TITLE
[Auto Logout] Added warning dialog for log out action

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1257,5 +1257,11 @@
   "lock": {
     "message": "Lock",
     "description": "Verb form: to make secure or inaccesible by"
+  },
+  "vaultTimeoutLogOutConfirmation": {
+    "message": "Logging out will remove all access to your vault and requires online authentication after the timeout period. Are you sure you want to use this setting?"
+  },
+  "vaultTimeoutLogOutConfirmationTitle": {
+    "message": "Timeout Action Confirmation"
   }
 }

--- a/src/popup/settings/settings.component.html
+++ b/src/popup/settings/settings.component.html
@@ -33,8 +33,8 @@
             </div>
             <div class="box-content-row display-block" appBoxRow>
                 <label for="vaultTimeoutAction">{{'vaultTimeoutAction' | i18n}}</label>
-                <select id="vaultTimeoutAction" name="VaultTimeoutActions" [ngModel]="vaultTimeoutAction"
-                    (ngModelChange)="saveVaultTimeoutAction($event)">
+                <select #vaultTimeoutActionSelect id="vaultTimeoutAction" name="VaultTimeoutActions"
+                    [ngModel]="vaultTimeoutAction" (ngModelChange)="saveVaultTimeoutAction($event)">
                     <option *ngFor="let o of vaultTimeoutActions" [ngValue]="o.value">{{o.name}}</option>
                 </select>
             </div>

--- a/src/popup/settings/settings.component.ts
+++ b/src/popup/settings/settings.component.ts
@@ -45,6 +45,7 @@ const RateUrls = {
 })
 export class SettingsComponent implements OnInit {
     @ViewChild('vaultTimeoutSelect', { read: ElementRef }) vaultTimeoutSelectRef: ElementRef;
+    @ViewChild('vaultTimeoutActionSelect', { read: ElementRef }) vaultTimeoutActionSelectRef: ElementRef;
     vaultTimeouts: any[];
     vaultTimeout: number = null;
     vaultTimeoutActions: any[];
@@ -126,6 +127,20 @@ export class SettingsComponent implements OnInit {
     }
 
     async saveVaultTimeoutAction(newValue: string) {
+        if (newValue === 'logOut') {
+            const confirmed = await this.platformUtilsService.showDialog(
+                this.i18nService.t('vaultTimeoutLogOutConfirmation'),
+                this.i18nService.t('vaultTimeoutLogOutConfirmationTitle'),
+                this.i18nService.t('yes'), this.i18nService.t('cancel'), 'warning');
+            if (!confirmed) {
+                this.vaultTimeoutActions.forEach((option: any, i) => {
+                    if (option.value === this.vaultTimeoutAction) {
+                        this.vaultTimeoutActionSelectRef.nativeElement.value = i + ': ' + this.vaultTimeoutAction;
+                    }
+                });
+                return;
+            }
+        }
         this.vaultTimeoutAction = newValue;
         await this.vaultTimeoutService.setVaultTimeoutOptions(this.vaultTimeout != null ? this.vaultTimeout : null,
             this.vaultTimeoutAction);


### PR DESCRIPTION
## Objective
> Users selecting the `Log Out` timeout action need to be made more aware of the necessary requirements for accessing their vault next time.

## Code Changes
- **settings.component.ts**: Added warning dialog if selected vault action is `logOut`. 
- **settings.component.html**: Added element ref tag
- **messages.json**: Added title and body for warning dialog

## Screenshots
<img width="386" alt="1-logout-warning" src="https://user-images.githubusercontent.com/26154748/80280512-29bd2980-86ca-11ea-850e-3d463dcf55d2.png">

