### PR TITLE
Attempt fix for safari app extension crash

### DIFF
--- a/src/browser/browserApi.ts
+++ b/src/browser/browserApi.ts
@@ -133,16 +133,6 @@ export class BrowserApi {
         }
     }
 
-    static getAssetUrl(path: string): Promise<string> {
-        if (BrowserApi.isChromeApi) {
-            return Promise.resolve(chrome.extension.getURL(path));
-        } else if (BrowserApi.isSafariApi) {
-            return SafariApp.sendMessageToApp('getAppPath');
-        } else {
-            return Promise.resolve(null);
-        }
-    }
-
     static messageListener(name: string, callback: (message: any, sender: any, response: any) => void) {
         if (BrowserApi.isChromeApi) {
             chrome.runtime.onMessage.addListener((msg: any, sender: any, response: any) => {


### PR DESCRIPTION
`getAssetUrl()` method is not referenced by any code anywhere any longer. Digging through git history it appears once upon a time it was used for showing icons stored via a local path. With that, nothing else raises the `'getAppPath'` message for the swift controller to handle; so that handler could be removed (which also seems to be the line of code from the app crash traces).

Besides that, I think I've address any of the last few places we're unwrapping `!` (unsafe) values without testing for `nil` first, so hopefully this either solves the issue, or the additional `NSLog()` will help trace it in the crash logs again if it continues crashing (not sure how else to get logging to work properly with Safari app extensions in this context).