### PR TITLE
Corrected webpacked CSS filename

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -98,8 +98,8 @@ const plugins = [
         include: ['popup/main.js', 'background.js'],
     }),
     new MiniCssExtractPlugin({
-        filename: '[name].[hash].css',
-        chunkFilename: '[id].[hash].css',
+        filename: '[name].css',
+        chunkFilename: 'chunk-[id].css',
     }),
     new webpack.DefinePlugin({
         'process.env': {


### PR DESCRIPTION
Prior changes updated the minified CSS filename from webpack config which broke the Safari browser plug-in once distributed/packed/signed by introducing a hash into the filename but no has was tokenized in the index.html using webpack either, reverting to the primary file name `'[name].css'`