### PR TITLE
[Bug] Make sure update flow sets vault timeout action

### DIFF
--- a/src/background/runtime.background.ts
+++ b/src/background/runtime.background.ts
@@ -383,6 +383,9 @@ export default class RuntimeBackground {
             }
         }
 
+        // Regardless of installed reason - new vaultTimeoutAction key must have a non-null value
+        await this.setDefaultVaultTimeoutAction();
+
         setTimeout(async () => {
             if (this.onInstalledReason != null) {
                 if (this.onInstalledReason === 'install') {
@@ -405,7 +408,9 @@ export default class RuntimeBackground {
         if (currentVaultTimeout == null) {
             await this.storageService.save(ConstantsService.vaultTimeoutKey, -1);
         }
+    }
 
+    private async setDefaultVaultTimeoutAction() {
         // Default action to "lock".
         const currentVaultTimeoutAction = await this.storageService.get<string>(ConstantsService.vaultTimeoutActionKey);
         if (currentVaultTimeoutAction == null) {


### PR DESCRIPTION
## Objective
> Fix bug for update paths not properly setting the `vaultTimeoutAction` in storage. Originated from the default settings being applied **only** during a clean `install` state. Since the `vaultTimeoutAction` can be accessed before ever saving/changing the setting, the key needs regardless of `install/update` state.

## Code Changes
- **runtime.background.ts**: Separated function for setting the `vaultTimeoutAction` and made sure to call regardless of new install/update since a `null` value is not valid for this key.