### PR TITLE
feat: allow popping out before unlocking

### DIFF
--- a/src/popup/accounts/lock.component.html
+++ b/src/popup/accounts/lock.component.html
@@ -1,6 +1,8 @@
 <form (ngSubmit)="submit()">
     <header>
-        <div class="left"></div>
+        <div class="left">
+            <app-pop-out></app-pop-out>
+        </div>
         <div class="center">
             <span class="title">{{(pinLock ? 'verifyPin' : 'verifyMasterPassword') | i18n}}</span>
         </div>


### PR DESCRIPTION
I use a yubikey for my 2FA.
It's hard to predict when bitwarden is going to ask me press my yubikey.
In firefox it requires typing in your password, then the u2f prompt will ask to pop out to a new window in order to use the yubikey
Once you pop out into a new window you need to enter the password again
So I've ended up just copying the password just in case I need to pop out to a new window.
It would be nice to allow me to just pop out before even logging in to avoid this hassle.
This PR does just that by placing the pop out button on the left and moving the settings button over to the right.