### PR TITLE
cmd + 8 to autofill for safari

### DIFF
--- a/src/content/shortcuts.ts
+++ b/src/content/shortcuts.ts
@@ -18,7 +18,12 @@ document.addEventListener('DOMContentLoaded', (event) => {
         return false;
     };
 
-    const autofillCommand = isSafari || isEdge ? ['mod+\\', 'mod+9'] : ['mod+shift+l'];
+    let autofillCommand = ['mod+shift+l'];
+    if (isSafari) {
+        autofillCommand = ['mod+\\', 'mod+8'];
+    } else if (isEdge) {
+        autofillCommand = ['mod+\\', 'mod+9'];
+    }
     Mousetrap.bind(autofillCommand, () => {
         sendMessage('autofill_login');
     });


### PR DESCRIPTION
For whatever reason , the `Cmd + 9` keybinding doesn't work, so moving autofill to `Cmd + 8`. Resolves https://github.com/bitwarden/browser/issues/1285