### PR TITLE
Ignore local safari debugging/packaging assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ build.safariextension/
 coverage/
 xcuserdata/
 *.hmap
+!src/safari/safari/app/popup/index.html
+src/safari/safari/app/


### PR DESCRIPTION
## Objective

When packaging, debugging and deploying the Safari App Extension locally on macOS, you need the appropriate assets from the browser build output (web), but those should be ignored/not checked in. These are copied manually to the `src/safari/safari/app/` directory from the browser build output, however the only file that should be included in that source control is the placeholder, `src/safari/safari/app/popup/index.html`