### PR TITLE
Update Japanese translation

### DIFF
--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -83,7 +83,7 @@
     "message": "自動入力"
   },
   "generatePasswordCopied": {
-    "message": "パスワードを生成 (コピーしました)"
+    "message": "パスワードを生成してコピー"
   },
   "noMatchingLogins": {
     "message": "一致するログインがありません。"


### PR DESCRIPTION
Previous translation (パスワードを生成(コピーしました)) sounds a bit weird to me.
New translation, "パスワードを生成してコピー" sounds more natural and it's simpler.
