### PR TITLE
Avoid a common One Time Password field name

### DIFF
--- a/src/services/autofill.service.ts
+++ b/src/services/autofill.service.ts
@@ -896,6 +896,9 @@ export default class AutofillService implements AutofillServiceInterface {
                     return false;
                 }
                 const lowerValue = value.toLowerCase();
+                if (lowerValue.indexOf('onetimepassword') >= 0 {
+                    return false;
+                }
                 if (lowerValue.indexOf('password') < 0) {
                     return false;
                 }


### PR DESCRIPTION
Many sites have one time password fields for Two Factor Authentication. A common name for those fields is OneTimePassword or some variant. If these fields were commonly of type "password" it would not be significant. However, since they are commonly of type "text", it is a security risk for users to auto fill these fields.