### PR TITLE
Addressed issue #1269

### DIFF
--- a/src/popup/vault/view.component.html
+++ b/src/popup/vault/view.component.html
@@ -17,7 +17,7 @@
         <div class="box-content">
             <div class="box-content-row">
                 <span class="row-label">{{'name' | i18n}}</span>
-                <input type="text" [value]="cipher.name" disabled/>
+                <input type="text" [value]="cipher.name" readonly aria-readonly="true"/>
             </div>
             <!-- Login -->
             <div *ngIf="cipher.login">
@@ -26,7 +26,7 @@
                         <span class="row-label draggable" draggable="true"
                             (dragstart)="setTextDataOnDrag($event, cipher.login.username)">{{'username' | i18n}}
                         </span>
-                        <input type="text" [value]="cipher.login.username" disabled />
+                        <input type="text" [value]="cipher.login.username" readonly aria-readonly="true" />
                     </div>
                     <div class="action-buttons">
                         <a class="row-btn" href="#" appStopClick appA11yTitle="{{'copyUsername' | i18n}}"
@@ -189,7 +189,7 @@
                     <span class="row-label" *ngIf="!u.isWebsite">{{'uri' | i18n}}</span>
                     <span class="row-label" *ngIf="u.isWebsite">{{'website' | i18n}}</span>
                     <span title="{{u.uri}}">
-                        <input type="text" [value]="u.hostnameOrUri" disabled />
+                        <input type="text" [value]="u.hostnameOrUri" readonly aria-readonly="true" />
                     </span>
                 </div>
                 <div class="action-buttons">
@@ -211,7 +211,7 @@
         </div>
         <div class="box-content">
             <div class="box-content-row">
-                <textarea [value]="cipher.notes" rows="6" disabled></textarea>
+                <textarea [value]="cipher.notes" rows="6" readonly aria-readonly="true"></textarea>
             </div>
         </div>
     </div>

--- a/src/popup/vault/view.component.html
+++ b/src/popup/vault/view.component.html
@@ -17,15 +17,16 @@
         <div class="box-content">
             <div class="box-content-row">
                 <span class="row-label">{{'name' | i18n}}</span>
-                {{cipher.name}}
+                <input type="text" [value]="cipher.name" disabled/>
             </div>
             <!-- Login -->
             <div *ngIf="cipher.login">
                 <div class="box-content-row box-content-row-flex" *ngIf="cipher.login.username">
                     <div class="row-main">
                         <span class="row-label draggable" draggable="true"
-                            (dragstart)="setTextDataOnDrag($event, cipher.login.username)">{{'username' | i18n}}</span>
-                        {{cipher.login.username}}
+                            (dragstart)="setTextDataOnDrag($event, cipher.login.username)">{{'username' | i18n}}
+                        </span>
+                        <input type="text" [value]="cipher.login.username" disabled />
                     </div>
                     <div class="action-buttons">
                         <a class="row-btn" href="#" appStopClick appA11yTitle="{{'copyUsername' | i18n}}"
@@ -187,7 +188,9 @@
                 <div class="row-main">
                     <span class="row-label" *ngIf="!u.isWebsite">{{'uri' | i18n}}</span>
                     <span class="row-label" *ngIf="u.isWebsite">{{'website' | i18n}}</span>
-                    <span title="{{u.uri}}">{{u.hostnameOrUri}}</span>
+                    <span title="{{u.uri}}">
+                        <input type="text" [value]="u.hostnameOrUri" disabled />
+                    </span>
                 </div>
                 <div class="action-buttons">
                     <a class="row-btn" href="#" appStopClick appA11yTitle="{{'launch' | i18n}}" *ngIf="u.canLaunch"
@@ -207,7 +210,9 @@
             {{'notes' | i18n}}
         </div>
         <div class="box-content">
-            <div class="box-content-row pre-wrap">{{cipher.notes}}</div>
+            <div class="box-content-row">
+                <textarea [value]="cipher.notes" rows="6" disabled></textarea>
+            </div>
         </div>
     </div>
     <div class="box" *ngIf="cipher.hasFields">


### PR DESCRIPTION
## Objective
Resolve an issue involving users not being able to highlight notes on the view screen. This seems to be cause by a Firefox bug, and isn't specific to this page or to the Bitwarden extension.


## Code change
Changed plain text fields to disabled inputs on the view screen. Made this change to notes per the issue, as well as the other fields for consistency. 

## Screenshots

The only visual difference found is the draggable expand for the textarea field, everything else remains the same.

### Before
![Screen Shot 2020-07-08 at 1 38 05 PM](https://user-images.githubusercontent.com/15897251/86957640-a172f000-c120-11ea-9e03-0f5513575839.png)
### After 
![Screen Shot 2020-07-08 at 1 38 41 PM](https://user-images.githubusercontent.com/15897251/86957646-a2a41d00-c120-11ea-985a-116d8db714cb.png)
Resolves #1269 