### PR TITLE
Modified Chrome to pass in null unicode on clear

### DIFF
--- a/src/services/browserPlatformUtils.service.ts
+++ b/src/services/browserPlatformUtils.service.ts
@@ -207,6 +207,10 @@ export default class BrowserPlatformUtilsService implements PlatformUtilsService
                 this.clipboardWriteCallback(text, clearMs);
             }
         } else if (doc.queryCommandSupported && doc.queryCommandSupported('copy')) {
+            if(this.isChrome() && text === '') {
+                text = '\u0000';
+            }
+            
             const textarea = doc.createElement('textarea');
             textarea.textContent = text == null || text === '' ? ' ' : text;
             // Prevent scrolling to bottom of page in MS Edge.

--- a/src/services/browserPlatformUtils.service.ts
+++ b/src/services/browserPlatformUtils.service.ts
@@ -207,7 +207,7 @@ export default class BrowserPlatformUtilsService implements PlatformUtilsService
                 this.clipboardWriteCallback(text, clearMs);
             }
         } else if (doc.queryCommandSupported && doc.queryCommandSupported('copy')) {
-            if(this.isChrome() && text === '') {
+            if (this.isChrome() && text === '') {
                 text = '\u0000';
             }
             


### PR DESCRIPTION
## Objective

When clearing the clipboard at an interval, the resulting clipboard clear should be '', nothing. Chrome was interpreting nothing as ' ', an empty space. To mitigate this, if Chrome, we transform the '' to unicode \u0000, or a null. 

## Code Changes

**src/services/browserPlatformUtils.service.ts** - Modifications made on clear, if '' and Chrome are detected, it sets the text to unicode null.

Closes #1234 