### PR TITLE
Fix edge double password reveal buttons issue #1308

### DIFF
--- a/src/popup/scss/misc.scss
+++ b/src/popup/scss/misc.scss
@@ -303,3 +303,7 @@ app-vault-icon {
         }
     }
 }
+
+input[type="password"]::-ms-reveal {
+    display: none;
+}


### PR DESCRIPTION
This PR fixes issue #1308 

Duplicate password reveal icon shown on Microsoft edge is fixed by using ms specific css selector -ms-reveal & marking it as display:none

This change fixes the issue for all password input fields throughout the extension.