### PR TITLE
Fix completion handler nil crashes SFSafariWindow

### DIFF
--- a/src/safari/safari/SafariExtensionViewController.swift
+++ b/src/safari/safari/SafariExtensionViewController.swift
@@ -175,7 +175,9 @@ class SafariExtensionViewController: SFSafariExtensionViewController, WKScriptMe
         } else if command == "createNewTab" {
             if let data = m.data, let url = URL(string: data) {
                 SFSafariApplication.getActiveWindow { win in
-                    win?.openTab(with: url, makeActiveIfPossible: true, completionHandler: nil)
+                    win?.openTab(with: url, makeActiveIfPossible: true, completionHandler: { _ in
+                        // Tab opened
+                    })
                 }
             }
         } else if command == "reloadExtension" {


### PR DESCRIPTION
Fixes https://github.com/bitwarden/browser/issues/1338

## Objective
Prior refactoring of swift code removed a completion handler for the `openTab()` method of `SFSafariWindow`, which even though may be `nil`, in this case passing `nil` explicitly results in a memory access exception. Passing in an empty handler resolves this exception.