### PR TITLE
Added logging and completion handler for JS

### DIFF
--- a/src/safari/safari/SafariExtensionViewController.swift
+++ b/src/safari/safari/SafariExtensionViewController.swift
@@ -96,7 +96,12 @@ class SafariExtensionViewController: SFSafariExtensionViewController, WKScriptMe
             let messagesUrl = bundleUrl.appendingPathComponent("app/_locales/\(language)/messages.json")
             do {
                 let json = try String(contentsOf: messagesUrl, encoding: .utf8)
-                webView.evaluateJavaScript("window.bitwardenLocaleStrings = \(json);", completionHandler: nil)
+                webView.evaluateJavaScript("window.bitwardenLocaleStrings = \(json);", completionHandler: {(result, error) in
+                    guard let err = error else {
+                        return;
+                    }
+                    NSLog("evaluateJavaScript error : %@", err.localizedDescription);
+                })
             } catch {
                 NSLog("ERROR on getLocaleStrings, \(error)")
             }
@@ -236,7 +241,12 @@ class SafariExtensionViewController: SFSafariExtensionViewController, WKScriptMe
             return
         }
         let json = (jsonSerialize(obj: message) ?? "null")
-        webView.evaluateJavaScript("window.bitwardenSafariAppMessageReceiver(\(json));", completionHandler: nil)
+        webView.evaluateJavaScript("window.bitwardenSafariAppMessageReceiver(\(json));", completionHandler: {(result, error) in
+            guard let err = error else {
+                return;
+            }
+            NSLog("evaluateJavaScript error : %@", err.localizedDescription);
+        })
     }
 }
 


### PR DESCRIPTION
## Overview

Over the course of the last few weeks I've noticed and found that while several async methods in WKWebView and associated framework allow `nil` completion handlers, every once in a while, if `nil` is indeed provided, there are app crashes without much explanation. In that light, and given that the crash occurring in #1021 is happening when calling into the JavaScript world and dies within the WebKit internals; this leads me to believe that it may be relating to a missing completion handler with some perhaps hardware specific handling of the same which we're not able to reproduce.

Either way, it doesn't hurt to have the relatively empty completion handlers with a little bit of error logging in there just in case and I've tested to ensure there are no regression issues with the addition of these.