### PR TITLE
Added Cmd+Shift+P for autofill in safari

### DIFF
--- a/src/content/shortcuts.ts
+++ b/src/content/shortcuts.ts
@@ -20,7 +20,7 @@ document.addEventListener('DOMContentLoaded', (event) => {
 
     let autofillCommand = ['mod+shift+l'];
     if (isSafari) {
-        autofillCommand = ['mod+\\', 'mod+8'];
+        autofillCommand = ['mod+\\', 'mod+8', 'mod+shift+p'];
     } else if (isEdge) {
         autofillCommand = ['mod+\\', 'mod+9'];
     }


### PR DESCRIPTION
fixes https://github.com/bitwarden/browser/issues/701

## Overview
This relates to adding additional support for keyboards such as AZERTY, or QWERTY with a German or French layout, etc. where the existing hotkeys do not work due to additional key combinations that are already bound or simply not possible.

⌘8 does't work on all foreign keyboard layouts such as AZERTY, but supports some alternative keyboards
⌘\ also doesn't work on all keyboards
⇧⌘P, however, is not yet bound in Safari by default and does seem to work for all mentioned keyboards (so far).

Assuming this fix allows more possible keyboard combinations for macOS keyboards across regions with one of the 3 options since we can't control bindings themselves from an extension. In the future, we may be able to make this configurable through the Bitwarden extension settings itself (preferably).