### PR TITLE
“Autofill” and “Autofill and Save” buttons for the browser extension Vault

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1304,12 +1304,9 @@
     "message": "Auto-fill and Save"
   },
   "savedUri": {
-    "message": "Saved URI"
-  },
-  "uriExists": {
-    "message": "URI already saved"
+    "message": "Auto-filled and Saved Item"
   },
   "autoFillSuccess": {
-    "message": "Autofilled item"
+    "message": "Auto-filled Item"
   }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1297,6 +1297,15 @@
   "vaultTimeoutLogOutConfirmationTitle": {
     "message": "Timeout Action Confirmation"
   },
+  "autoFillAndSave": {
+    "message": "Auto-fill and Save"
+  },
+  "savedUri": {
+    "message": "Saved URI"
+  },
+  "uriExists": {
+    "message": "URI already saved"
+  },
   "autoFillSuccess": {
     "message": "Autofilled item"
   }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1296,5 +1296,8 @@
   },
   "vaultTimeoutLogOutConfirmationTitle": {
     "message": "Timeout Action Confirmation"
+  },
+  "autoFillSuccess": {
+    "message": "Autofilled item"
   }
 }

--- a/src/popup/vault/view.component.html
+++ b/src/popup/vault/view.component.html
@@ -277,6 +277,15 @@
                     <span>{{'autoFill' | i18n}}</span>
                 </div>
             </a>
+            <a class="box-content-row" href="#" appStopClick appBlurClick (click)="fillCipherAndSave()" 
+                *ngIf="!cipher.isDeleted">
+                <div class="row-main text-primary">
+                    <div class="icon text-primary" aria-hidden="true">
+                        <i class="fa fa-bookmark fa-lg fa-fw"></i>
+                    </div>
+                    <span>{{'autoFillAndSave' | i18n}}</span>
+                </div>
+            </a>
             <a class="box-content-row" href="#" appStopClick appBlurClick (click)="clone()" 
                 *ngIf="!cipher.organizationId && !cipher.isDeleted">
                 <div class="row-main text-primary">

--- a/src/popup/vault/view.component.html
+++ b/src/popup/vault/view.component.html
@@ -268,6 +268,15 @@
     </div>
     <div class="box list">
         <div class="box-content single-line">
+            <a class="box-content-row" href="#" appStopClick appBlurClick (click)="fillCipher()" 
+                *ngIf="!cipher.isDeleted">
+                <div class="row-main text-primary">
+                    <div class="icon text-primary" aria-hidden="true">
+                        <i class="fa fa-pencil-square-o fa-lg fa-fw"></i>
+                    </div>
+                    <span>{{'autoFill' | i18n}}</span>
+                </div>
+            </a>
             <a class="box-content-row" href="#" appStopClick appBlurClick (click)="clone()" 
                 *ngIf="!cipher.organizationId && !cipher.isDeleted">
                 <div class="row-main text-primary">

--- a/src/popup/vault/view.component.html
+++ b/src/popup/vault/view.component.html
@@ -269,7 +269,7 @@
     <div class="box list">
         <div class="box-content single-line">
             <a class="box-content-row" href="#" appStopClick appBlurClick (click)="fillCipher()" 
-                *ngIf="!cipher.isDeleted">
+                *ngIf="!cipher.isDeleted && !inPopout">
                 <div class="row-main text-primary">
                     <div class="icon text-primary" aria-hidden="true">
                         <i class="fa fa-pencil-square-o fa-lg fa-fw"></i>
@@ -278,7 +278,7 @@
                 </div>
             </a>
             <a class="box-content-row" href="#" appStopClick appBlurClick (click)="fillCipherAndSave()" 
-                *ngIf="!cipher.isDeleted">
+                *ngIf="!cipher.isDeleted && !inPopout">
                 <div class="row-main text-primary">
                     <div class="icon text-primary" aria-hidden="true">
                         <i class="fa fa-bookmark fa-lg fa-fw"></i>

--- a/src/popup/vault/view.component.ts
+++ b/src/popup/vault/view.component.ts
@@ -27,6 +27,7 @@ import { BroadcasterService } from 'jslib/angular/services/broadcaster.service';
 import { ViewComponent as BaseViewComponent } from 'jslib/angular/components/view.component';
 import { BrowserApi } from '../../browser/browserApi';
 import { AutofillService } from '../../services/abstractions/autofill.service';
+import { PopupUtilsService } from '../services/popup-utils.service';
 
 const BroadcasterSubscriptionId = 'ViewComponent';
 
@@ -37,6 +38,7 @@ const BroadcasterSubscriptionId = 'ViewComponent';
 export class ViewComponent extends BaseViewComponent {
     showAttachments = true;
     pageDetails: any[] = [];
+    inPopout: boolean = false;
 
     constructor(cipherService: CipherService, totpService: TotpService,
         tokenService: TokenService, i18nService: I18nService,
@@ -46,13 +48,14 @@ export class ViewComponent extends BaseViewComponent {
         broadcasterService: BroadcasterService, ngZone: NgZone,
         changeDetectorRef: ChangeDetectorRef, userService: UserService,
         eventService: EventService, private autofillService: AutofillService,
-        private messagingService: MessagingService) {
+        private messagingService: MessagingService, private popupUtilsService: PopupUtilsService) {
         super(cipherService, totpService, tokenService, i18nService, cryptoService, platformUtilsService,
             auditService, window, broadcasterService, ngZone, changeDetectorRef, userService, eventService);
     }
 
     ngOnInit() {
         this.showAttachments = !this.platformUtilsService.isEdge();
+        this.inPopout = this.popupUtilsService.inPopout(window);
         const queryParamsSub = this.route.queryParams.subscribe(async (params) => {
             if (params.cipherId) {
                 this.cipherId = params.cipherId;


### PR DESCRIPTION
## What?
I have added "Autofill" and "Autofill and Save" buttons in the View Item screen in the Vault. See [my post in the community forums](https://community.bitwarden.com/t/autofill-and-autofill-and-save-buttons-for-the-browser-extension-vault/13385) for more information about the proposal.

## Why?
This makes it quicker and easier for users to:
- autofill login credentials where there are no saved URIs for those credentials
- save the URI of the current page for easier autofilling in the future

This reflects a similar feature that already exists in the mobile app.

## How?
I have used the existing autofill and cipher services.

## Testing?
- Tested manually in Firefox and Chrome
- Passed the test:watch script in Firefox and Chrome.

## Screenshots
![tempsnip](https://user-images.githubusercontent.com/31796059/90631173-9b1a7c80-e265-11ea-9138-6937ca4b6d8b.png)

