### PR TITLE
add settings -> Excluded Domains component

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1437,5 +1437,14 @@
   },
   "personalOwnershipPolicyInEffect": {
     "message": "An organization policy is affecting your ownership options."
+  },
+  "excludedDomains": {
+    "message": "Excluded Domains"
+  },
+  "excludedDomainsDesc": {
+    "message": "Bitwarden will not ask to save login details for these domains."
+  },
+  "excludedDomainsInvalidDomain": {
+    "message": " is not a valid domain"
   }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1445,6 +1445,12 @@
     "message": "Bitwarden will not ask to save login details for these domains."
   },
   "excludedDomainsInvalidDomain": {
-    "message": " is not a valid domain"
+    "message": "$DOMAIN$ is not a valid domain",
+    "placeholders": {
+      "domain": {
+        "content": "$1",
+        "example": "googlecom"
+      }
+    }
   }
 }

--- a/src/popup/app-routing.module.ts
+++ b/src/popup/app-routing.module.ts
@@ -23,6 +23,7 @@ import { SsoComponent } from './accounts/sso.component';
 import { PasswordGeneratorHistoryComponent } from './generator/password-generator-history.component';
 import { PasswordGeneratorComponent } from './generator/password-generator.component';
 import { PrivateModeComponent } from './private-mode.component';
+import { ExcludedDomainsComponent } from './settings/excluded-domains.component';
 import { ExportComponent } from './settings/export.component';
 import { FolderAddEditComponent } from './settings/folder-add-edit.component';
 import { FoldersComponent } from './settings/folders.component';
@@ -40,7 +41,6 @@ import { GroupingsComponent } from './vault/groupings.component';
 import { PasswordHistoryComponent } from './vault/password-history.component';
 import { ShareComponent } from './vault/share.component';
 import { ViewComponent } from './vault/view.component';
-import { ExcludedDomainsComponent } from './settings/excluded-domains.component';
 
 const routes: Routes = [
     {

--- a/src/popup/app-routing.module.ts
+++ b/src/popup/app-routing.module.ts
@@ -40,6 +40,7 @@ import { GroupingsComponent } from './vault/groupings.component';
 import { PasswordHistoryComponent } from './vault/password-history.component';
 import { ShareComponent } from './vault/share.component';
 import { ViewComponent } from './vault/view.component';
+import { ExcludedDomainsComponent } from './settings/excluded-domains.component';
 
 const routes: Routes = [
     {
@@ -199,6 +200,12 @@ const routes: Routes = [
         component: SyncComponent,
         canActivate: [AuthGuardService],
         data: { state: 'sync' },
+    },
+    {
+        path: 'excluded-domains',
+        component: ExcludedDomainsComponent,
+        canActivate: [AuthGuardService],
+        data: { state: 'excluded-domains' },
     },
     {
         path: 'premium',

--- a/src/popup/app.module.ts
+++ b/src/popup/app.module.ts
@@ -29,6 +29,7 @@ import { AppComponent } from './app.component';
 import { PasswordGeneratorHistoryComponent } from './generator/password-generator-history.component';
 import { PasswordGeneratorComponent } from './generator/password-generator.component';
 import { PrivateModeComponent } from './private-mode.component';
+import { ExcludedDomainsComponent } from './settings/excluded-domains.component';
 import { ExportComponent } from './settings/export.component';
 import { FolderAddEditComponent } from './settings/folder-add-edit.component';
 import { FoldersComponent } from './settings/folders.component';
@@ -46,7 +47,6 @@ import { GroupingsComponent } from './vault/groupings.component';
 import { PasswordHistoryComponent } from './vault/password-history.component';
 import { ShareComponent } from './vault/share.component';
 import { ViewComponent } from './vault/view.component';
-import { ExcludedDomainsComponent } from './settings/excluded-domains.component';
 
 import { A11yTitleDirective } from 'jslib/angular/directives/a11y-title.directive';
 import { ApiActionDirective } from 'jslib/angular/directives/api-action.directive';

--- a/src/popup/app.module.ts
+++ b/src/popup/app.module.ts
@@ -46,6 +46,7 @@ import { GroupingsComponent } from './vault/groupings.component';
 import { PasswordHistoryComponent } from './vault/password-history.component';
 import { ShareComponent } from './vault/share.component';
 import { ViewComponent } from './vault/view.component';
+import { ExcludedDomainsComponent } from './settings/excluded-domains.component';
 
 import { A11yTitleDirective } from 'jslib/angular/directives/a11y-title.directive';
 import { ApiActionDirective } from 'jslib/angular/directives/api-action.directive';
@@ -181,6 +182,7 @@ registerLocaleData(localeZhTw, 'zh-TW');
         ColorPasswordPipe,
         CurrentTabComponent,
         EnvironmentComponent,
+        ExcludedDomainsComponent,
         ExportComponent,
         FallbackSrcDirective,
         FolderAddEditComponent,

--- a/src/popup/settings/excluded-domains.component.html
+++ b/src/popup/settings/excluded-domains.component.html
@@ -1,0 +1,53 @@
+<form #form (ngSubmit)="submit()">
+    <header>
+        <div class="left">
+            <a routerLink="/tabs/settings">{{'cancel' | i18n}}</a>
+        </div>
+        <div class="center">
+            <span class="title">{{'excludedDomains' | i18n}}</span>
+        </div>
+        <div class="right">
+            <button type="submit" appBlurClick>{{'save' | i18n}}</button>
+        </div>
+    </header>
+    <content>
+        <div class="box">
+            <div class="box-content">
+                <ng-container *ngIf="excludedDomains">
+                    <div class="box-content-row box-content-row-multi" appBoxRow
+                        *ngFor="let domain of excludedDomains; let i = index; trackBy:trackByFunction">
+                        <a href="#" appStopClick (click)="removeUri(i)" appA11yTitle="{{'remove' | i18n}}">
+                            <i class="fa fa-minus-circle fa-lg" aria-hidden="true"></i>
+                        </a>
+                        <div class="row-main">
+                            <label for="excludedDomain{{i}}">{{'uriPosition' | i18n : (i + 1)}}</label>
+                            <input id="excludedDomain{{i}}" name="excludedDomain{{i}}" type="text" [(ngModel)]="domain.uri"
+                                placeholder="{{'ex' | i18n}} https://google.com" inputmode="url" appInputVerbatim>
+                            <label for="currentUris{{i}}" class="sr-only">
+                                {{'currentUri' | i18n}} {{(i + 1)}}
+                            </label>
+                            <select *ngIf="currentUris && currentUris.length" id="currentUris{{i}}"
+                                name="currentUris{{i}}" [(ngModel)]="domain.uri" [hidden]="!domain.showCurrentUris">
+                                <option [ngValue]="null">-- {{'select' | i18n}} --</option>
+                                <option *ngFor="let u of currentUris" [ngValue]="u">{{u}}</option>
+                            </select>
+                        </div>
+                        <div class="action-buttons">
+                            <a *ngIf="currentUris && currentUris.length" class="row-btn" href="#" appStopClick
+                                appBlurClick appA11yTitle="{{'toggleCurrentUris' | i18n}}" (click)="toggleUriInput(domain)">
+                                <i aria-hidden="true" class="fa fa-lg fa-list"></i>
+                            </a>
+                        </div>
+                    </div>
+                </ng-container>
+                <a href="#" appStopClick appBlurClick (click)="addUri()"
+                    class="box-content-row box-content-row-newmulti">
+                    <i class="fa fa-plus-circle fa-fw fa-lg" aria-hidden="true"></i> {{'newUri' | i18n}}
+                </a>
+            </div>
+            <div class="box-footer">
+                {{'excludedDomainsDesc' | i18n}}
+            </div>
+        </div>
+    </content>
+</form>

--- a/src/popup/settings/excluded-domains.component.ts
+++ b/src/popup/settings/excluded-domains.component.ts
@@ -1,18 +1,19 @@
 import {
     Component,
+    OnDestroy,
     OnInit,
-    NgZone,
-    OnDestroy
+    NgZone
 } from '@angular/core';
 import { Router } from '@angular/router';
 
 import { I18nService } from 'jslib/abstractions/i18n.service';
+import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
 import { StorageService } from 'jslib/abstractions/storage.service';
 import { ConstantsService } from 'jslib/services/constants.service';
-import { BrowserApi } from '../../browser/browserApi';
 import { BroadcasterService } from 'jslib/angular/services/broadcaster.service';
+
+import { BrowserApi } from '../../browser/browserApi';
 import { Utils } from 'jslib/misc/utils';
-import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
 
 interface ExcludedDomain {
     uri: string,
@@ -40,7 +41,7 @@ export class ExcludedDomainsComponent implements OnInit, OnDestroy {
         const savedDomains = await this.storageService.get<any>(ConstantsService.neverDomainsKey);
         if (savedDomains) {
             for (const uri of Object.keys(savedDomains)) {
-                this.excludedDomains.push({uri: uri, showCurrentUris: false})
+                this.excludedDomains.push({ uri: uri, showCurrentUris: false })
             }
         }
 
@@ -68,7 +69,7 @@ export class ExcludedDomainsComponent implements OnInit, OnDestroy {
     }
 
     async addUri() {
-        this.excludedDomains.push({uri: '', showCurrentUris: false})
+        this.excludedDomains.push({ uri: '', showCurrentUris: false })
     }
 
     async removeUri(i: number) {
@@ -76,7 +77,7 @@ export class ExcludedDomainsComponent implements OnInit, OnDestroy {
     }
 
     async submit() {
-        const savedDomains: {[name: string]: null} = {};
+        const savedDomains: { [name: string]: null } = {};
         for (const domain of this.excludedDomains) {
             if (domain.uri && domain.uri !== '') {
                 const validDomain = Utils.getHostname(domain.uri);

--- a/src/popup/settings/excluded-domains.component.ts
+++ b/src/popup/settings/excluded-domains.component.ts
@@ -16,8 +16,8 @@ import { BrowserApi } from '../../browser/browserApi';
 import { Utils } from 'jslib/misc/utils';
 
 interface ExcludedDomain {
-    uri: string,
-    showCurrentUris: boolean
+    uri: string;
+    showCurrentUris: boolean;
 }
 
 const BroadcasterSubscriptionId = 'excludedDomains';
@@ -41,11 +41,11 @@ export class ExcludedDomainsComponent implements OnInit, OnDestroy {
         const savedDomains = await this.storageService.get<any>(ConstantsService.neverDomainsKey);
         if (savedDomains) {
             for (const uri of Object.keys(savedDomains)) {
-                this.excludedDomains.push({ uri: uri, showCurrentUris: false })
+                this.excludedDomains.push({ uri: uri, showCurrentUris: false });
             }
         }
 
-        this.loadCurrentUris();
+        await this.loadCurrentUris();
 
         this.broadcasterService.subscribe(BroadcasterSubscriptionId, (message: any) => {
             this.ngZone.run(async () => {
@@ -55,7 +55,7 @@ export class ExcludedDomainsComponent implements OnInit, OnDestroy {
                         if (this.loadCurrentUrisTimeout != null) {
                             window.clearTimeout(this.loadCurrentUrisTimeout);
                         }
-                        this.loadCurrentUrisTimeout = window.setTimeout(() => this.loadCurrentUris(), 500);
+                        this.loadCurrentUrisTimeout = window.setTimeout(async () => await this.loadCurrentUris(), 500);
                         break;
                     default:
                         break;
@@ -69,7 +69,7 @@ export class ExcludedDomainsComponent implements OnInit, OnDestroy {
     }
 
     async addUri() {
-        this.excludedDomains.push({ uri: '', showCurrentUris: false })
+        this.excludedDomains.push({ uri: '', showCurrentUris: false });
     }
 
     async removeUri(i: number) {
@@ -83,10 +83,10 @@ export class ExcludedDomainsComponent implements OnInit, OnDestroy {
                 const validDomain = Utils.getHostname(domain.uri);
                 if (!validDomain) {
                     this.platformUtilsService.showToast('error', null,
-                        '\'' + domain.uri + '\'' + this.i18nService.t('excludedDomainsInvalidDomain'));
+                        this.i18nService.t('excludedDomainsInvalidDomain', domain.uri));
                     return;
                 }
-                savedDomains[validDomain] = null
+                savedDomains[validDomain] = null;
             }
         }
         await this.storageService.save(ConstantsService.neverDomainsKey, savedDomains);

--- a/src/popup/settings/excluded-domains.component.ts
+++ b/src/popup/settings/excluded-domains.component.ts
@@ -1,0 +1,111 @@
+import {
+    Component,
+    OnInit,
+    NgZone,
+    OnDestroy
+} from '@angular/core';
+import { Router } from '@angular/router';
+
+import { I18nService } from 'jslib/abstractions/i18n.service';
+import { StorageService } from 'jslib/abstractions/storage.service';
+import { ConstantsService } from 'jslib/services/constants.service';
+import { BrowserApi } from '../../browser/browserApi';
+import { BroadcasterService } from 'jslib/angular/services/broadcaster.service';
+import { Utils } from 'jslib/misc/utils';
+import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
+
+interface ExcludedDomain {
+    uri: string,
+    showCurrentUris: boolean
+}
+
+const BroadcasterSubscriptionId = 'excludedDomains';
+
+@Component({
+    selector: 'app-excluded-domains',
+    templateUrl: 'excluded-domains.component.html',
+})
+export class ExcludedDomainsComponent implements OnInit, OnDestroy {
+    excludedDomains: ExcludedDomain[] = [];
+    currentUris: string[];
+    loadCurrentUrisTimeout: number;
+
+    constructor(private storageService: StorageService,
+        private i18nService: I18nService, private router: Router,
+        private broadcasterService: BroadcasterService, private ngZone: NgZone,
+        private platformUtilsService: PlatformUtilsService) {
+    }
+
+    async ngOnInit() {
+        const savedDomains = await this.storageService.get<any>(ConstantsService.neverDomainsKey);
+        if (savedDomains) {
+            for (const uri of Object.keys(savedDomains)) {
+                this.excludedDomains.push({uri: uri, showCurrentUris: false})
+            }
+        }
+
+        this.loadCurrentUris();
+
+        this.broadcasterService.subscribe(BroadcasterSubscriptionId, (message: any) => {
+            this.ngZone.run(async () => {
+                switch (message.command) {
+                    case 'tabChanged':
+                    case 'windowChanged':
+                        if (this.loadCurrentUrisTimeout != null) {
+                            window.clearTimeout(this.loadCurrentUrisTimeout);
+                        }
+                        this.loadCurrentUrisTimeout = window.setTimeout(() => this.loadCurrentUris(), 500);
+                        break;
+                    default:
+                        break;
+                }
+            });
+        });
+    }
+
+    ngOnDestroy() {
+        this.broadcasterService.unsubscribe(BroadcasterSubscriptionId);
+    }
+
+    async addUri() {
+        this.excludedDomains.push({uri: '', showCurrentUris: false})
+    }
+
+    async removeUri(i: number) {
+        this.excludedDomains.splice(i, 1);
+    }
+
+    async submit() {
+        const savedDomains: {[name: string]: null} = {};
+        for (const domain of this.excludedDomains) {
+            if (domain.uri && domain.uri !== '') {
+                const validDomain = Utils.getHostname(domain.uri);
+                if (!validDomain) {
+                    this.platformUtilsService.showToast('error', null,
+                        '\'' + domain.uri + '\'' + this.i18nService.t('excludedDomainsInvalidDomain'));
+                    return;
+                }
+                savedDomains[validDomain] = null
+            }
+        }
+        await this.storageService.save(ConstantsService.neverDomainsKey, savedDomains);
+        this.router.navigate(['/tabs/settings']);
+    }
+
+    trackByFunction(index: number, item: any) {
+        return index;
+    }
+
+    toggleUriInput(domain: ExcludedDomain) {
+        domain.showCurrentUris = !domain.showCurrentUris;
+    }
+
+    async loadCurrentUris() {
+        const tabs = await BrowserApi.tabsQuery({ windowType: 'normal' });
+        if (tabs) {
+            const uriSet = new Set(tabs.map((tab) => Utils.getHostname(tab.url)));
+            uriSet.delete(null);
+            this.currentUris = Array.from(uriSet);
+        }
+    }
+}

--- a/src/popup/settings/settings.component.html
+++ b/src/popup/settings/settings.component.html
@@ -19,6 +19,10 @@
                 <div class="row-main">{{'sync' | i18n}}</div>
                 <i class="fa fa-chevron-right fa-lg row-sub-icon" aria-hidden="true"></i>
             </a>
+            <a class="box-content-row box-content-row-flex text-default" routerLink="/excluded-domains">
+                <div class="row-main">{{'excludedDomains' | i18n}}</div>
+                <i class="fa fa-chevron-right fa-lg row-sub-icon" aria-hidden="true"></i>
+            </a>
         </div>
     </div>
     <div class="box list">


### PR DESCRIPTION
## What

- **Feature name**: Ability to manage Excluded Domains
- **Description**: Adds an "Excluded Domains" screen in the Settings tab. This allows users to add and remove “Excluded Domains”, which are domains that Bitwarden will not offer to save the password for. 
- **Community Forums link:** see [here](https://community.bitwarden.com/t/ability-to-manage-excluded-domains/14194) for previous discussion.

## Screenshots and UI
Located in the Settings tab:

![Excluded domains 1](https://user-images.githubusercontent.com/31796059/92382449-f39bb600-f14f-11ea-89ef-bcf7bcd60916.PNG)

It uses the familiar URI list from the item edit screen. It includes an optional dropdown list to select from currently open domains:

![Excluded domains 22](https://user-images.githubusercontent.com/31796059/92382679-58571080-f150-11ea-8e69-6d0268c2c5e8.PNG)

It raises an error if the user tries to save with an invalid domain:

![Excluded domains 3](https://user-images.githubusercontent.com/31796059/92382725-6d33a400-f150-11ea-8515-85457b210200.PNG)

If the user enters a URI that includes a path or other information, only the domain portion of the URI will be saved. For example, "https://github.com/bitwarden/browser" is  saved as "github.com". This is intended to meet the expectation/assumption that these are domain names only (i.e. notificationBar.ts expects an exact match against window.location.hostname in the current tab).