### PR TITLE
fixes to SSO process

### DIFF
--- a/src/background/main.background.ts
+++ b/src/background/main.background.ts
@@ -52,6 +52,7 @@ import {
     UserService as UserServiceAbstraction,
     VaultTimeoutService as VaultTimeoutServiceAbstraction,
 } from 'jslib/abstractions';
+import { CryptoFunctionService as CryptoFunctionServiceAbstraction } from 'jslib/abstractions/cryptoFunction.service';
 import { EventService as EventServiceAbstraction } from 'jslib/abstractions/event.service';
 import { ExportService as ExportServiceAbstraction } from 'jslib/abstractions/export.service';
 import { NotificationsService as NotificationsServiceAbstraction } from 'jslib/abstractions/notifications.service';
@@ -90,6 +91,7 @@ export default class MainBackground {
     platformUtilsService: PlatformUtilsServiceAbstraction;
     constantsService: ConstantsService;
     cryptoService: CryptoServiceAbstraction;
+    cryptoFunctionService: CryptoFunctionServiceAbstraction;
     tokenService: TokenServiceAbstraction;
     appIdService: AppIdServiceAbstraction;
     apiService: ApiServiceAbstraction;
@@ -148,8 +150,9 @@ export default class MainBackground {
         this.storageService = new BrowserStorageService(this.platformUtilsService);
         this.secureStorageService = new BrowserStorageService(this.platformUtilsService);
         this.i18nService = new I18nService(BrowserApi.getUILanguage(window));
-        const cryptoFunctionService = new WebCryptoFunctionService(window, this.platformUtilsService);
-        this.cryptoService = new CryptoService(this.storageService, this.secureStorageService, cryptoFunctionService);
+        this.cryptoFunctionService = new WebCryptoFunctionService(window, this.platformUtilsService);
+        this.cryptoService = new CryptoService(this.storageService, this.secureStorageService,
+            this.cryptoFunctionService);
         this.tokenService = new TokenService(this.storageService);
         this.appIdService = new AppIdService(this.storageService);
         this.apiService = new ApiService(this.tokenService, this.platformUtilsService,
@@ -190,11 +193,11 @@ export default class MainBackground {
             this.cipherService);
         this.passwordGenerationService = new PasswordGenerationService(this.cryptoService, this.storageService,
             this.policyService);
-        this.totpService = new TotpService(this.storageService, cryptoFunctionService);
+        this.totpService = new TotpService(this.storageService, this.cryptoFunctionService);
         this.autofillService = new AutofillService(this.cipherService, this.userService, this.totpService,
             this.eventService);
         this.containerService = new ContainerService(this.cryptoService);
-        this.auditService = new AuditService(cryptoFunctionService, this.apiService);
+        this.auditService = new AuditService(this.cryptoFunctionService, this.apiService);
         this.exportService = new ExportService(this.folderService, this.cipherService, this.apiService);
         this.notificationsService = new NotificationsService(this.userService, this.syncService, this.appIdService,
             this.apiService, this.vaultTimeoutService, () => this.logout(true));

--- a/src/background/runtime.background.ts
+++ b/src/background/runtime.background.ts
@@ -174,9 +174,8 @@ export default class RuntimeBackground {
                 }
 
                 try {
-                    chrome.tabs.create({
-                        url: 'popup/index.html?uilocation=popout#/sso?code=' + msg.code + '&state=' + msg.state
-                    });
+                    BrowserApi.createNewTab('popup/index.html?uilocation=popout#/sso?code=' +
+                        msg.code + '&state=' + msg.state);
                 }
                 catch { }
                 break;

--- a/src/browser/browserApi.ts
+++ b/src/browser/browserApi.ts
@@ -215,10 +215,10 @@ export class BrowserApi {
 
     static reloadOpenWindows() {
         if (!BrowserApi.isSafariApi) {
-            const sidebarWindows = chrome.extension.getViews({ type: 'sidebar' });
-            if (sidebarWindows && sidebarWindows.length > 0) {
-                sidebarWindows[0].location.reload();
-            }
+            const views = chrome.extension.getViews() as Window[];
+            views.filter((w) => w.location.href != null).forEach((w) => {
+                w.location.reload();
+            });
         }
     }
 }


### PR DESCRIPTION
There are three issues addressed here:

1. The CryptoFunctionService abstraction was not publicly available in the background main service, so it was not accessible when trying to be resolved as a dependency to the popup angular app. This change exposes `cryptoFunctionService` as a public member of the background main service so that it can be resolved.
2. Opening the sso component on the SSO authResult used web extension API specifics (`chrome.tabs.create`) rather than the `BrowserApi` abstractions. Use `BrowserApi.createNewTab` instead.
3. The newly added `reloadOpenWindows` function used `chrome.extension.getViews({ type: 'sidebar' })` which only works with the Firefox sidebar. Opera doesn't work with this type filter. Switch to just `chrome.extension.getViews()` and reload them all.