### PR TITLE
change default match on basic auth to host

### DIFF
--- a/src/background/webRequest.background.ts
+++ b/src/background/webRequest.background.ts
@@ -2,6 +2,8 @@ import { CipherService } from 'jslib/abstractions/cipher.service';
 import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
 import { VaultTimeoutService } from 'jslib/abstractions/vaultTimeout.service';
 
+import { UriMatchType } from 'jslib/enums';
+
 export default class WebRequestBackground {
     private pendingAuthRequests: any[] = [];
     private webRequest: any;
@@ -50,7 +52,7 @@ export default class WebRequestBackground {
         }
 
         try {
-            const ciphers = await this.cipherService.getAllDecryptedForUrl(domain);
+            const ciphers = await this.cipherService.getAllDecryptedForUrl(domain, null, UriMatchType.Host);
             if (ciphers == null || ciphers.length !== 1) {
                 error();
                 return;


### PR DESCRIPTION
ref #1124 

Since filling HTTP basic auth credentials is non-interactive, this PR changes the default match detection rule for these operations to the more restrictive "Host", so that sub-domains are not matched. This can still be overwritten by the user if they desire by changing the match detection setting for that individual item back to "Base Domain". This would restore the current functionality that exists today.