### PR TITLE
Potential fix for pinned tab auto-fill in Safari

### DIFF
--- a/src/safari/safari/SafariExtensionHandler.swift
+++ b/src/safari/safari/SafariExtensionHandler.swift
@@ -70,11 +70,26 @@ func makeSenderTabObject(page: SFSafariPage, props: SFSafariPageProperties?, com
     t.url = props?.url?.absoluteString
     page.getContainingTab { tab in
         tab.getContainingWindow(completionHandler: { win in
-            win?.getActiveTab(completionHandler: { activeTab in
+            guard let window = win else {
+                t.active = false;
+                t.windowId = -100
+                SFSafariApplication.getAllWindows(completionHandler: { allWins in
+                    if (allWins.count == 0) {
+                        return
+                    }
+                    allWins[0].getAllTabs { allWinTabs in
+                        t.index = allWinTabs.firstIndex(of: tab) ?? -1
+                        t.id = "\(t.windowId)_\(t.index)"
+                        complete(t)
+                    }
+                })
+                return
+            }
+            window.getActiveTab(completionHandler: { activeTab in
                 t.active = activeTab != nil && tab == activeTab
                 SFSafariApplication.getAllWindows(completionHandler: { allWins in
-                    t.windowId = allWins.firstIndex(of: win!) ?? -100
-                    win!.getAllTabs { allWinTabs in
+                    t.windowId = allWins.firstIndex(of: window) ?? -100
+                    window.getAllTabs { allWinTabs in
                         t.index = allWinTabs.firstIndex(of: tab) ?? -1
                         t.id = "\(t.windowId)_\(t.index)"
                         complete(t)


### PR DESCRIPTION
## Overview

This is a draft/potential fix for #1018 , but I'm no longer able to get my local Safari debug environment working (will have to play with that in a bit), however this _may_ work given pinned tabs have no container window, as a hack because any/every window can potentially own the tabs that are pinned (doesn't matter which window, just need 1 I believe), but need to ensure the index reference won't break anything else.