### PR TITLE
Ensure auto auto-fill ignores new-password

### DIFF
--- a/src/background/runtime.background.ts
+++ b/src/background/runtime.background.ts
@@ -188,6 +188,7 @@ export default class RuntimeBackground {
         const totpCode = await this.autofillService.doAutoFill({
             cipher: this.main.loginToAutoFill,
             pageDetails: this.pageDetailsToAutoFill,
+            fillNewPassword: true
         });
 
         if (totpCode != null) {

--- a/src/popup/vault/current-tab.component.ts
+++ b/src/popup/vault/current-tab.component.ts
@@ -147,6 +147,7 @@ export class CurrentTabComponent implements OnInit, OnDestroy {
                 cipher: cipher,
                 pageDetails: this.pageDetails,
                 doc: window.document,
+                fillNewPassword: true,
             });
             this.analytics.eventTrack.next({ action: 'Autofilled' });
             if (this.totpCode != null) {

--- a/src/popup/vault/view.component.ts
+++ b/src/popup/vault/view.component.ts
@@ -220,6 +220,7 @@ export class ViewComponent extends BaseViewComponent {
                 cipher: this.cipher,
                 pageDetails: this.pageDetails,
                 doc: window.document,
+                fillNewPassword: true,
             });
             if (this.totpCode != null) {
                 this.platformUtilsService.copyToClipboard(this.totpCode, { window: window });

--- a/src/services/autofill.service.ts
+++ b/src/services/autofill.service.ts
@@ -126,7 +126,7 @@ export default class AutofillService implements AutofillServiceInterface {
     getFormsWithPasswordFields(pageDetails: AutofillPageDetails): any[] {
         const formData: any[] = [];
 
-        const passwordFields = this.loadPasswordFields(pageDetails, true, true, false);
+        const passwordFields = this.loadPasswordFields(pageDetails, true, true, false, false);
         if (passwordFields.length === 0) {
             return formData;
         }
@@ -174,6 +174,7 @@ export default class AutofillService implements AutofillServiceInterface {
                 skipUsernameOnlyFill: options.skipUsernameOnlyFill || false,
                 onlyEmptyFields: options.onlyEmptyFields || false,
                 onlyVisibleFields: options.onlyVisibleFields || false,
+                fillNewPassword: options.fillNewPassword || false,
                 cipher: options.cipher,
             });
 
@@ -241,6 +242,7 @@ export default class AutofillService implements AutofillServiceInterface {
             skipUsernameOnlyFill: !fromCommand,
             onlyEmptyFields: !fromCommand,
             onlyVisibleFields: !fromCommand,
+            fillNewPassword: fromCommand,
         });
     }
 
@@ -326,10 +328,12 @@ export default class AutofillService implements AutofillServiceInterface {
             return fillScript;
         }
 
-        let passwordFields = this.loadPasswordFields(pageDetails, false, false, options.onlyEmptyFields);
+        let passwordFields = this.loadPasswordFields(pageDetails, false, false, options.onlyEmptyFields,
+            options.fillNewPassword);
         if (!passwordFields.length && !options.onlyVisibleFields) {
             // not able to find any viewable password fields. maybe there are some "hidden" ones?
-            passwordFields = this.loadPasswordFields(pageDetails, true, true, options.onlyEmptyFields);
+            passwordFields = this.loadPasswordFields(pageDetails, true, true, options.onlyEmptyFields,
+                options.fillNewPassword);
         }
 
         for (const formKey in pageDetails.forms) {
@@ -891,7 +895,7 @@ export default class AutofillService implements AutofillServiceInterface {
     }
 
     private loadPasswordFields(pageDetails: AutofillPageDetails, canBeHidden: boolean, canBeReadOnly: boolean,
-        mustBeEmpty: boolean) {
+        mustBeEmpty: boolean, fillNewPassword: boolean) {
         const arr: AutofillField[] = [];
         pageDetails.fields.forEach((f) => {
             const isPassword = f.type === 'password';
@@ -927,7 +931,8 @@ export default class AutofillService implements AutofillServiceInterface {
                 return false;
             };
             if (!f.disabled && (canBeReadOnly || !f.readonly) && (isPassword || isLikePassword())
-                && (canBeHidden || f.viewable) && (!mustBeEmpty || f.value == null || f.value.trim() === '')) {
+                && (canBeHidden || f.viewable) && (!mustBeEmpty || f.value == null || f.value.trim() === '')
+                && (fillNewPassword || f.autoCompleteType !== 'new-password')) {
                 arr.push(f);
             }
         });


### PR DESCRIPTION
## Overview

Closes and resolves #842. The fields marked as `autocomplete="new-password"` should not be auto-filled with an existing password unless auto-fill is explicitly executed by a command or context menu action by the user. In other words, having automatic auto-fill on page load enabled should not populate fields on a user registration form OR reset password form unless the user expressly asks for it.

### User Stories

#### New Registration / Signup Form
As a Bitwarden user who relies on the ability to create multiple accounts on the same site, I should not have my information or password automatically populated from another account (or last used account) in the `new-password` field for risk of creating a new user account with the same password so that I must manually enter a password or use Bitwarden's password generator feature to populate this field myself.

As a Bitwarden user who first provisions accounts within Bitwarden and then goes to the target site to sign up for an account, I should be able to auto-fill on demand, even if automatic auto-fill on page load is enabled, so I can at least auto-fill the new user registration and new-password fields with the account I've pre-provisioned in Bitwarden so that I can minimize the work and reduce the risk of change password capturing the new password from the form.

#### Change Password
As a Bitwarden user who must change their password on a target site, I should not have my vault autofill the new password field(s) from my existing account information if auto-complete on page load is true so that I have control over the new password being populated and so that I am not confused or submitting the same password when I should be changing it.

As a Bitwarden user who has already changed their password for a target site before resetting it there, I should be able to auto-fill that password into the new-password field by using an explicit action, even if auto-fill on page load is enabled, so that I can minimize the work and reduce the risk of change password capturing the new password from the form.

## Changes

* **runtime.background.ts**: The private method `autofillPage()` is only called when running a context menu command, and therefore it is safe to auto-fill new-password fields from here (explicit user action).
* **current-tab.component.ts**: The current tab component (auto-fill preview pane of the extension UI) executes the `fillCipher()` method when explicit user action is taken from here, also assumes we can auto-fill "new-password" fields as it behaved before
* **view.component.ts**: Ditto
* **autofill.service.ts**: The auto fill service has to handle whether or not it considers a password field with the autocomplete type of `"new-password"` while also only including those password fields if the flag is passed in as `true` or internally that is set to `true` when it is from a command context.

## Testing
Tested with the community provided URLs and registration forms where the behavior was observed both before and after changes and it appears this corrects to the necessary behavior while not deprecating (yet slightly altering) previous behavior for these forms (explicit user action).