### PR TITLE
beefed up restrictions on what is considered isLikePassword

### DIFF
--- a/src/services/autofill.service.ts
+++ b/src/services/autofill.service.ts
@@ -903,18 +903,16 @@ export default class AutofillService implements AutofillServiceInterface {
                 if (value == null) {
                     return false;
                 }
-                // Removes all whitespace and _ characters
-                const cleanedValue = value.toLowerCase().trim().replace(/[\s_]/g, '');
+                // Removes all whitespace, _ and - characters
+                const cleanedValue = value.toLowerCase().replace(/[\s_-]/g, '');
 
                 if (cleanedValue.indexOf('password') < 0) {
                     return false;
                 }
 
-                const ignoreList = ['onetimepassword', 'captcha', 'findanything']
-                for (let index = 0; index < ignoreList.length; index++) {
-                    if (cleanedValue.indexOf(ignoreList[index]) > -1) {
-                        return false;
-                    }
+                const ignoreList = ['onetimepassword', 'captcha', 'findanything'];
+                if (ignoreList.some((i) => cleanedValue.indexOf(i) > -1)) {
+                    return false;
                 }
 
                 return true;

--- a/src/services/autofill.service.ts
+++ b/src/services/autofill.service.ts
@@ -903,16 +903,20 @@ export default class AutofillService implements AutofillServiceInterface {
                 if (value == null) {
                     return false;
                 }
-                const lowerValue = value.toLowerCase();
-                if (lowerValue.indexOf('onetimepassword') >= 0) {
+                // Removes all whitespace and _ characters
+                const cleanedValue = value.toLowerCase().trim().replace(/[\s_]/g, '');
+
+                if (cleanedValue.indexOf('password') < 0) {
                     return false;
                 }
-                if (lowerValue.indexOf('password') < 0) {
-                    return false;
+
+                const ignoreList = ['onetimepassword', 'captcha', 'findanything']
+                for (let index = 0; index < ignoreList.length; index++) {
+                    if (cleanedValue.indexOf(ignoreList[index]) > -1) {
+                        return false;
+                    }
                 }
-                if (lowerValue.indexOf('captcha') >= 0) {
-                    return false;
-                }
+
                 return true;
             };
             const isLikePassword = () => {

--- a/src/services/autofill.service.ts
+++ b/src/services/autofill.service.ts
@@ -904,7 +904,7 @@ export default class AutofillService implements AutofillServiceInterface {
                     return false;
                 }
                 // Removes all whitespace, _ and - characters
-                const cleanedValue = value.toLowerCase().replace(/[\s_-]/g, '');
+                const cleanedValue = value.toLowerCase().replace(/[\s_\-]/g, '');
 
                 if (cleanedValue.indexOf('password') < 0) {
                     return false;


### PR DESCRIPTION
Relates to https://github.com/bitwarden/browser/issues/1372

### Issue
Some non-password type fields are being autofilled as passwordLike erroneously. 

### Solution
While I'm sure there will never be 100% coverage here these changes address the use cases mentioned in the linked issue, and sets us up to be able to better exclude certain unwanted fields from being autofilled in the future.

(also updated jslib)