### PR TITLE
disable angular ivy compiler

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,7 +29,8 @@
     }
   },
   "angularCompilerOptions": {
-    "preserveWhitespaces": true
+    "preserveWhitespaces": true,
+    "enableIvy": false
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
The Ivy compiler breaks `onScroll` events for ngx-infinite-scroll plugin. Until we can figure out why or a fix, this change disabled the Ivy compiler.