### PR TITLE
expand CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,32 @@
-Code contributions are welcome! Please commit any pull requests against the `master` branch.
+# How to Contribute
+
+Contributions of all kinds are welcome!
+
+Please visit our [Community Forums](https://community.bitwarden.com/) for general community discussion and the development roadmap.
+
+Here is how you can get involved:
+
+* **Request a new feature:** Go to the [Feature Requests category](https://community.bitwarden.com/c/feature-requests/) of the Community Forums. Please search existing feature requests before making a new one
+  
+* **Write code for a new feature:** Make a new post in the [Github Contributions category](https://community.bitwarden.com/c/github-contributions/) of the Community Forums. Include a description of your proposed contribution, screeshots, and links to any relevant feature requests. This helps get feedback from the community and Bitwarden team members before you start writing code
+  
+* **Report a bug or submit a bugfix:** Use Github issues and pull requests
+  
+* **Write documentation:** Submit a pull request to the [Bitwarden help repository](https://github.com/bitwarden/help)
+  
+* **Help other users:** Go to the [User-to-User Support category](https://community.bitwarden.com/c/support/) on the Community Forums
+  
+* **Translate:** See the localization (i10n) section below
+
+## Contributor Agreement
+
+Please sign the [Contributor Agreement](https://cla-assistant.io/bitwarden/browser) if you intend on contributing to any Github repository. Pull requests cannot be accepted and merged unless the author has signed the Contributor Agreement.
+
+## Pull Request Guidelines
+
+* use `npm run lint` and fix any linting suggestions before submitting a pull request
+* commit any pull requests against the `master` branch
+* include a link to your Community Forums post
 
 # Localization (l10n)
 


### PR DESCRIPTION
I have expanded CONTRIBUTING.md with the aim of:
* pointing people to the community forums where appropriate - there is a fairly specific division of labour between the github repos and forums, but this isn't really set out anywhere
* encouraging other ways of contributing (docs, user-to-user support, etc)
* pointing people to the contributor agreement in advance
* flagging any repo-specific tools (such as linting tools) that will help improve the quality of submissions

Once we have wording that we are happy with, I can make substantially identical PRs to the other client & server repos to bring them all into line.