### PR TITLE
Upgrade bl: 2.2.0 -> 2.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1778,9 +1778,9 @@
       "dev": true
     },
     "bl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.0.tgz",
-      "integrity": "sha512-wbgvOpqopSr7uq6fJrLH8EsvYMJf9gzfo2jCsL2eTy75qXPukA4pCgHamOQkZtY5vmfVtjB+P3LNlMHW5CEZXA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
       "requires": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"


### PR DESCRIPTION
Upgrade `bl` from `2.2.0` to `2.2.1`. To get rid of the following (potential from the Bitwarden's user perspective) vulnerability:

```
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Remote Memory Exposure                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ bl                                                           │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ @microsoft/signalr-protocol-msgpack                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ @microsoft/signalr-protocol-msgpack > msgpack5 > bl          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1555                            │
└───────────────┴──────────────────────────────────────────────────────────────┘
```

Diff: https://github.com/rvagg/bl/compare/v2.2.0...v2.2.1.

## Risk assessment of this change

Potential risk relates only to usage of `@microsoft/signalr-protocol-msgpack`. The risk is low, because:
* the `bl` package is not a direct dependency,
* the scope of the change is small (see the link to the diff above). According to the official changelog, it only fixes unintialized memory access.