### PR TITLE
tracked last-launched ciphers for autofill

### DIFF
--- a/src/popup/vault/ciphers.component.ts
+++ b/src/popup/vault/ciphers.component.ts
@@ -15,6 +15,7 @@ import {
 
 import { BrowserApi } from '../../browser/browserApi';
 
+import { CipherService } from 'jslib/abstractions/cipher.service';
 import { CollectionService } from 'jslib/abstractions/collection.service';
 import { FolderService } from 'jslib/abstractions/folder.service';
 import { I18nService } from 'jslib/abstractions/i18n.service';
@@ -62,7 +63,8 @@ export class CiphersComponent extends BaseCiphersComponent implements OnInit, On
         private changeDetectorRef: ChangeDetectorRef, private stateService: StateService,
         private popupUtils: PopupUtilsService, private i18nService: I18nService,
         private folderService: FolderService, private collectionService: CollectionService,
-        private analytics: Angulartics2, private platformUtilsService: PlatformUtilsService) {
+        private analytics: Angulartics2, private platformUtilsService: PlatformUtilsService,
+        private cipherService: CipherService) {
         super(searchService);
         this.pageSize = 100;
         this.applySavedState = (window as any).previousPopupUrl != null &&
@@ -195,6 +197,7 @@ export class CiphersComponent extends BaseCiphersComponent implements OnInit, On
         }
         this.preventSelected = true;
         this.analytics.eventTrack.next({ action: 'Launched URI From Listing' });
+        await this.cipherService.updateLastLaunchedDate(cipher.id);
         BrowserApi.createNewTab(cipher.login.launchUri);
         if (this.popupUtils.inPopup(window)) {
             BrowserApi.closePopup(window);

--- a/src/popup/vault/groupings.component.ts
+++ b/src/popup/vault/groupings.component.ts
@@ -286,6 +286,7 @@ export class GroupingsComponent extends BaseGroupingsComponent implements OnInit
         }
         this.preventSelected = true;
         this.analytics.eventTrack.next({ action: 'Launched URI From Listing' });
+        await this.cipherService.updateLastLaunchedDate(cipher.id);
         BrowserApi.createNewTab(cipher.login.launchUri);
         if (this.popupUtils.inPopup(window)) {
             BrowserApi.closePopup(window);

--- a/src/services/autofill.service.ts
+++ b/src/services/autofill.service.ts
@@ -232,6 +232,13 @@ export default class AutofillService implements AutofillServiceInterface {
             cipher = await this.cipherService.getNextCipherForUrl(tab.url);
         } else {
             cipher = await this.cipherService.getLastUsedForUrl(tab.url);
+            const lastLaunchedCipher = await this.cipherService.getLastLaunchedForUrl(tab.url);
+            if (lastLaunchedCipher && Date.now().valueOf() - lastLaunchedCipher.localData?.lastLaunched?.valueOf() < 30000) {
+                cipher = lastLaunchedCipher;
+            }
+            else {
+                cipher = await this.cipherService.getLastUsedForUrl(tab.url);
+            }
         }
 
         const autoFillResponse = await this.doAutoFill({

--- a/src/services/autofill.service.ts
+++ b/src/services/autofill.service.ts
@@ -231,7 +231,6 @@ export default class AutofillService implements AutofillServiceInterface {
         if (fromCommand) {
             cipher = await this.cipherService.getNextCipherForUrl(tab.url);
         } else {
-            cipher = await this.cipherService.getLastUsedForUrl(tab.url);
             const lastLaunchedCipher = await this.cipherService.getLastLaunchedForUrl(tab.url);
             if (lastLaunchedCipher && Date.now().valueOf() - lastLaunchedCipher.localData?.lastLaunched?.valueOf() < 30000) {
                 cipher = lastLaunchedCipher;


### PR DESCRIPTION
This is a recreation of the changes on https://github.com/bitwarden/browser/pull/1405 since that PR became stale and then I broke it horribly

It will resolve #1391


### Issue
When using the search bar to launch a url & autofill the autofill process is not using the login that was clicked, it is using the last used login previous to the clicked login.

### Resolution
We can locally track last launched logins and get that data back for autofill