### PR TITLE
fix typo in symlink:win script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "sub:update": "git submodule update --remote",
     "sub:pull": "git submodule foreach git pull origin master",
     "postinstall": "npm run sub:init",
-    "symlink:win": "rmdir /S /Q ./jslib && cmd /c mklink /J .\\jslib ..\\jslib",
+    "symlink:win": "rmdir /S /Q .\\jslib && cmd /c mklink /J .\\jslib ..\\jslib",
     "symlink:mac": "npm run symlink:lin",
     "symlink:lin": "rm -rf ./jslib && ln -s ../jslib ./jslib",
     "build": "gulp build && webpack",


### PR DESCRIPTION
`npm run symlink:win` currently returns `Invalid switch - "jslib".`

`rmdir` appears to interpret `./jslib` as a switch rather than as an argument specifying the directory. Fixed by changing `/` to `\\`.