### PR TITLE
Add 'lock_vault' command

### DIFF
--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -894,9 +894,6 @@
   "commandGeneratePasswordDesc": {
     "message": "Ein neues zufälliges Passwort generieren und in die Zwischenablage kopieren"
   },
-  "commandLockVaultDesc": {
-    "message": "Tresor sperren"
-  },
   "privateModeMessage": {
     "message": "Leider ist dieses Fenster nicht im privaten Modus für diesen Browser verfügbar."
   },

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -894,6 +894,9 @@
   "commandGeneratePasswordDesc": {
     "message": "Ein neues zufälliges Passwort generieren und in die Zwischenablage kopieren"
   },
+  "commandLockVaultDesc": {
+    "message": "Tresor sperren"
+  },
   "privateModeMessage": {
     "message": "Leider ist dieses Fenster nicht im privaten Modus für diesen Browser verfügbar."
   },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -895,7 +895,7 @@
     "message": "Generate and copy a new random password to the clipboard"
   },
   "commandLockVaultDesc": {
-    "message": "Lock Vault"
+    "message": "Lock the vault"
   },
   "privateModeMessage": {
     "message": "Unfortunately this window is not available in private mode for this browser."

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -894,6 +894,9 @@
   "commandGeneratePasswordDesc": {
     "message": "Generate and copy a new random password to the clipboard"
   },
+  "commandLockVaultDesc": {
+    "message": "Lock Vault"
+  },
   "privateModeMessage": {
     "message": "Unfortunately this window is not available in private mode for this browser."
   },

--- a/src/background/commands.background.ts
+++ b/src/background/commands.background.ts
@@ -44,6 +44,9 @@ export default class CommandsBackground {
             case 'open_popup':
                 await this.openPopup();
                 break;
+            case 'lock_vault':
+                await this.vaultTimeoutService.lock(true);
+                break;
             default:
                 break;
         }

--- a/src/content/shortcuts.ts
+++ b/src/content/shortcuts.ts
@@ -35,7 +35,7 @@ document.addEventListener('DOMContentLoaded', (event) => {
         });
     }
 
-    // Not sure if needed, but seems to handle everything not handled in commands.background.ts:29-30
+    // Default Keybinding for Safari
     Mousetrap.bind('mod+shift+s', () => {
         sendMessage('lock_vault');
     });

--- a/src/content/shortcuts.ts
+++ b/src/content/shortcuts.ts
@@ -35,7 +35,6 @@ document.addEventListener('DOMContentLoaded', (event) => {
         });
     }
 
-    // Default Keybinding for Safari
     Mousetrap.bind('mod+shift+s', () => {
         sendMessage('lock_vault');
     });

--- a/src/content/shortcuts.ts
+++ b/src/content/shortcuts.ts
@@ -35,6 +35,11 @@ document.addEventListener('DOMContentLoaded', (event) => {
         });
     }
 
+    // Not sure if needed, but seems to handle everything not handled in commands.background.ts:29-30
+    Mousetrap.bind('mod+shift+s', () => {
+        sendMessage('lock_vault');
+    });
+
     function sendMessage(shortcut: string) {
         const msg: any = {
             command: 'keyboardShortcutTriggered',

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -118,6 +118,9 @@
         "default": "Ctrl+Shift+9"
       },
       "description": "__MSG_commandGeneratePasswordDesc__"
+    },
+    "lock_vault": {
+      "description": "__MSG_commandLockVaultDesc__"
     }
   },
   "web_accessible_resources": [


### PR DESCRIPTION
Pull Request for [Contribution - Add 'lock_vault' command](https://community.bitwarden.com/t/add-lock-vault-command-to-browser-extension/15325) (addresses Feature Requests: [1](https://community.bitwarden.com/t/add-shortcut-to-manually-lock-vault/15319) and [2](https://community.bitwarden.com/t/add-global-hotkey-to-lock-log-out-without-closing-the-browser))

This Pull Request will add an command called 'lock_vault' in the manifest file without suggestedkeys (as there seems to be a limit of 4 suggestedkeys). see: [Chrome Commands](https://developer.chrome.com/apps/commands#usage)

But it will be possible to manually add a shortcut to trigger the command and lock the browser extension manually in Chrome Configure Commands (chrome://extensions/configureCommands) or Firefox About Addons (about:addons -> tools for all addons -> manage extension shortcuts)
![FirefoxAboutAddons](https://user-images.githubusercontent.com/73910438/98233530-7a59ed00-1f5f-11eb-832c-04c074b070e0.png)

Tested in Firefox and Chrome Extension

Needed:
- [ ] Feedback Safari
- [ ] Feedback Edge
- [ ] Other Feedback