### PR TITLE
lock vault shortcut only for safari

### DIFF
--- a/src/content/shortcuts.ts
+++ b/src/content/shortcuts.ts
@@ -29,15 +29,15 @@ document.addEventListener('DOMContentLoaded', (event) => {
         Mousetrap.bind('mod+shift+y', () => {
             sendMessage('open_popup');
         });
+
+        Mousetrap.bind('mod+shift+s', () => {
+            sendMessage('lock_vault');
+        });
     } else {
         Mousetrap.bind('mod+shift+9', () => {
             sendMessage('generate_password');
         });
     }
-
-    Mousetrap.bind('mod+shift+s', () => {
-        sendMessage('lock_vault');
-    });
 
     function sendMessage(shortcut: string) {
         const msg: any = {


### PR DESCRIPTION
We only want this shortcut binding to apply to safari. Others that use shortcuts, like vivaldi, use this shortcut for something already.

ref #1450