### PR TITLE
Use helper method to get web vault url

### DIFF
--- a/src/background/runtime.background.ts
+++ b/src/background/runtime.background.ts
@@ -164,7 +164,7 @@ export default class RuntimeBackground {
                 }
                 break;
             case 'authResult':
-                let vaultUrl = this.environmentService.webVaultUrl;
+                let vaultUrl = this.environmentService.getWebVaultUrl();
                 if (vaultUrl == null) {
                     vaultUrl = 'https://vault.bitwarden.com';
                 }


### PR DESCRIPTION
The helper method yields either 1) the configured web vault url or 2)
the configured server url. If neither are configured, null is returned,
which is already handled by defaulting to vault.bitwarden.com

# Objective
Easier configuration of self-hosted SSO instances

# Files changed
* **runtime.background.ts** If only Server URL was configured, this did not fall back correctly to the configured server URL, but redirected to vault.bitwarden.com. This is fixed by the helper method getWebVaultUrl, which already exists in jslib