### PR TITLE
Close 2fa window if redirected from sso login

### DIFF
--- a/src/background/main.background.ts
+++ b/src/background/main.background.ts
@@ -155,7 +155,7 @@ export default class MainBackground {
             async () => {
                 if (this.nativeMessagingBackground != null) {
                     const promise = this.nativeMessagingBackground.getResponse();
-                    
+
                     try {
                         await this.nativeMessagingBackground.send({command: 'biometricUnlock'});
                     } catch (e) {

--- a/src/content/sso.ts
+++ b/src/content/sso.ts
@@ -10,4 +10,4 @@ window.addEventListener('message', (event) => {
             referrer: event.source.location.hostname,
         });
     }
-}, false)
+}, false);

--- a/src/popup/accounts/home.component.ts
+++ b/src/popup/accounts/home.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 
-import { ConstantsService } from 'jslib/services/constants.service'
+import { ConstantsService } from 'jslib/services/constants.service';
 import { CryptoFunctionService } from 'jslib/abstractions/cryptoFunction.service';
 import { EnvironmentService } from 'jslib/abstractions/environment.service';
 import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';

--- a/src/popup/accounts/two-factor.component.ts
+++ b/src/popup/accounts/two-factor.component.ts
@@ -83,18 +83,18 @@ export class TwoFactorComponent extends BaseTwoFactorComponent {
         }
 
         const queryParamsSub = this.route.queryParams.subscribe(async (qParams) => {
-            if (qParams.sso != null && qParams.sso === 'true') {
+            if (qParams.sso === 'true') {
                 super.onSuccessfulLogin = () => {
                     BrowserApi.reloadOpenWindows();
                     const thisWindow = window.open('', '_self');
                     thisWindow.close();
                     return this.syncService.fullSync(true);
-                }
+                };
                 if (queryParamsSub != null) {
                     queryParamsSub.unsubscribe();
                 }
             }
-        })
+        });
     }
 
     ngOnDestroy() {

--- a/src/popup/accounts/two-factor.component.ts
+++ b/src/popup/accounts/two-factor.component.ts
@@ -25,6 +25,7 @@ import { BroadcasterService } from 'jslib/angular/services/broadcaster.service';
 import { TwoFactorComponent as BaseTwoFactorComponent } from 'jslib/angular/components/two-factor.component';
 
 import { PopupUtilsService } from '../services/popup-utils.service';
+import { BrowserApi } from '../../browser/browserApi';
 
 const BroadcasterSubscriptionId = 'TwoFactorComponent';
 
@@ -37,7 +38,7 @@ export class TwoFactorComponent extends BaseTwoFactorComponent {
 
     constructor(authService: AuthService, router: Router,
         i18nService: I18nService, apiService: ApiService,
-        platformUtilsService: PlatformUtilsService, syncService: SyncService,
+        platformUtilsService: PlatformUtilsService, private syncService: SyncService,
         environmentService: EnvironmentService, private ngZone: NgZone,
         private broadcasterService: BroadcasterService, private changeDetectorRef: ChangeDetectorRef,
         private popupUtilsService: PopupUtilsService, stateService: StateService,
@@ -80,6 +81,20 @@ export class TwoFactorComponent extends BaseTwoFactorComponent {
                 this.popupUtilsService.popOut(window);
             }
         }
+
+        const queryParamsSub = this.route.queryParams.subscribe(async (qParams) => {
+            if (qParams.sso != null && qParams.sso === 'true') {
+                super.onSuccessfulLogin = () => {
+                    BrowserApi.reloadOpenWindows();
+                    const thisWindow = window.open('', '_self');
+                    thisWindow.close();
+                    return this.syncService.fullSync(true);
+                }
+                if (queryParamsSub != null) {
+                    queryParamsSub.unsubscribe();
+                }
+            }
+        })
     }
 
     ngOnDestroy() {

--- a/src/services/autofill.service.ts
+++ b/src/services/autofill.service.ts
@@ -42,14 +42,14 @@ const FirstnameFieldNames: string[] = [
     'f-name', 'first-name', 'given-name', 'first-n',
     // German
     'vorname'
-]
+];
 
 const LastnameFieldNames: string[] = [
     // English
     'l-name', 'last-name', 's-name', 'surname', 'family-name', 'family-n', 'last-n',
     // German
     'nachname', 'familienname'
-]
+];
 
 const ExcludedAutofillTypes: string[] = ['radio', 'checkbox', 'hidden', 'file', 'button', 'image', 'reset', 'search'];
 

--- a/tslint.json
+++ b/tslint.json
@@ -49,6 +49,10 @@
       "check-separator",
       "check-type"
     ],
-    "max-classes-per-file": false
+    "max-classes-per-file": false,
+    "semicolon": [
+      true,
+      "always"
+    ]
   }
 }


### PR DESCRIPTION
# Objective

Closes 2fa window if the window was opened as part of an sso login. Reduces the number of hanging tabs left open from sso flow.

Closes #1479 

# Files Changed

* **main.background.ts**: linter fix, just removed from whitespace.
* **two-factor.component.ts**: subscribe to query parameters and alter onSuccessfulLogin event handler to close the current window.

## Commit messages
This is a workaround until we can get browser extension sso to use the
toolbar popup.

main.background.ts is a linter autofix