### PR TITLE
[Policy] Personal Ownership

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1415,6 +1415,6 @@
     "message": "Desktop communication interupted"
   },
   "personalOwnershipSubmitError": {
-    "message": "Due to an Enterprise Policy, you are restricted from saving items to your personal vault. Change the Ownership Option to an organization and choose from available Collections."
+    "message": "Due to an Enterprise Policy, you are restricted from saving items to your personal vault. Change the Ownership option to an organization and choose from available Collections."
   }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1410,5 +1410,8 @@
   },
   "nativeMessagingInvalidEncryptionTitle": {
     "message": "Desktop communication interupted"
+  },
+  "personalOwnershipSubmitError": {
+    "message": "Due to an Enterprise Policy, you are restricted from saving items to your personal vault. Change the Ownership Option to an organization and choose from available Collections."
   }
 }

--- a/src/background/main.background.ts
+++ b/src/background/main.background.ts
@@ -243,7 +243,7 @@ export default class MainBackground {
         this.runtimeBackground = new RuntimeBackground(this, this.autofillService, this.cipherService,
             this.platformUtilsService as BrowserPlatformUtilsService, this.storageService, this.i18nService,
             this.analytics, this.notificationsService, this.systemService, this.vaultTimeoutService,
-            this.environmentService, this.policyService);
+            this.environmentService, this.policyService, this.userService);
         this.nativeMessagingBackground = new NativeMessagingBackground(this.storageService, this.cryptoService, this.cryptoFunctionService,
             this.vaultTimeoutService, this.runtimeBackground, this.i18nService, this.userService, this.messagingService);
         this.commandsBackground = new CommandsBackground(this, this.passwordGenerationService,

--- a/src/background/main.background.ts
+++ b/src/background/main.background.ts
@@ -155,9 +155,9 @@ export default class MainBackground {
             async () => {
                 if (this.nativeMessagingBackground != null) {
                     const promise = this.nativeMessagingBackground.getResponse();
-                    
+
                     try {
-                        await this.nativeMessagingBackground.send({command: 'biometricUnlock'});
+                        await this.nativeMessagingBackground.send({ command: 'biometricUnlock' });
                     } catch (e) {
                         return Promise.reject(e);
                     }
@@ -243,7 +243,7 @@ export default class MainBackground {
         this.runtimeBackground = new RuntimeBackground(this, this.autofillService, this.cipherService,
             this.platformUtilsService as BrowserPlatformUtilsService, this.storageService, this.i18nService,
             this.analytics, this.notificationsService, this.systemService, this.vaultTimeoutService,
-            this.environmentService);
+            this.environmentService, this.policyService);
         this.nativeMessagingBackground = new NativeMessagingBackground(this.storageService, this.cryptoService, this.cryptoFunctionService,
             this.vaultTimeoutService, this.runtimeBackground, this.i18nService, this.userService, this.messagingService);
         this.commandsBackground = new CommandsBackground(this, this.passwordGenerationService,

--- a/src/background/runtime.background.ts
+++ b/src/background/runtime.background.ts
@@ -12,6 +12,7 @@ import { ConstantsService } from 'jslib/services/constants.service';
 import { EnvironmentService } from 'jslib/abstractions/environment.service';
 import { I18nService } from 'jslib/abstractions/i18n.service';
 import { NotificationsService } from 'jslib/abstractions/notifications.service';
+import { PolicyService } from 'jslib/abstractions/policy.service';
 import { PopupUtilsService } from '../popup/services/popup-utils.service';
 import { StateService } from 'jslib/abstractions/state.service';
 import { StorageService } from 'jslib/abstractions/storage.service';
@@ -27,6 +28,8 @@ import { NativeMessagingBackground } from './nativeMessaging.background';
 import { Analytics } from 'jslib/misc';
 import { Utils } from 'jslib/misc/utils';
 
+import { PolicyType } from 'jslib/enums/policyType';
+
 export default class RuntimeBackground {
     private runtime: any;
     private autofillTimeout: any;
@@ -39,7 +42,7 @@ export default class RuntimeBackground {
         private storageService: StorageService, private i18nService: I18nService,
         private analytics: Analytics, private notificationsService: NotificationsService,
         private systemService: SystemService, private vaultTimeoutService: VaultTimeoutService,
-        private environmentService: EnvironmentService) {
+        private environmentService: EnvironmentService, private policyService: PolicyService) {
         this.isSafari = this.platformUtilsService.isSafari();
         this.runtime = this.isSafari ? {} : chrome.runtime;
 
@@ -318,6 +321,11 @@ export default class RuntimeBackground {
             if (disabledAddLogin) {
                 return;
             }
+
+            if (!(await this.allowPersonalOwnership())) {
+                return;
+            }
+
             // remove any old messages for this tab
             this.removeTabFromNotificationQueue(tab);
             this.main.notificationQueue.push({
@@ -436,10 +444,12 @@ export default class RuntimeBackground {
         const responseData: any = {};
         if (responseCommand === 'notificationBarDataResponse') {
             responseData.neverDomains = await this.storageService.get<any>(ConstantsService.neverDomainsKey);
-            responseData.disabledAddLoginNotification = await this.storageService.get<boolean>(
+            const disableAddLoginFromOptions = await this.storageService.get<boolean>(
                 ConstantsService.disableAddLoginNotificationKey);
+            responseData.disabledAddLoginNotification = disableAddLoginFromOptions || !(await this.allowPersonalOwnership());
             responseData.disabledChangedPasswordNotification = await this.storageService.get<boolean>(
                 ConstantsService.disableChangedPasswordNotificationKey);
+            // TODO Pass along allowPersonal data to the content scripts
         } else if (responseCommand === 'autofillerAutofillOnPageLoadEnabledResponse') {
             responseData.autofillEnabled = await this.storageService.get<boolean>(
                 ConstantsService.enableAutoFillOnPageLoadKey);
@@ -458,5 +468,17 @@ export default class RuntimeBackground {
         }
 
         await BrowserApi.tabSendMessageData(tab, responseCommand, responseData);
+    }
+
+    private async allowPersonalOwnership(): Promise<boolean> {
+        const personalOwnershipPolicies = await this.policyService.getAll(PolicyType.PersonalOwnership);
+        if (personalOwnershipPolicies != null) {
+            for (const policy of personalOwnershipPolicies) {
+                if (policy.enabled) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 }

--- a/src/background/runtime.background.ts
+++ b/src/background/runtime.background.ts
@@ -29,8 +29,8 @@ import { NativeMessagingBackground } from './nativeMessaging.background';
 import { Analytics } from 'jslib/misc';
 import { Utils } from 'jslib/misc/utils';
 
-import { PolicyType } from 'jslib/enums/policyType';
 import { OrganizationUserStatusType } from 'jslib/enums/organizationUserStatusType';
+import { PolicyType } from 'jslib/enums/policyType';
 
 export default class RuntimeBackground {
     private runtime: any;

--- a/src/popup/vault/add-edit.component.html
+++ b/src/popup/vault/add-edit.component.html
@@ -340,7 +340,7 @@
                 </div>
             </div>
         </div>
-        <div class="box" *ngIf="(!editMode || cloneMode) && ownershipOptions && ownershipOptions.length > 1">
+        <div class="box" *ngIf="allowOwnershipOptions()">
             <div class="box-header">
                 {{'ownership' | i18n}}
             </div>

--- a/src/popup/vault/add-edit.component.ts
+++ b/src/popup/vault/add-edit.component.ts
@@ -15,6 +15,7 @@ import { FolderService } from 'jslib/abstractions/folder.service';
 import { I18nService } from 'jslib/abstractions/i18n.service';
 import { MessagingService } from 'jslib/abstractions/messaging.service';
 import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
+import { PolicyService } from 'jslib/abstractions/policy.service';
 import { StateService } from 'jslib/abstractions/state.service';
 import { UserService } from 'jslib/abstractions/user.service';
 
@@ -36,9 +37,9 @@ export class AddEditComponent extends BaseAddEditComponent {
         userService: UserService, collectionService: CollectionService,
         messagingService: MessagingService, private route: ActivatedRoute,
         private router: Router, private location: Location,
-        eventService: EventService) {
+        eventService: EventService, policyService: PolicyService) {
         super(cipherService, folderService, i18nService, platformUtilsService, auditService, stateService,
-            userService, collectionService, messagingService, eventService);
+            userService, collectionService, messagingService, eventService, policyService);
     }
 
     async ngOnInit() {
@@ -160,5 +161,10 @@ export class AddEditComponent extends BaseAddEditComponent {
     toggleUriInput(uri: LoginUriView) {
         const u = (uri as any);
         u.showCurrentUris = !u.showCurrentUris;
+    }
+
+    allowOwnershipOptions(): boolean {
+        return (!this.editMode || this.cloneMode) && this.ownershipOptions
+            && (this.ownershipOptions.length > 1 || !this.allowPersonal);
     }
 }


### PR DESCRIPTION
## Objective
> Allow organizations to restrict user's from saving added/cloned items to their personal vaults. Remove the personal ownership option when this policy is enabled and the user is not an Admin/Owner of the organization.

## Code Changes
- **messages.json**: Added error message
- **main.background.ts**: Updated constructor for `runtimeBackground` object
- **runtime.background.ts**: Added `policyService` and `userService` to the class constructor. Added return logic to cipher creation via notification bar.  Adjusted `responseData` being sent to the content scripts - made sure to include whether or not personal ownership is allowed. Added helper method for determining if personal ownership should be allowed via the notification bar.
- **add-edit.component.html**: Adjusted visibility to use `allowOwnershipOptions`
- **add-edit.component.ts**: Added `allowOwnershipOptions` method that mimics other clients in regards to ownership options visibility.
- **jslib**: Updated jslib from dcbd09e to 72bf18f

## Screenshots
<img width="394" alt="0-error" src="https://user-images.githubusercontent.com/26154748/101553093-aeb73380-3979-11eb-8857-c339c5a50179.png">
<img width="394" alt="1-edit" src="https://user-images.githubusercontent.com/26154748/101553094-afe86080-3979-11eb-9c36-24db4f1d6dd0.png">
