### PR TITLE
Add ConsoleLogService dependency from jslib

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "angular2-toaster": "8.0.0",
     "angulartics2": "9.1.0",
     "big-integer": "1.6.36",
+    "browser-process-hrtime": "1.0.0",
     "core-js": "2.6.2",
     "duo_web_sdk": "git+https://github.com/duosecurity/duo_web_sdk.git",
     "font-awesome": "4.7.0",

--- a/src/background/main.background.ts
+++ b/src/background/main.background.ts
@@ -21,6 +21,7 @@ import {
     UserService,
     VaultTimeoutService,
 } from 'jslib/services';
+import { ConsoleLogService } from 'jslib/services/consoleLog.service';
 import { EventService } from 'jslib/services/event.service';
 import { ExportService } from 'jslib/services/export.service';
 import { NotificationsService } from 'jslib/services/notifications.service';
@@ -93,6 +94,7 @@ export default class MainBackground {
     i18nService: I18nServiceAbstraction;
     platformUtilsService: PlatformUtilsServiceAbstraction;
     constantsService: ConstantsService;
+    consoleLogService: ConsoleLogService;
     cryptoService: CryptoServiceAbstraction;
     cryptoFunctionService: CryptoFunctionServiceAbstraction;
     tokenService: TokenServiceAbstraction;
@@ -169,8 +171,9 @@ export default class MainBackground {
         this.secureStorageService = new BrowserStorageService(this.platformUtilsService);
         this.i18nService = new I18nService(BrowserApi.getUILanguage(window));
         this.cryptoFunctionService = new WebCryptoFunctionService(window, this.platformUtilsService);
+        this.consoleLogService = new ConsoleLogService(false);
         this.cryptoService = new CryptoService(this.storageService, this.secureStorageService,
-            this.cryptoFunctionService, this.platformUtilsService);
+            this.cryptoFunctionService, this.platformUtilsService, this.consoleLogService);
         this.tokenService = new TokenService(this.storageService);
         this.appIdService = new AppIdService(this.storageService);
         this.apiService = new ApiService(this.tokenService, this.platformUtilsService,
@@ -178,7 +181,7 @@ export default class MainBackground {
         this.userService = new UserService(this.tokenService, this.storageService);
         this.authService = new AuthService(this.cryptoService, this.apiService, this.userService,
             this.tokenService, this.appIdService, this.i18nService, this.platformUtilsService,
-            this.messagingService, this.vaultTimeoutService);
+            this.messagingService, this.vaultTimeoutService, this.consoleLogService);
         this.settingsService = new SettingsService(this.userService, this.storageService);
         this.cipherService = new CipherService(this.cryptoService, this.userService, this.settingsService,
             this.apiService, this.storageService, this.i18nService, () => this.searchService);
@@ -186,7 +189,7 @@ export default class MainBackground {
             this.storageService, this.i18nService, this.cipherService);
         this.collectionService = new CollectionService(this.cryptoService, this.userService, this.storageService,
             this.i18nService);
-        this.searchService = new SearchService(this.cipherService);
+        this.searchService = new SearchService(this.cipherService, this.consoleLogService);
         this.sendService = new SendService(this.cryptoService, this.userService, this.apiService, this.storageService,
             this.i18nService, this.cryptoFunctionService);
         this.stateService = new StateService();
@@ -220,7 +223,7 @@ export default class MainBackground {
         this.auditService = new AuditService(this.cryptoFunctionService, this.apiService);
         this.exportService = new ExportService(this.folderService, this.cipherService, this.apiService);
         this.notificationsService = new NotificationsService(this.userService, this.syncService, this.appIdService,
-            this.apiService, this.vaultTimeoutService, () => this.logout(true));
+            this.apiService, this.vaultTimeoutService, () => this.logout(true), this.consoleLogService);
         this.environmentService = new EnvironmentService(this.apiService, this.storageService,
             this.notificationsService);
         this.analytics = new Analytics(window, () => BrowserApi.gaFilter(), this.platformUtilsService,

--- a/src/background/runtime.background.ts
+++ b/src/background/runtime.background.ts
@@ -479,7 +479,7 @@ export default class RuntimeBackground {
                 if (policy.enabled) {
                     const org = await this.userService.getOrganization(policy.organizationId);
                     if (org != null && org.enabled && org.usePolicies && !org.isAdmin
-                        && org.status == OrganizationUserStatusType.Confirmed) {
+                        && org.status === OrganizationUserStatusType.Confirmed) {
                         return false;
                     }
                 }

--- a/src/popup/services/popup-search.service.ts
+++ b/src/popup/services/popup-search.service.ts
@@ -1,10 +1,12 @@
 import { CipherService } from 'jslib/abstractions/cipher.service';
 
+import { ConsoleLogService } from 'jslib/services/consoleLog.service';
 import { SearchService } from 'jslib/services/search.service';
 
 export class PopupSearchService extends SearchService {
-    constructor(private mainSearchService: SearchService, cipherService: CipherService) {
-        super(cipherService);
+    constructor(private mainSearchService: SearchService, cipherService: CipherService,
+        consoleLogService: ConsoleLogService) {
+        super(cipherService, consoleLogService);
     }
 
     clearIndex() {

--- a/src/popup/services/services.module.ts
+++ b/src/popup/services/services.module.ts
@@ -50,6 +50,7 @@ import { AuthService } from 'jslib/services/auth.service';
 import { ConstantsService } from 'jslib/services/constants.service';
 import { SearchService } from 'jslib/services/search.service';
 import { StateService } from 'jslib/services/state.service';
+import { ConsoleLogService } from 'jslib/services/consoleLog.service';
 
 import { Analytics } from 'jslib/misc/analytics';
 
@@ -69,9 +70,9 @@ export const authService = new AuthService(getBgService<CryptoService>('cryptoSe
     getBgService<ApiService>('apiService')(), getBgService<UserService>('userService')(),
     getBgService<TokenService>('tokenService')(), getBgService<AppIdService>('appIdService')(),
     getBgService<I18nService>('i18nService')(), getBgService<PlatformUtilsService>('platformUtilsService')(),
-    messagingService, getBgService<VaultTimeoutService>('vaultTimeoutService')());
+    messagingService, getBgService<VaultTimeoutService>('vaultTimeoutService')(), getBgService<ConsoleLogService>('consoleLogService')());
 export const searchService = new PopupSearchService(getBgService<SearchService>('searchService')(),
-    getBgService<CipherService>('cipherService')());
+    getBgService<CipherService>('cipherService')(), getBgService<ConsoleLogService>('consoleLogService')());
 
 export function initFactory(i18nService: I18nService, storageService: StorageService,
     popupUtilsService: PopupUtilsService): Function {


### PR DESCRIPTION
# Overview

Use the default consoleLogService. jslib is moving toward requiring clients to specify a console logger. This change also includes the browser-process-hrtime dependency

# Files Changed

* **package.json**: include `browser-process-hrtime`
* **main.background.ts**: define consoleLogService dependency. This just uses the base class in non-dev mode since there's no dev build concept currently existing in the browser extension.
* **runtime.background.ts**: linter fix
* **popup-search.service.ts/services.module.ts**: including new required ConsoleLogService dependency

# Draft Reason

Need to update jslib reference once bitwarden/jslib#221 is merged