### PR TITLE
Add totp copy to clipboard button to cipher view

### DIFF
--- a/src/popup/components/action-buttons.component.html
+++ b/src/popup/components/action-buttons.component.html
@@ -16,6 +16,11 @@
         [ngClass]="{disabled: (!cipher.login.password || !cipher.viewPassword)}">
         <i class="fa fa-lg fa-key" aria-hidden="true"></i>
     </span>
+    <span class="row-btn" appStopClick appStopProp appA11yTitle="{{'copyVerificationCode' | i18n}}"
+        (click)="copy(cipher, cipher.login.totp, 'verificationCodeTotp', 'TOTP')"
+        [ngClass]="{disabled: (!cipher.login.hasTotp || !cipher.viewPassword)}">
+        <i class="fa fa-lg fa-clock-o" aria-hidden="true"></i>
+    </span>
 </ng-container>
 <ng-container *ngIf="cipher.type === cipherType.Card">
     <span class="row-btn" appStopClick appStopProp appA11yTitle="{{'copyNumber' | i18n}}"

--- a/src/popup/components/action-buttons.component.html
+++ b/src/popup/components/action-buttons.component.html
@@ -18,7 +18,7 @@
     </span>
     <span class="row-btn" appStopClick appStopProp appA11yTitle="{{'copyVerificationCode' | i18n}}"
         (click)="copy(cipher, cipher.login.totp, 'verificationCodeTotp', 'TOTP')"
-        *ngIf="cipher.login.hasTotp">
+        [ngClass]="{disabled: (!cipher.login.hasTotp)}">
         <i class="fa fa-lg fa-clock-o" aria-hidden="true"></i>
     </span>
 </ng-container>

--- a/src/popup/components/action-buttons.component.html
+++ b/src/popup/components/action-buttons.component.html
@@ -18,7 +18,7 @@
     </span>
     <span class="row-btn" appStopClick appStopProp appA11yTitle="{{'copyVerificationCode' | i18n}}"
         (click)="copy(cipher, cipher.login.totp, 'verificationCodeTotp', 'TOTP')"
-        [ngClass]="{disabled: (!cipher.login.hasTotp)}">
+        [ngClass]="{disabled: (!displayTotpCopyButton(cipher))}">
         <i class="fa fa-lg fa-clock-o" aria-hidden="true"></i>
     </span>
 </ng-container>

--- a/src/popup/components/action-buttons.component.html
+++ b/src/popup/components/action-buttons.component.html
@@ -18,7 +18,7 @@
     </span>
     <span class="row-btn" appStopClick appStopProp appA11yTitle="{{'copyVerificationCode' | i18n}}"
         (click)="copy(cipher, cipher.login.totp, 'verificationCodeTotp', 'TOTP')"
-        [ngClass]="{disabled: (!cipher.login.hasTotp || !cipher.viewPassword)}">
+        *ngIf="cipher.login.hasTotp">
         <i class="fa fa-lg fa-clock-o" aria-hidden="true"></i>
     </span>
 </ng-container>

--- a/src/popup/components/action-buttons.component.ts
+++ b/src/popup/components/action-buttons.component.ts
@@ -17,8 +17,9 @@ import { CipherView } from 'jslib/models/view/cipherView';
 
 import { EventService } from 'jslib/abstractions/event.service';
 import { I18nService } from 'jslib/abstractions/i18n.service';
-import { TotpService } from 'jslib/abstractions/index';
 import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
+import { TotpService } from 'jslib/abstractions/totp.service';
+import { UserService } from 'jslib/abstractions/user.service';
 
 import { PopupUtilsService } from '../services/popup-utils.service';
 
@@ -32,12 +33,17 @@ export class ActionButtonsComponent {
     @Input() showView = false;
 
     cipherType = CipherType;
+    userHasPremiumAccess = false;
 
     constructor(private analytics: Angulartics2, private toasterService: ToasterService,
         private i18nService: I18nService, private platformUtilsService: PlatformUtilsService,
         private popupUtilsService: PopupUtilsService, private eventService: EventService,
-        private totpService: TotpService) { }
+        private totpService: TotpService, private userService: UserService) { }
 
+    async ngOnInit() {
+        this.userHasPremiumAccess = await this.userService.canAccessPremium();
+    }
+    
     launch() {
         if (this.cipher.type !== CipherType.Login || !this.cipher.login.canLaunch) {
             return;
@@ -51,7 +57,7 @@ export class ActionButtonsComponent {
     }
 
     async copy(cipher: CipherView, value: string, typeI18nKey: string, aType: string) {
-        if (value == null) {
+        if (value == null || !this.displayTotpCopyButton(cipher)) {
             return;
         } else if (value === cipher.login.totp) {
             value = await this.totpService.getCode(value);
@@ -71,6 +77,11 @@ export class ActionButtonsComponent {
         } else if (typeI18nKey === 'securityCode') {
             this.eventService.collect(EventType.Cipher_ClientCopiedCardCode, cipher.id);
         }
+    }
+
+    displayTotpCopyButton(cipher: CipherView) {
+        return (cipher?.login?.hasTotp ?? false) &&
+            (cipher.organizationUseTotp || this.userHasPremiumAccess);
     }
 
     view() {


### PR DESCRIPTION
# Overview

Offering copying of totp from context menu covers only one method-of-use. Offering another quick-copy button on the tabs/cipher list view closes this gap.

# Files Changed

action-buttons are responsible for populating the quick-action buttons to the right of cipher names in the cipher list view.

* **action-buttons.component.html**: add another view to copy configured totp. Uses loginView.hasTotp to verify plaintext copy is allowed and valid.
* **action-buttons.component.ts**: Converts totp configuration code to totp, copies that password to the clipboard, and pushes a notification that a hidden field was copied.

# Screenshots

## With and without Totp
<img width="376" alt="image" src="https://user-images.githubusercontent.com/18214891/102122915-d1c76480-3e0b-11eb-894d-dd149bf72126.png">


# Draft Reason

Waiting on bitwarden/jslib#225