### PR TITLE
Move share from edit to view. Fix animations

### DIFF
--- a/src/popup/app-routing.animations.ts
+++ b/src/popup/app-routing.animations.ts
@@ -150,6 +150,9 @@ export const routerTransition = trigger('routerTransition', [
     transition('view-cipher => clone-cipher', inSlideUp),
     transition('clone-cipher => view-cipher, clone-cipher => tabs', outSlideDown),
 
+    transition('view-cipher => share-cipher', inSlideUp),
+    transition('share-cipher => view-cipher', outSlideDown),
+
     transition('tabs => add-cipher', inSlideUp),
     transition('add-cipher => tabs', outSlideDown),
 
@@ -158,9 +161,6 @@ export const routerTransition = trigger('routerTransition', [
 
     transition('add-cipher => generator, edit-cipher => generator, clone-cipher => generator', inSlideUp),
     transition('generator => add-cipher, generator => edit-cipher, generator => clone-cipher', outSlideDown),
-
-    transition('edit-cipher => share-cipher', inSlideUp),
-    transition('share-cipher => edit-cipher, share-cipher => view-cipher', outSlideDown),
 
     transition('edit-cipher => attachments, edit-cipher => collections', inSlideLeft),
     transition('attachments => edit-cipher, collections => edit-cipher', outSlideRight),

--- a/src/popup/components/action-buttons.component.ts
+++ b/src/popup/components/action-buttons.component.ts
@@ -43,7 +43,7 @@ export class ActionButtonsComponent {
     async ngOnInit() {
         this.userHasPremiumAccess = await this.userService.canAccessPremium();
     }
-    
+
     launch() {
         if (this.cipher.type !== CipherType.Login || !this.cipher.login.canLaunch) {
             return;

--- a/src/popup/vault/add-edit.component.html
+++ b/src/popup/vault/add-edit.component.html
@@ -374,15 +374,6 @@
         </div>
         <div class="box list" *ngIf="editMode && !cloneMode">
             <div class="box-content single-line">
-                <a class="box-content-row" href="#" appStopClick appBlurClick (click)="share()"
-                    *ngIf="!cipher.organizationId">
-                    <div class="row-main text-primary">
-                        <div class="icon text-primary" aria-hidden="true">
-                            <i class="fa fa-share-alt fa-lg fa-fw"></i>
-                        </div>
-                        <span>{{'shareItem' | i18n}}</span>
-                    </div>
-                </a>
                 <a class="box-content-row" href="#" appStopClick appBlurClick (click)="delete()"
                     [appApiAction]="deletePromise" #deleteBtn>
                     <div class="row-main text-danger">

--- a/src/popup/vault/add-edit.component.ts
+++ b/src/popup/vault/add-edit.component.ts
@@ -118,12 +118,6 @@ export class AddEditComponent extends BaseAddEditComponent {
         this.router.navigate(['/attachments'], { queryParams: { cipherId: this.cipher.id } });
     }
 
-    share() {
-        super.share();
-        if (this.cipher.organizationId == null) {
-            this.router.navigate(['/share-cipher'], { queryParams: { cipherId: this.cipher.id } });
-        }
-    }
 
     editCollections() {
         super.editCollections();

--- a/src/popup/vault/share.component.ts
+++ b/src/popup/vault/share.component.ts
@@ -41,14 +41,12 @@ export class ShareComponent extends BaseShareComponent {
     async submit(): Promise<boolean> {
         const success = await super.submit();
         if (success) {
-            window.setTimeout(() => {
-                this.location.back();
-            }, 200);
+            this.cancel();
         }
         return success;
     }
 
     cancel() {
-        this.location.back();
+        this.router.navigate(['/view-cipher'], { replaceUrl: true, queryParams: { cipherId: this.cipher.id } });
     }
 }

--- a/src/popup/vault/view.component.html
+++ b/src/popup/vault/view.component.html
@@ -295,6 +295,14 @@
                     <span>{{'cloneItem' | i18n}}</span>
                 </div>
             </a>
+            <a class="box-content-row" href="#" appStopClick appBlurClick (click)="share()" *ngIf="!cipher.organizationId">
+                <div class="row-main text-primary">
+                    <div class="icon text-primary" aria-hidden="true">
+                        <i class="fa fa-share-alt fa-lg fa-fw"></i>
+                    </div>
+                    <span>{{'shareItem' | i18n}}</span>
+                </div>
+            </a>
             <a class="box-content-row" href="#" appStopClick appBlurClick (click)="restore()" *ngIf="cipher.isDeleted">
                 <div class="row-main text-primary">
                     <div class="icon text-primary" aria-hidden="true">

--- a/src/popup/vault/view.component.ts
+++ b/src/popup/vault/view.component.ts
@@ -129,6 +129,13 @@ export class ViewComponent extends BaseViewComponent {
         });
     }
 
+    share() {
+        super.share();
+        if (this.cipher.organizationId == null) {
+            this.router.navigate(['/share-cipher'], { replaceUrl: true, queryParams: { cipherId: this.cipher.id } });
+        }
+    }
+
     async fillCipher() {
         const didAutofill = await this.doAutofill();
         if (didAutofill) {


### PR DESCRIPTION
Editing and Sharing a cipher simultaneously results in lost edits. Move
share button to the view page to resolve this confusion.

Previous routing caused the share form to be animated again on
submission, resulting in a stuttering page load. This method correctly
animates all transitions with the concession that the share page
always takes you back to the view page. This is not necessarily the current
behavior, but it is the most likely behavior in the current scheme


# Overview

## Share button

Implementing this is pretty simple copy-paste from `add-edit.component.ts`.

## Animations

Animations on this were a bit of a journey. Current behavior loads in the share page twice with animations and hard-cuts back to the edit page. I wanted smooth in-out transitions for all button navigations.

The first issue is that the slide in animation is repeated upon form submission. To fix this, we need to immediately navigate away. Using a simple back will result in actually going back TWO pages to the index, because share is not yet loaded in. This is solved by a redirect to the expected location, the cipher view page.

Second, hitting cancel OR a successful submit should take you back to the exact state prior to entering the share page. This requires using the `replaceUrl` option to erase share's presence from navigation history.

# Files-Changed

* **app-routing.animations.ts**: View now routes directly to share, need to include these routing transitions. At the same time, it's safe to remove edit => share
* **action-button.component.ts**: linter autofix
* **add-edit.component.ts/add-edit.component.html**: Removing share infrastructure.
* **share.component.ts**: There are a few changes here. First, it makes sense to navigate in the same way whether we succeed in a share or cancel it -- in both cases we're done with the share page. Second, the change in `cancel` behavior is a result of the [animations](#animations) discussion above.
* **view.component.html**: A copy-pasta served up hot from add-edit.component.html
* **view.component.ts**: Mostly more pasta, with the exception of the `replaceUrl: true` option. This replaces the current page in history with the new page.

# Draft Reason
awaiting bitwarden/jslib#229

# Screen shots

## View page on un-shared item
<img width="376" alt="image" src="https://user-images.githubusercontent.com/18214891/102286209-71185480-3efd-11eb-927f-d49ee9a128a7.png">

## Edit page on un-shared item
<img width="376" alt="image" src="https://user-images.githubusercontent.com/18214891/102286249-868d7e80-3efd-11eb-9bc6-c483845ea42e.png">

## View page on shared item
<img width="376" alt="image" src="https://user-images.githubusercontent.com/18214891/102286274-9ad17b80-3efd-11eb-9d0a-8839a7f476a3.png">