### PR TITLE
Native Messaging - Support multiple extensions concurrently

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1417,6 +1417,18 @@
   "nativeMessagingInvalidEncryptionTitle": {
     "message": "Desktop communication interupted"
   },
+  "biometricsNotEnabledTitle": {
+    "message": "Biometrics not enabled"
+  },
+  "biometricsNotEnabledDesc": {
+    "message": "Browser biometric requires desktop biometric to be enabled in the settings first."
+  },
+  "biometricsNotSupportedTitle": {
+    "message": "Biometrics not supported"
+  },
+  "biometricsNotSupportedDesc": {
+    "message": "Browser biometric is not supported on this device."
+  },
   "personalOwnershipSubmitError": {
     "message": "Due to an Enterprise Policy, you are restricted from saving items to your personal vault. Change the Ownership option to an organization and choose from available Collections."
   }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1415,19 +1415,19 @@
     "message": "Desktop application invalidated the secure communication channel. Please retry this operation"
   },
   "nativeMessagingInvalidEncryptionTitle": {
-    "message": "Desktop communication interupted"
+    "message": "Desktop communication interrupted"
   },
   "biometricsNotEnabledTitle": {
     "message": "Biometrics not enabled"
   },
   "biometricsNotEnabledDesc": {
-    "message": "Browser biometric requires desktop biometric to be enabled in the settings first."
+    "message": "Browser biometrics requires desktop biometric to be enabled in the settings first."
   },
   "biometricsNotSupportedTitle": {
     "message": "Biometrics not supported"
   },
   "biometricsNotSupportedDesc": {
-    "message": "Browser biometric is not supported on this device."
+    "message": "Browser biometrics is not supported on this device."
   },
   "personalOwnershipSubmitError": {
     "message": "Due to an Enterprise Policy, you are restricted from saving items to your personal vault. Change the Ownership option to an organization and choose from available Collections."

--- a/src/background/main.background.ts
+++ b/src/background/main.background.ts
@@ -248,7 +248,7 @@ export default class MainBackground {
             this.analytics, this.notificationsService, this.systemService, this.vaultTimeoutService,
             this.environmentService, this.policyService, this.userService);
         this.nativeMessagingBackground = new NativeMessagingBackground(this.storageService, this.cryptoService, this.cryptoFunctionService,
-            this.vaultTimeoutService, this.runtimeBackground, this.i18nService, this.userService, this.messagingService);
+            this.vaultTimeoutService, this.runtimeBackground, this.i18nService, this.userService, this.messagingService, this.appIdService);
         this.commandsBackground = new CommandsBackground(this, this.passwordGenerationService,
             this.platformUtilsService, this.analytics, this.vaultTimeoutService);
 

--- a/src/background/nativeMessaging.background.ts
+++ b/src/background/nativeMessaging.background.ts
@@ -159,6 +159,24 @@ export class NativeMessagingBackground {
             case 'biometricUnlock':
                 await this.storageService.remove(ConstantsService.biometricAwaitingAcceptance);
 
+                if (message.response === 'not enabled') {
+                    this.messagingService.send('showDialog', {
+                        text: this.i18nService.t('biometricsNotEnabledDesc'),
+                        title: this.i18nService.t('biometricsNotEnabledTitle'),
+                        confirmText: this.i18nService.t('ok'),
+                        type: 'error',
+                    });
+                    break;
+                } else if (message.response === 'not supported') {
+                    this.messagingService.send('showDialog', {
+                        text: this.i18nService.t('biometricsNotSupportedDesc'),
+                        title: this.i18nService.t('biometricsNotSupportedTitle'),
+                        confirmText: this.i18nService.t('ok'),
+                        type: 'error',
+                    });
+                    break;
+                }
+
                 const enabled = await this.storageService.get(ConstantsService.biometricUnlockKey);
                 if (enabled === null || enabled === false) {
                     if (message.response === 'unlocked') {

--- a/src/background/nativeMessaging.background.ts
+++ b/src/background/nativeMessaging.background.ts
@@ -1,4 +1,5 @@
 import { ConstantsService } from 'jslib/services/constants.service';
+import { AppIdService } from 'jslib/abstractions/appId.service';
 import { CryptoFunctionService } from 'jslib/abstractions/cryptoFunction.service';
 import { CryptoService } from 'jslib/abstractions/crypto.service';
 import { I18nService } from 'jslib/abstractions/i18n.service';
@@ -12,7 +13,6 @@ import { SymmetricCryptoKey } from 'jslib/models/domain';
 
 import { BrowserApi } from '../browser/browserApi';
 import RuntimeBackground from './runtime.background';
-import { AppIdService } from 'jslib/abstractions';
 
 const MessageValidTimeout = 10 * 1000;
 const EncryptionAlgorithm = 'sha1';


### PR DESCRIPTION
The old implementation assumed that only a single browser extension was running, which resulted in the `sharedSecret` being constantly invalidated. This change assumes the browser sends a unique `appId` which is used to decide which shared secret to use.

Also display an error message informing the user to turn on desktop biometrics before browser biometrics can be enabled.

Depends on https://github.com/bitwarden/desktop/pull/615