### PR TITLE
Fix native messaging handling interuptions wrong

### DIFF
--- a/src/background/nativeMessaging.background.ts
+++ b/src/background/nativeMessaging.background.ts
@@ -90,11 +90,12 @@ export class NativeMessagingBackground {
                             confirmText: this.i18nService.t('ok'),
                             type: 'error',
                         });
+                        break;
                     case 'verifyFingerprint': {
                         if (this.sharedSecret == null) {
                             this.showFingerprintDialog();
                         }
-                        return;
+                        break;
                     }
                     default:
                         // Ignore since it belongs to another device


### PR DESCRIPTION
Due to a missing break statement the browser extension would show the fingerprint verification message instead of the communication interrupted error.

I also changed the return statement to break to be more consistent with the other cases.