### PR TITLE
Fix safari sso

### DIFF
--- a/src/browser/safariApp.ts
+++ b/src/browser/safariApp.ts
@@ -25,12 +25,20 @@ export class SafariApp {
         return new Promise((resolve) => {
             const now = new Date();
             const messageId = now.getTime().toString() + '_' + Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
-            (window as any).webkit.messageHandlers.bitwardenApp.postMessage(JSON.stringify({
-                id: messageId,
-                command: command,
-                data: data,
-                responseData: null,
-            }));
+            if (typeof safari === typeof undefined) {
+                (window as any).webkit.messageHandlers.bitwardenApp.postMessage(JSON.stringify({
+                    id: messageId,
+                    command: command,
+                    data: data,
+                    responseData: null,
+                }));
+            } else {
+                safari.extension.dispatchMessage('bitwarden', {
+                    command: command,
+                    data: data,
+                    responseData: null,
+                });
+            }
             if (resolveNow) {
                 resolve();
             } else {

--- a/src/content/sso.ts
+++ b/src/content/sso.ts
@@ -3,6 +3,15 @@ window.addEventListener('message', (event) => {
         return;
 
     if (event.data.command && (event.data.command === 'authResult')) {
+        if (typeof chrome === typeof undefined) {
+            safari.extension.dispatchMessage('bitwarden', {
+                command: event.data.command,
+                code: event.data.code,
+                state: event.data.state,
+                referrer: event.source.location.hostname,
+            });
+            return;
+        }
         chrome.runtime.sendMessage({
             command: event.data.command,
             code: event.data.code,

--- a/src/popup/accounts/sso.component.ts
+++ b/src/popup/accounts/sso.component.ts
@@ -41,11 +41,11 @@ export class SsoComponent extends BaseSsoComponent {
         this.redirectUri = url + '/sso-connector.html';
         this.clientId = 'browser';
 
-        super.onSuccessfulLogin = () => {
+        super.onSuccessfulLogin = async () => {
+            await syncService.fullSync(true);
             BrowserApi.reloadOpenWindows();
             const thisWindow = window.open('', '_self');
             thisWindow.close();
-            return syncService.fullSync(true);
         };
     }
 }

--- a/src/safari/safari/SafariExtensionViewController.swift
+++ b/src/safari/safari/SafariExtensionViewController.swift
@@ -178,7 +178,13 @@ class SafariExtensionViewController: SFSafariExtensionViewController, WKScriptMe
             m.responseData = popoverOpenCount > 0 ? "true" : "false"
             replyMessage(message: m)
         } else if command == "createNewTab" {
-            if let data = m.data, let url = URL(string: data) {
+            if let data = m.data, var url = URL(string: data) {
+                if !data.starts(with: "https://") && !data.starts(with: "http://") {
+                    SFSafariExtension.getBaseURI { baseURI in
+                        guard let baseURI = baseURI else {return}
+                        url = URL(string: baseURI.absoluteString + "app/" + url.absoluteString) ?? url
+                    }
+                }
                 SFSafariApplication.getActiveWindow { win in
                     win?.openTab(with: url, makeActiveIfPossible: true, completionHandler: { _ in
                         // Tab opened

--- a/src/safari/safari/SafariExtensionViewController.swift
+++ b/src/safari/safari/SafariExtensionViewController.swift
@@ -37,13 +37,14 @@ class SafariExtensionViewController: SFSafariExtensionViewController, WKScriptMe
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
         let bundleUrl = Bundle.main.resourceURL!.absoluteURL
 
-        var urlComponents = URLComponents(string: bundleUrl.appendingPathComponent(relativeUrl).absoluteString)
+        if var urlComponents = URLComponents(string: bundleUrl.absoluteString + relativeUrl) {
+            if (urlComponents.queryItems?.first(where: { $0.name == "appVersion" })?.value == nil) {
+                urlComponents.queryItems = urlComponents.queryItems ?? []
+                urlComponents.queryItems!.append(URLQueryItem(name: "appVersion", value: version))
+            }
 
-        if (urlComponents?.queryItems?.first(where: { $0.name == "appVersion" })?.value == nil) {
-            urlComponents?.queryItems?.append(URLQueryItem(name: "appVersion", value: version))
+            webView.loadFileURL(urlComponents.url!, allowingReadAccessTo: bundleUrl)
         }
-
-        webView.loadFileURL(urlComponents!.url!, allowingReadAccessTo: bundleUrl)
     }
 
     func webView(_ webView: WKWebView, didFinish _: WKNavigation!) {


### PR DESCRIPTION
# Overview

Closes #1473. Safari SSO sign on from browser is still broken. Full SSO process is triggered, but final tab open to the SSO extension component does not work. We need to get Safari responding correctly to messages in all contexts.

# Files Changed

* **safariApp.ts**: webkit message handlers is not available from a tab opened to an extension resource. In this context, we should use safari.extension.dispatchMessage as done elsewhere.
* **content/sso.ts**: Safari app extension does not respond to chrome.runtime. Use dispatchMessage here too.
* **SafariExtensionsViewController.swift**: `createNewTab` messages for extension resources are delivered as path?query URIs only, which Safari does not interpret correctly. Detect these types of paths and navigate to the appropriate resource
