### PR TITLE
Disables autofill when autocomplete="off" is detected

### DIFF
--- a/src/content/autofill.js
+++ b/src/content/autofill.js
@@ -297,7 +297,9 @@
                 addProp(field, 'type', toLowerString(getElementAttrValue(el, 'type')));
                 addProp(field, 'value', getElementValue(el));
                 addProp(field, 'checked', el.checked, false);
-                addProp(field, 'autoCompleteType', el.getAttribute('x-autocompletetype') || el.getAttribute('autocompletetype') || el.getAttribute('autocomplete'), 'off');
+                // Change from addProp(..., 'autoCompleteType', ..., 'off') to addProp(..., 'autoCompleteType', ..., 'on') to fix #1469
+                // Maunal autocomplete override from HTML side can be ignored when they're set to 'on' (default) instead of 'off' (special case)
+                addProp(field, 'autoCompleteType', el.getAttribute('x-autocompletetype') || el.getAttribute('autocompletetype') || el.getAttribute('autocomplete'), 'on');
                 addProp(field, 'disabled', el.disabled);
                 addProp(field, 'readonly', el.b || el.readOnly);
                 addProp(field, 'selectInfo', getSelectElementOptions(el));

--- a/src/services/autofill.service.ts
+++ b/src/services/autofill.service.ts
@@ -420,7 +420,9 @@ export default class AutofillService implements AutofillServiceInterface {
             pageDetails.fields.forEach((f: any) => {
                 if (f.viewable && (f.type === 'text' || f.type === 'email' || f.type === 'tel') &&
                     this.fieldIsFuzzyMatch(f, UsernameFieldNames)) {
-                    usernames.push(f);
+                    if (f.autoCompleteType !== 'off') {
+                        usernames.push(f);
+                    }
                 }
             });
         }
@@ -962,7 +964,9 @@ export default class AutofillService implements AutofillServiceInterface {
             if (!f.disabled && (canBeReadOnly || !f.readonly) && (isPassword || isLikePassword())
                 && (canBeHidden || f.viewable) && (!mustBeEmpty || f.value == null || f.value.trim() === '')
                 && (fillNewPassword || f.autoCompleteType !== 'new-password')) {
-                arr.push(f);
+                if (f.autoCompleteType !== 'off') {
+                    arr.push(f);
+                }
             }
         });
         return arr;
@@ -980,7 +984,9 @@ export default class AutofillService implements AutofillServiceInterface {
             if (!f.disabled && (canBeReadOnly || !f.readonly) &&
                 (withoutForm || f.form === passwordField.form) && (canBeHidden || f.viewable) &&
                 (f.type === 'text' || f.type === 'email' || f.type === 'tel')) {
-                usernameField = f;
+                if (f.autoCompleteType !== 'off') {
+                    usernameField = f;
+                }
 
                 if (this.findMatchingFieldIndex(f, UsernameFieldNames) > -1) {
                     // We found an exact match. No need to keep looking.

--- a/src/services/autofill.service.ts
+++ b/src/services/autofill.service.ts
@@ -419,10 +419,9 @@ export default class AutofillService implements AutofillServiceInterface {
             // No password fields on this page. Let's try to just fuzzy fill the username.
             pageDetails.fields.forEach((f: any) => {
                 if (f.viewable && (f.type === 'text' || f.type === 'email' || f.type === 'tel') &&
+                    (f.autoCompleteType !== 'off') &&
                     this.fieldIsFuzzyMatch(f, UsernameFieldNames)) {
-                    if (f.autoCompleteType !== 'off') {
-                        usernames.push(f);
-                    }
+                    usernames.push(f);
                 }
             });
         }
@@ -458,7 +457,7 @@ export default class AutofillService implements AutofillServiceInterface {
         const fillFields: { [id: string]: AutofillField; } = {};
 
         pageDetails.fields.forEach((f: any) => {
-            if (this.isExcludedType(f.type, ExcludedAutofillTypes)) {
+            if (this.isExcludedType(f.type, ExcludedAutofillTypes) || f.autoCompleteType === 'off') {
                 return;
             }
 
@@ -690,7 +689,7 @@ export default class AutofillService implements AutofillServiceInterface {
         const fillFields: { [id: string]: AutofillField; } = {};
 
         pageDetails.fields.forEach((f: any) => {
-            if (this.isExcludedType(f.type, ExcludedAutofillTypes)) {
+            if (this.isExcludedType(f.type, ExcludedAutofillTypes) || f.autoCompleteType === 'off') {
                 return;
             }
 
@@ -963,10 +962,9 @@ export default class AutofillService implements AutofillServiceInterface {
             };
             if (!f.disabled && (canBeReadOnly || !f.readonly) && (isPassword || isLikePassword())
                 && (canBeHidden || f.viewable) && (!mustBeEmpty || f.value == null || f.value.trim() === '')
-                && (fillNewPassword || f.autoCompleteType !== 'new-password')) {
-                if (f.autoCompleteType !== 'off') {
-                    arr.push(f);
-                }
+                && (fillNewPassword || f.autoCompleteType !== 'new-password')
+                && (f.autoCompleteType !== 'off')) {
+                arr.push(f);
             }
         });
         return arr;
@@ -983,10 +981,10 @@ export default class AutofillService implements AutofillServiceInterface {
 
             if (!f.disabled && (canBeReadOnly || !f.readonly) &&
                 (withoutForm || f.form === passwordField.form) && (canBeHidden || f.viewable) &&
+                (f.autoCompleteType !== 'off') &&
                 (f.type === 'text' || f.type === 'email' || f.type === 'tel')) {
-                if (f.autoCompleteType !== 'off') {
-                    usernameField = f;
-                }
+
+                usernameField = f;
 
                 if (this.findMatchingFieldIndex(f, UsernameFieldNames) > -1) {
                     // We found an exact match. No need to keep looking.


### PR DESCRIPTION
This pull request fixes #1469.

## The problem this pr is trying to solve:
As described in #1469, currently, the plugin does not respect [autocomplete=off attribute](https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion#Disabling_autocompletion).

## Changes made:
On "client" side, autofill.js, I altered some code for collecting autocompletion attribute. 
On "server" side, autofill.service.ts, I added rules to prevent autofill service from generating auto-fill action scripts when this attribute is set to "off".

## Testing
I have personally performed some integration testings on some custom htmls with this attributes. 