### PR TITLE
Improved readability as #1441

### DIFF
--- a/src/services/autofill.service.ts
+++ b/src/services/autofill.service.ts
@@ -254,7 +254,7 @@ export default class AutofillService implements AutofillServiceInterface {
             }
         }
 
-        const autoFillResponse = await this.doAutoFill({
+        const totpCode = await this.doAutoFill({
             cipher: cipher,
             pageDetails: pageDetails,
             skipTotp: !fromCommand,
@@ -265,12 +265,12 @@ export default class AutofillService implements AutofillServiceInterface {
             fillNewPassword: fromCommand,
         });
 
-        // Only update last used index if doAutoFill didn't throw an exception
+        // Update last used index as autofill has succeed
         if (fromCommand) {
             this.cipherService.updateLastUsedIndexForUrl(tab.url);
         }
 
-        return autoFillResponse;
+        return totpCode;
     }
 
     // Helpers


### PR DESCRIPTION
## Why this pull request:
As #1441 pointed out, the comment `Only update last used index if doAutoFill didn't throw an exception` confuses maintainers/ contributors. 
https://github.com/bitwarden/browser/blob/74a9ff799227759628de01669208fc1e1ea14829/src/services/autofill.service.ts#L257-L271

This pull request attempt to improve the readability of the code in this section, to resolve #1441 .

## What this pull request does:
This pull request renamed the variable for `doAutoFill` from _autoFillResponse_ to _totpCode_ as:
1. The **response** keyword implies the code may continue to execute with a failed-to-autofill state.
2. The return variable from `doAutoFill` can only be **TOTP** code or **null**, as described here: https://github.com/bitwarden/browser/issues/1441#issuecomment-717868796. Using totpCode as the variable name properly describe the intent.

This pull request also altered the comment in question to `Update last used index as autofill has succeed` to resolve the confusion.