### PR TITLE
Fix action buttons not working when TOTP is not available

### DIFF
--- a/src/popup/components/action-buttons.component.ts
+++ b/src/popup/components/action-buttons.component.ts
@@ -57,7 +57,7 @@ export class ActionButtonsComponent {
     }
 
     async copy(cipher: CipherView, value: string, typeI18nKey: string, aType: string) {
-        if (value == null || !this.displayTotpCopyButton(cipher)) {
+        if (value == null || aType === 'TOTP' && !this.displayTotpCopyButton(cipher)) {
             return;
         } else if (value === cipher.login.totp) {
             value = await this.totpService.getCode(value);


### PR DESCRIPTION
Resolves a bug introduced in https://github.com/bitwarden/browser/pull/1493 where it was not possible to copy *any* field from an item without TOTP.