### PR TITLE
Popover arrow background color

### DIFF
--- a/src/popup/scss/base.scss
+++ b/src/popup/scss/base.scss
@@ -22,7 +22,7 @@ body {
 
     @include themify($themes) {
         color: themed('textColor');
-        background-color: themed('backgroundColor');
+        background-color: themed('headerBackgroundColor');
     }
 
     &.body-sm {


### PR DESCRIPTION
Small tweak to get the popover arrow to appear with the same background color as the header. Applies to Firefox.

Before:
![Before](https://user-images.githubusercontent.com/137855/104470414-f9038400-55b9-11eb-9218-e466d90046e0.png)
After:
![After](https://user-images.githubusercontent.com/137855/104470423-fbfe7480-55b9-11eb-9e05-9dfbeb5987d4.png)
