### PR TITLE
Handle desktop logged into a different account for biometrics

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1420,6 +1420,12 @@
   "nativeMessagingInvalidEncryptionTitle": {
     "message": "Desktop communication interrupted"
   },
+  "nativeMessagingWrongUserDesc": {
+    "message": "The desktop application is logged into a different account. Please ensure both applications are logged into the same account."
+  },
+  "nativeMessagingWrongUserTitle": {
+    "message": "Account missmatch"
+  },
   "biometricsNotEnabledTitle": {
     "message": "Biometrics not enabled"
   },

--- a/src/background/nativeMessaging.background.ts
+++ b/src/background/nativeMessaging.background.ts
@@ -106,6 +106,13 @@ export class NativeMessagingBackground {
                         }
                         break;
                     }
+                    case 'wrongUserId':
+                        this.messagingService.send('showDialog', {
+                            text: this.i18nService.t('nativeMessagingWrongUserDesc'),
+                            title: this.i18nService.t('nativeMessagingWrongUserTitle'),
+                            confirmText: this.i18nService.t('ok'),
+                            type: 'error',
+                        });
                     default:
                         // Ignore since it belongs to another device
                         if (message.appId !== this.appId) {
@@ -247,7 +254,11 @@ export class NativeMessagingBackground {
         this.publicKey = publicKey;
         this.privateKey = privateKey;
 
-        this.sendUnencrypted({command: 'setupEncryption', publicKey: Utils.fromBufferToB64(publicKey)});
+        this.sendUnencrypted({
+            command: 'setupEncryption',
+            publicKey: Utils.fromBufferToB64(publicKey),
+            userId: await this.userService.getUserId()
+        });
 
         return new Promise((resolve, reject) => this.secureSetupResolve = resolve);
     }


### PR DESCRIPTION
If the desktop and browser applications are logged into two different accounts, the biometric unlock sequence would still work but send the wrong encryption hash which would result in the vault not decrypting secrets correctly.

This was solved by including the `userId` in `setupEncryption` which the desktop application verifies before allowing the communication to be secured. Which also necessitated a new error message.

Companion PR: https://github.com/bitwarden/desktop/pull/645