### PR TITLE
Resolve login page having wrong background

### DIFF
--- a/src/popup/scss/base.scss
+++ b/src/popup/scss/base.scss
@@ -342,6 +342,9 @@ app-root {
     width: 100%;
     height: 100%;
     z-index: 980;
+    @include themify($themes) {
+        background-color: themed('backgroundColor');
+    }
 }
 
 content {


### PR DESCRIPTION
https://github.com/bitwarden/browser/pull/1529 Set the body to have the same backgorund color as the header to resolve the popover arrow appearing with a different color in firefox. Unfortunately this had a bleed though effect on the login page.

Resolved by adding a background color to the app-root element instead which always appears.