### PR TITLE
Make nativeMessaging optional on all platforms except firefox

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -75,6 +75,7 @@ function distOpera() {
         delete manifest.applications;
         delete manifest.content_security_policy;
         removeShortcuts(manifest);
+        moveNativeMessagingToOptional(manifest);
         return manifest;
     });
 }
@@ -85,6 +86,7 @@ function distChrome() {
         delete manifest.content_security_policy;
         delete manifest.sidebar_action;
         delete manifest.commands._execute_sidebar_action;
+        moveNativeMessagingToOptional(manifest);
         return manifest;
     });
 }
@@ -95,6 +97,7 @@ function distEdge() {
         delete manifest.content_security_policy;
         delete manifest.sidebar_action;
         delete manifest.commands._execute_sidebar_action;
+        moveNativeMessagingToOptional(manifest);
         return manifest;
     });
 }
@@ -106,6 +109,14 @@ function removeShortcuts(manifest) {
             manifest.content_scripts.splice(1, 1);
         }
     }
+}
+
+function moveNativeMessagingToOptional(manifest) {
+    const index = manifest.permissions.indexOf("nativeMessaging");
+    index > -1 ? manifest.permissions.splice(index, 1) : false
+    manifest.optional_permissions = [
+        "nativeMessaging"
+    ];
 }
 
 function distSafariMas(cb) {

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1442,7 +1442,7 @@
     "message": "Permission not provided"
   },
   "nativeMessaginPermissionErrorDesc": {
-    "message": "Without permission to communicate with the Bitwarden Desktop Application we cannot provide biometrics in the browser extension. Please retry again."
+    "message": "Without permission to communicate with the Bitwarden Desktop Application we cannot provide biometrics in the browser extension. Please try again."
   },
   "personalOwnershipSubmitError": {
     "message": "Due to an Enterprise Policy, you are restricted from saving items to your personal vault. Change the Ownership option to an organization and choose from available Collections."

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1438,6 +1438,12 @@
   "biometricsNotSupportedDesc": {
     "message": "Browser biometrics is not supported on this device."
   },
+  "nativeMessaginPermissionErrorTitle": {
+    "message": "Permission not provided"
+  },
+  "nativeMessaginPermissionErrorDesc": {
+    "message": "Without permission to communicate with the Bitwarden Desktop Application we cannot provide biometrics in the browser extension. Please retry again."
+  },
   "personalOwnershipSubmitError": {
     "message": "Due to an Enterprise Policy, you are restricted from saving items to your personal vault. Change the Ownership option to an organization and choose from available Collections."
   },

--- a/src/popup/settings/settings.component.ts
+++ b/src/popup/settings/settings.component.ts
@@ -23,6 +23,7 @@ import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
 import { StorageService } from 'jslib/abstractions/storage.service';
 import { UserService } from 'jslib/abstractions/user.service';
 import { VaultTimeoutService } from 'jslib/abstractions/vaultTimeout.service';
+import { resolve } from '@angular/compiler-cli/src/ngtsc/file_system';
 
 const RateUrls = {
     [DeviceType.ChromeExtension]:
@@ -208,6 +209,24 @@ export class SettingsComponent implements OnInit {
 
     async updateBiometric() {
         if (this.biometric) {
+
+            // Request permission to use the optional permission for nativeMessaging
+            if (!this.platformUtilsService.isFirefox()) {
+                const granted = await new Promise((resolve, reject) => {
+                    chrome.permissions.request({permissions: ['nativeMessaging']}, function(granted) {
+                        resolve(granted);
+                    });
+                });
+                
+                if (!granted) {
+                    await this.platformUtilsService.showDialog(
+                        this.i18nService.t('nativeMessaginPermissionErrorDesc'), this.i18nService.t('nativeMessaginPermissionErrorTitle'),
+                        this.i18nService.t('ok'), null);
+                    this.biometric = false;
+                    return;
+                }
+            }
+
             const submitted = Swal.fire({
                 heightAuto: false,
                 buttonsStyling: false,


### PR DESCRIPTION
Since FF doesn't support having `nativeMessaging` as a optional permission. https://bugzilla.mozilla.org/show_bug.cgi?id=1630415