### PR TITLE
Fix action button disable css

### DIFF
--- a/src/popup/scss/box.scss
+++ b/src/popup/scss/box.scss
@@ -378,11 +378,13 @@
             &.disabled {
                 @include themify($themes) {
                     color: themed('disabledIconColor');
+                    opacity: themed('disabledBoxOpacity');
                 }
 
                 &:hover {
                     @include themify($themes) {
                         color: themed('disabledIconColor');
+                        opacity: themed('disabledBoxOpacity');
                     }
                 }
             }

--- a/src/popup/scss/variables.scss
+++ b/src/popup/scss/variables.scss
@@ -1,4 +1,4 @@
-﻿@import '~nord/src/sass/nord.scss';
+@import '~nord/src/sass/nord.scss';
 
 $font-family-sans-serif: 'Open Sans','Helvetica Neue',Helvetica,Arial,sans-serif;
 $font-family-monospace: Menlo, Monaco, Consolas, 'Courier New', monospace;
@@ -9,7 +9,7 @@ $text-color: #000000;
 $border-color: #f0f0f0;
 $border-color-dark: #ddd;
 $list-item-hover: #fbfbfb;
-$list-icon-color: #c7c7cd;
+$list-icon-color: #767679;
 $border-radius: 3px;
 $line-height-base: 1.42857143;
 

--- a/src/popup/scss/variables.scss
+++ b/src/popup/scss/variables.scss
@@ -1,4 +1,4 @@
-@import '~nord/src/sass/nord.scss';
+﻿@import '~nord/src/sass/nord.scss';
 
 $font-family-sans-serif: 'Open Sans','Helvetica Neue',Helvetica,Arial,sans-serif;
 $font-family-monospace: Menlo, Monaco, Consolas, 'Courier New', monospace;
@@ -10,6 +10,7 @@ $border-color: #f0f0f0;
 $border-color-dark: #ddd;
 $list-item-hover: #fbfbfb;
 $list-icon-color: #767679;
+$disabled-box-opacity: 1;
 $border-radius: 3px;
 $line-height-base: 1.42857143;
 
@@ -59,6 +60,7 @@ $themes: (
         headerInputPlaceholderColor: lighten($brand-primary, 35%),
         listItemBackgroundHoverColor: $list-item-hover,
         disabledIconColor: $list-icon-color,
+        disabledBoxOpacity: $disabled-box-opacity,
         headingColor: $gray-light,
         labelColor: $gray-light,
         mutedColor: $text-muted,
@@ -106,7 +108,8 @@ $themes: (
         headerInputColor: #ffffff,
         headerInputPlaceholderColor: #707070,
         listItemBackgroundHoverColor: #3c3c3c,
-        disabledIconColor: #c7c7cd,
+        disabledIconColor: #cacaca,
+        disabledBoxOpacity: 0.5,
         headingColor: #a3a3a3,
         labelColor: #a3a3a3,
         mutedColor: #a3a3a3,
@@ -154,7 +157,8 @@ $themes: (
         headerInputColor: $nord2,
         headerInputPlaceholderColor: $nord3,
         listItemBackgroundHoverColor: $nord3,
-        disabledIconColor: $nord5,
+        disabledIconColor: $nord4,
+        disabledBoxOpacity: 0.5,
         headingColor: $nord4,
         labelColor: $nord4,
         mutedColor: $nord4,


### PR DESCRIPTION
# Overview

Closes #1550 

Action-button does not sufficiently alter action-box buttons that are disabled. This introduces new theme variable disabledOpacity to allow setting opacity of disabled object. Unfortunately, not all disabled elements look good with the same color/opacity combinations, so this isn't applied to all `&[disabled]` rules.

I've also darkened the action-button for the light theme to comply with WCAG AA standards. Because light uses a new color to denote a button is disabled, opacity is set to 1. Other themes don't do this so they differentiate through opacity.

# Files changed

* **box.scss**: Use theme opacity **and** color to differentiate disabled vs enabled
* **variables.scss**: Set reasonable colors/themes for disabled elements
  * **light**: uses a new color, darken relative to previous and so does not change opacity
  * **dark/nord**: Identical color is used for disabled elements, but opacity is reduced to 0.5. The same color is used because the previous colors are too difficult to distinguish

# screen shots

## Light

<img width="547" alt="Screen Shot 2021-01-25 at 11 35 57" src="https://user-images.githubusercontent.com/18214891/105746070-9937a200-5f04-11eb-9e52-b55abba61dac.png">

## Dark

<img width="547" alt="Screen Shot 2021-01-25 at 11 35 30" src="https://user-images.githubusercontent.com/18214891/105746081-9dfc5600-5f04-11eb-9382-93db33f3bda0.png">

## Nord
 
<img width="547" alt="Screen Shot 2021-01-25 at 11 36 15" src="https://user-images.githubusercontent.com/18214891/105746093-a2287380-5f04-11eb-9652-3ee98b199adb.png">