### PR TITLE
Remove nativeMessaging requirement from Firefox

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -65,6 +65,7 @@ function dist(browserName, manifest) {
 function distFirefox() {
     return dist('firefox', (manifest) => {
         delete manifest.content_security_policy;
+        delete manifest.optional_permissions;
         removeShortcuts(manifest);
         return manifest;
     });
@@ -75,7 +76,6 @@ function distOpera() {
         delete manifest.applications;
         delete manifest.content_security_policy;
         removeShortcuts(manifest);
-        moveNativeMessagingToOptional(manifest);
         return manifest;
     });
 }
@@ -86,7 +86,6 @@ function distChrome() {
         delete manifest.content_security_policy;
         delete manifest.sidebar_action;
         delete manifest.commands._execute_sidebar_action;
-        moveNativeMessagingToOptional(manifest);
         return manifest;
     });
 }
@@ -97,7 +96,6 @@ function distEdge() {
         delete manifest.content_security_policy;
         delete manifest.sidebar_action;
         delete manifest.commands._execute_sidebar_action;
-        moveNativeMessagingToOptional(manifest);
         return manifest;
     });
 }
@@ -109,14 +107,6 @@ function removeShortcuts(manifest) {
             manifest.content_scripts.splice(1, 1);
         }
     }
-}
-
-function moveNativeMessagingToOptional(manifest) {
-    const index = manifest.permissions.indexOf("nativeMessaging");
-    index > -1 ? manifest.permissions.splice(index, 1) : false
-    manifest.optional_permissions = [
-        "nativeMessaging"
-    ];
 }
 
 function distSafariMas(cb) {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -89,7 +89,9 @@
     "http://*/*",
     "https://*/*",
     "webRequest",
-    "webRequestBlocking",
+    "webRequestBlocking"
+  ],
+  "optional_permissions": [
     "nativeMessaging"
   ],
   "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",

--- a/src/popup/settings/settings.component.html
+++ b/src/popup/settings/settings.component.html
@@ -42,7 +42,7 @@
                 <label for="pin">{{'unlockWithPin' | i18n}}</label>
                 <input id="pin" type="checkbox" (change)="updatePin()" [(ngModel)]="pin">
             </div>
-            <div class="box-content-row box-content-row-checkbox" appBoxRow>
+            <div class="box-content-row box-content-row-checkbox" appBoxRow *ngIf="supportsBiometric">
                 <label for="biometric">{{'unlockWithBiometrics' | i18n}}</label>
                 <input id="biometric" type="checkbox" (change)="updateBiometric()" [(ngModel)]="biometric">
             </div>

--- a/src/popup/settings/settings.component.ts
+++ b/src/popup/settings/settings.component.ts
@@ -23,7 +23,6 @@ import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
 import { StorageService } from 'jslib/abstractions/storage.service';
 import { UserService } from 'jslib/abstractions/user.service';
 import { VaultTimeoutService } from 'jslib/abstractions/vaultTimeout.service';
-import { resolve } from '@angular/compiler-cli/src/ngtsc/file_system';
 
 const RateUrls = {
     [DeviceType.ChromeExtension]:
@@ -216,11 +215,9 @@ export class SettingsComponent implements OnInit {
             // Request permission to use the optional permission for nativeMessaging
             if (!this.platformUtilsService.isFirefox()) {
                 const granted = await new Promise((resolve, reject) => {
-                    chrome.permissions.request({permissions: ['nativeMessaging']}, function(granted) {
-                        resolve(granted);
-                    });
+                    chrome.permissions.request({permissions: ['nativeMessaging']}, resolve);
                 });
-                
+
                 if (!granted) {
                     await this.platformUtilsService.showDialog(
                         this.i18nService.t('nativeMessaginPermissionErrorDesc'), this.i18nService.t('nativeMessaginPermissionErrorTitle'),

--- a/src/popup/settings/settings.component.ts
+++ b/src/popup/settings/settings.component.ts
@@ -52,6 +52,7 @@ export class SettingsComponent implements OnInit {
     vaultTimeoutActions: any[];
     vaultTimeoutAction: string;
     pin: boolean = null;
+    supportsBiometric: boolean;
     biometric: boolean = false;
     previousVaultTimeout: number = null;
 
@@ -102,6 +103,8 @@ export class SettingsComponent implements OnInit {
 
         const pinSet = await this.vaultTimeoutService.isPinLockSet();
         this.pin = pinSet[0] || pinSet[1];
+
+        this.supportsBiometric = await this.platformUtilsService.supportsBiometric();
         this.biometric = await this.vaultTimeoutService.isBiometricLockSet();
     }
 
@@ -208,7 +211,7 @@ export class SettingsComponent implements OnInit {
     }
 
     async updateBiometric() {
-        if (this.biometric) {
+        if (this.biometric && this.supportsBiometric) {
 
             // Request permission to use the optional permission for nativeMessaging
             if (!this.platformUtilsService.isFirefox()) {

--- a/src/services/browserPlatformUtils.service.ts
+++ b/src/services/browserPlatformUtils.service.ts
@@ -290,7 +290,7 @@ export default class BrowserPlatformUtilsService implements PlatformUtilsService
     }
 
     supportsBiometric() {
-        return Promise.resolve(true);
+        return Promise.resolve(!this.isFirefox() && !this.isSafari());
     }
 
     authenticateBiometric() {


### PR DESCRIPTION
We should follow https://bugzilla.mozilla.org/show_bug.cgi?id=1630415 for when we can re-add this feature. I also hid the setting from safari since we currently don't support it either.