### PR TITLE
Auto-fill the correct cipher after clicking launch button

### DIFF
--- a/src/popup/components/action-buttons.component.html
+++ b/src/popup/components/action-buttons.component.html
@@ -2,7 +2,7 @@
     <i class="fa fa-lg fa-list-alt" aria-hidden="true"></i>
 </span>
 <ng-container *ngIf="cipher.type === cipherType.Login">
-    <span class="row-btn" appStopClick appStopProp appA11yTitle="{{'launch' | i18n}}" (click)="launch()"
+    <span class="row-btn" appStopClick appStopProp appA11yTitle="{{'launch' | i18n}}" (click)="launchCipher()"
         *ngIf="!showView" [ngClass]="{disabled: !cipher.login.canLaunch}">
         <i class="fa fa-lg fa-share-square-o" aria-hidden="true"></i>
     </span>

--- a/src/popup/components/action-buttons.component.ts
+++ b/src/popup/components/action-buttons.component.ts
@@ -29,7 +29,7 @@ import { PopupUtilsService } from '../services/popup-utils.service';
 })
 export class ActionButtonsComponent {
     @Output() onView = new EventEmitter<CipherView>();
-    @Output() onLaunch = new EventEmitter<CipherView>();
+    @Output() launchEvent = new EventEmitter<CipherView>();
     @Input() cipher: CipherView;
     @Input() showView = false;
 
@@ -45,8 +45,8 @@ export class ActionButtonsComponent {
         this.userHasPremiumAccess = await this.userService.canAccessPremium();
     }
 
-    launch() {
-        this.onLaunch.emit(this.cipher);
+    launchCipher() {
+        this.launchEvent.emit(this.cipher);
     }
 
     async copy(cipher: CipherView, value: string, typeI18nKey: string, aType: string) {

--- a/src/popup/components/action-buttons.component.ts
+++ b/src/popup/components/action-buttons.component.ts
@@ -29,6 +29,7 @@ import { PopupUtilsService } from '../services/popup-utils.service';
 })
 export class ActionButtonsComponent {
     @Output() onView = new EventEmitter<CipherView>();
+    @Output() onLaunch = new EventEmitter<CipherView>();
     @Input() cipher: CipherView;
     @Input() showView = false;
 
@@ -45,15 +46,7 @@ export class ActionButtonsComponent {
     }
 
     launch() {
-        if (this.cipher.type !== CipherType.Login || !this.cipher.login.canLaunch) {
-            return;
-        }
-
-        this.analytics.eventTrack.next({ action: 'Launched URI From Listing' });
-        BrowserApi.createNewTab(this.cipher.login.launchUri);
-        if (this.popupUtilsService.inPopup(window)) {
-            BrowserApi.closePopup(window);
-        }
+        this.onLaunch.emit(this.cipher);
     }
 
     async copy(cipher: CipherView, value: string, typeI18nKey: string, aType: string) {

--- a/src/popup/components/ciphers-list.component.html
+++ b/src/popup/components/ciphers-list.component.html
@@ -1,4 +1,4 @@
-<a *ngFor="let c of ciphers" (click)="selectCipher(c)" (dblclick)="doubleSelectCipher(c)" href="#" appStopClick
+<a *ngFor="let c of ciphers" (click)="selectCipher(c)" (dblclick)="launchCipher(c)" href="#" appStopClick
     title="{{title}} - {{c.name}}" class="box-content-row box-content-row-flex">
     <div class="row-main">
         <app-vault-icon [cipher]="c"></app-vault-icon>
@@ -17,7 +17,7 @@
             <span class="detail">{{c.subTitle}}</span>
         </div>
     </div>
-    <app-action-buttons [cipher]="c" [showView]="showView" (onView)="viewCipher(c)" (onLaunch)="doubleSelectCipher(c)" 
+    <app-action-buttons [cipher]="c" [showView]="showView" (onView)="viewCipher(c)" (launchEvent)="launchCipher(c)" 
         class="action-buttons">
     </app-action-buttons>
 </a>

--- a/src/popup/components/ciphers-list.component.html
+++ b/src/popup/components/ciphers-list.component.html
@@ -17,6 +17,7 @@
             <span class="detail">{{c.subTitle}}</span>
         </div>
     </div>
-    <app-action-buttons [cipher]="c" [showView]="showView" (onView)="viewCipher(c)" class="action-buttons">
+    <app-action-buttons [cipher]="c" [showView]="showView" (onView)="viewCipher(c)" (onLaunch)="doubleSelectCipher(c)" 
+        class="action-buttons">
     </app-action-buttons>
 </a>

--- a/src/popup/components/ciphers-list.component.ts
+++ b/src/popup/components/ciphers-list.component.ts
@@ -15,7 +15,7 @@ import { CipherView } from 'jslib/models/view/cipherView';
 })
 export class CiphersListComponent {
     @Output() onSelected = new EventEmitter<CipherView>();
-    @Output() onDoubleSelected = new EventEmitter<CipherView>();
+    @Output() launchEvent = new EventEmitter<CipherView>();
     @Output() onView = new EventEmitter<CipherView>();
     @Input() ciphers: CipherView[];
     @Input() showView = false;
@@ -27,8 +27,8 @@ export class CiphersListComponent {
         this.onSelected.emit(c);
     }
 
-    doubleSelectCipher(c: CipherView) {
-        this.onDoubleSelected.emit(c);
+    launchCipher(c: CipherView) {
+        this.launchEvent.emit(c);
     }
 
     viewCipher(c: CipherView) {

--- a/src/popup/vault/ciphers.component.html
+++ b/src/popup/vault/ciphers.component.html
@@ -72,7 +72,7 @@
             </div>
             <div class="box-content">
                 <app-ciphers-list [ciphers]="filteredCiphers" title="{{'viewItem' | i18n}}"
-                    (onSelected)="selectCipher($event)" (onDoubleSelected)="launchCipher($event)"></app-ciphers-list>
+                    (onSelected)="selectCipher($event)" (launchEvent)="launchCipher($event)"></app-ciphers-list>
             </div>
         </div>
     </ng-container>


### PR DESCRIPTION
## Objective
Fix #869. With auto-fill on page load enabled, clicking the "launch" button for a cipher will auto-fill the last used cipher for that URI, not necessarily the cipher that you clicked the launch button for.

## Code changes

@addisonbeck Fixed the same problem when double-clicking on a cipher to launch it (see #1391). However, the launch button calls a different method, and the changes were not replicated in that method.

Rather than copy & paste this previous fix, I have refactored so that the launch button calls the same method as double-clicking.

Previously:
- `ciphers.component` implements the `launchCipher` method, which is passed down to the child `ciphers-list.component` and called when a cipher is double clicked.
- `ciphers-list.component` does not pass this down to its own child, `action-buttons.component`. Instead, `action-buttons.component` implements its own `launch` method (which is how they got out of step).

Now:
- `ciphers-list.component` passes `launchCipher` down to its child, `action-buttons.component`. The child calls this when the launch button is clicked.

This does mean that the components are more tightly coupled, however I could not see that `action-buttons.component` was used anywhere else in the app, so I thought it was better to DRY.