### PR TITLE
Resolve safari not working due to missing chrome api (nativeMessaging)

### DIFF
--- a/src/background/nativeMessaging.background.ts
+++ b/src/background/nativeMessaging.background.ts
@@ -36,10 +36,12 @@ export class NativeMessagingBackground {
         private messagingService: MessagingService, private appIdService: AppIdService) {
             this.storageService.save(ConstantsService.biometricFingerprintValidated, false);
 
-            // Reload extension to activate nativeMessaging
-            chrome.permissions.onAdded.addListener((permissions) => {
-                BrowserApi.reloadExtension(null);
-            });
+            if (BrowserApi.isChromeApi) {
+                // Reload extension to activate nativeMessaging
+                chrome.permissions.onAdded.addListener((permissions) => {
+                    BrowserApi.reloadExtension(null);
+                });
+            }
         }
 
     async connect() {


### PR DESCRIPTION
Chrome APIs are not available in the old safari extensions which caused the extension to crash on start in safari.