### PR TITLE
Add build:xcode script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build:watch": "gulp build && webpack --watch",
     "build:prod": "gulp build && cross-env NODE_ENV=production webpack",
     "build:prod:watch": "gulp build && cross-env NODE_ENV=production webpack --watch",
+    "build:xcode": "npm run build && rsync -av build/./ src/safari/safari/app --exclude popup/index.html",
     "clean:l10n": "git push origin --delete l10n_master",
     "dist": "npm run build:prod && gulp dist",
     "dist:firefox": "npm run build:prod && gulp dist:firefox",


### PR DESCRIPTION
`npm run build:xcode` will now copy build output to `src/safari/safari/app` (except for `popup/index.html`) in accordance with the [Safari testing instructions](https://github.com/bitwarden/company/wiki/Local-Dev:-Browser).

This makes it quicker & easier to side-load the extension via Xcode for testing in Safari.

I haven't tracked this in Asana, let me know if it needs a card somewhere.