### PR TITLE
[Send] Navigation Tab

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1470,5 +1470,9 @@
         "example": "googlecom"
       }
     }
+  },
+  "send": {
+    "message": "Send",
+    "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
   }
 }

--- a/src/popup/app-routing.module.ts
+++ b/src/popup/app-routing.module.ts
@@ -39,6 +39,7 @@ import { CollectionsComponent } from './vault/collections.component';
 import { CurrentTabComponent } from './vault/current-tab.component';
 import { GroupingsComponent } from './vault/groupings.component';
 import { PasswordHistoryComponent } from './vault/password-history.component';
+import { SendComponent } from './send/send.component';
 import { ShareComponent } from './vault/share.component';
 import { ViewComponent } from './vault/view.component';
 
@@ -265,6 +266,13 @@ const routes: Routes = [
                 canActivate: [AuthGuardService],
                 data: { state: 'tabs_settings' },
             },
+            {
+                path: 'send',
+                component: SendComponent,
+                canActivate: [AuthGuardService],
+                data: { state: 'tabs_send' },
+            },
+
         ],
     },
 ];

--- a/src/popup/app-routing.module.ts
+++ b/src/popup/app-routing.module.ts
@@ -272,7 +272,6 @@ const routes: Routes = [
                 canActivate: [AuthGuardService],
                 data: { state: 'tabs_send' },
             },
-
         ],
     },
 ];

--- a/src/popup/app-routing.module.ts
+++ b/src/popup/app-routing.module.ts
@@ -20,9 +20,13 @@ import { SetPasswordComponent } from './accounts/set-password.component';
 import { TwoFactorOptionsComponent } from './accounts/two-factor-options.component';
 import { TwoFactorComponent } from './accounts/two-factor.component';
 import { SsoComponent } from './accounts/sso.component';
-import { PasswordGeneratorHistoryComponent } from './generator/password-generator-history.component';
+
 import { PasswordGeneratorComponent } from './generator/password-generator.component';
+import { PasswordGeneratorHistoryComponent } from './generator/password-generator-history.component';
+
 import { PrivateModeComponent } from './private-mode.component';
+import { TabsComponent } from './tabs.component';
+
 import { ExcludedDomainsComponent } from './settings/excluded-domains.component';
 import { ExportComponent } from './settings/export.component';
 import { FolderAddEditComponent } from './settings/folder-add-edit.component';
@@ -31,7 +35,7 @@ import { OptionsComponent } from './settings/options.component';
 import { PremiumComponent } from './settings/premium.component';
 import { SettingsComponent } from './settings/settings.component';
 import { SyncComponent } from './settings/sync.component';
-import { TabsComponent } from './tabs.component';
+
 import { AddEditComponent } from './vault/add-edit.component';
 import { AttachmentsComponent } from './vault/attachments.component';
 import { CiphersComponent } from './vault/ciphers.component';
@@ -39,9 +43,10 @@ import { CollectionsComponent } from './vault/collections.component';
 import { CurrentTabComponent } from './vault/current-tab.component';
 import { GroupingsComponent } from './vault/groupings.component';
 import { PasswordHistoryComponent } from './vault/password-history.component';
-import { SendComponent } from './send/send.component';
 import { ShareComponent } from './vault/share.component';
 import { ViewComponent } from './vault/view.component';
+
+import { SendComponent } from './send/send.component';
 
 const routes: Routes = [
     {

--- a/src/popup/app.module.ts
+++ b/src/popup/app.module.ts
@@ -45,6 +45,7 @@ import { CollectionsComponent } from './vault/collections.component';
 import { CurrentTabComponent } from './vault/current-tab.component';
 import { GroupingsComponent } from './vault/groupings.component';
 import { PasswordHistoryComponent } from './vault/password-history.component';
+import { SendComponent } from './send/send.component';
 import { ShareComponent } from './vault/share.component';
 import { ViewComponent } from './vault/view.component';
 
@@ -205,6 +206,7 @@ registerLocaleData(localeZhTw, 'zh-TW');
         RegisterComponent,
         SearchCiphersPipe,
         SelectCopyDirective,
+        SendComponent,
         SettingsComponent,
         ShareComponent,
         StopClickDirective,

--- a/src/popup/app.module.ts
+++ b/src/popup/app.module.ts
@@ -25,10 +25,14 @@ import { SetPasswordComponent } from './accounts/set-password.component';
 import { TwoFactorOptionsComponent } from './accounts/two-factor-options.component';
 import { TwoFactorComponent } from './accounts/two-factor.component';
 import { SsoComponent } from './accounts/sso.component';
-import { AppComponent } from './app.component';
+
 import { PasswordGeneratorHistoryComponent } from './generator/password-generator-history.component';
 import { PasswordGeneratorComponent } from './generator/password-generator.component';
+
+import { AppComponent } from './app.component';
 import { PrivateModeComponent } from './private-mode.component';
+import { TabsComponent } from './tabs.component';
+
 import { ExcludedDomainsComponent } from './settings/excluded-domains.component';
 import { ExportComponent } from './settings/export.component';
 import { FolderAddEditComponent } from './settings/folder-add-edit.component';
@@ -37,7 +41,7 @@ import { OptionsComponent } from './settings/options.component';
 import { PremiumComponent } from './settings/premium.component';
 import { SettingsComponent } from './settings/settings.component';
 import { SyncComponent } from './settings/sync.component';
-import { TabsComponent } from './tabs.component';
+
 import { AddEditComponent } from './vault/add-edit.component';
 import { AttachmentsComponent } from './vault/attachments.component';
 import { CiphersComponent } from './vault/ciphers.component';
@@ -45,9 +49,10 @@ import { CollectionsComponent } from './vault/collections.component';
 import { CurrentTabComponent } from './vault/current-tab.component';
 import { GroupingsComponent } from './vault/groupings.component';
 import { PasswordHistoryComponent } from './vault/password-history.component';
-import { SendComponent } from './send/send.component';
 import { ShareComponent } from './vault/share.component';
 import { ViewComponent } from './vault/view.component';
+
+import { SendComponent } from './send/send.component';
 
 import { A11yTitleDirective } from 'jslib/angular/directives/a11y-title.directive';
 import { ApiActionDirective } from 'jslib/angular/directives/api-action.directive';

--- a/src/popup/scss/base.scss
+++ b/src/popup/scss/base.scss
@@ -287,7 +287,7 @@ header {
         margin: 0;
 
         li {
-            width: 25%;
+            width: 20%;
             float: left;
             display: inline-block;
             padding: 0;
@@ -330,9 +330,9 @@ header {
         }
     }
 
-    &.tabs-3 {
+    &.tabs-4 {
         ul li {
-            width: 33.33%;
+            width: 25%;
         }
     }
 }

--- a/src/popup/scss/base.scss
+++ b/src/popup/scss/base.scss
@@ -281,14 +281,13 @@ header {
     }
 
     ul {
-        width: 100%;
+        display: flex;
         list-style: none;
         padding: 0;
         margin: 0;
 
         li {
-            width: 20%;
-            float: left;
+            flex: 1;
             display: inline-block;
             padding: 0;
             margin: 0;
@@ -327,12 +326,6 @@ header {
                     }
                 }
             }
-        }
-    }
-
-    &.tabs-4 {
-        ul li {
-            width: 25%;
         }
     }
 }

--- a/src/popup/send/send.component.html
+++ b/src/popup/send/send.component.html
@@ -1,7 +1,7 @@
 <header>
 </header>
 <content>
-    <div class="no-items" *ngIf="(!ciphers || !ciphers.length) && !showSearching()">
+    <div class="no-items">
         <i class="fa fa-smile-o fa-4x"></i>
         <p>Coming soon...</p>
     </div>

--- a/src/popup/send/send.component.html
+++ b/src/popup/send/send.component.html
@@ -1,0 +1,8 @@
+<header>
+</header>
+<content>
+    <div class="no-items" *ngIf="(!ciphers || !ciphers.length) && !showSearching()">
+        <i class="fa fa-smile-o fa-4x"></i>
+        <p>Coming soon...</p>
+    </div>
+</content>

--- a/src/popup/send/send.component.ts
+++ b/src/popup/send/send.component.ts
@@ -1,0 +1,35 @@
+import {
+    Component,
+    NgZone,
+} from '@angular/core';
+
+import { SendView } from 'jslib/models/view/sendView';
+
+import { SendComponent as BaseSendComponent } from 'jslib/src/angular/components/send/send.component';
+
+import { EnvironmentService } from 'jslib/abstractions/environment.service';
+import { I18nService } from 'jslib/abstractions/i18n.service';
+import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
+import { SendService } from 'jslib/abstractions/send.service';
+
+import { BroadcasterService } from 'jslib/angular/services/broadcaster.service';
+
+@Component({
+    selector: 'app-send',
+    templateUrl: 'send.component.html',
+})
+export class SendComponent extends BaseSendComponent {
+    constructor(sendService: SendService, i18nService: I18nService,
+        platformUtilsService: PlatformUtilsService, environmentService: EnvironmentService,
+        broadcasterService: BroadcasterService, ngZone: NgZone) {
+        super(sendService, i18nService, platformUtilsService, environmentService, broadcasterService, ngZone);
+    }
+
+    addSend() {
+        // TODO
+    }
+
+    editSend(send: SendView) {
+        // TODO
+    }
+}

--- a/src/popup/send/send.component.ts
+++ b/src/popup/send/send.component.ts
@@ -5,7 +5,7 @@ import {
 
 import { SendView } from 'jslib/models/view/sendView';
 
-import { SendComponent as BaseSendComponent } from 'jslib/src/angular/components/send/send.component';
+import { SendComponent as BaseSendComponent } from 'jslib/angular/components/send/send.component';
 
 import { EnvironmentService } from 'jslib/abstractions/environment.service';
 import { I18nService } from 'jslib/abstractions/i18n.service';

--- a/src/popup/tabs.component.html
+++ b/src/popup/tabs.component.html
@@ -1,6 +1,6 @@
 <div class="tab-page">
     <router-outlet></router-outlet>
-    <nav class="tabs" [ngClass]="{'tabs-3': !showCurrentTab}">
+    <nav class="tabs" [ngClass]="{'tabs-4': !showCurrentTab}">
         <ul>
             <li routerLinkActive="active" *ngIf="showCurrentTab">
                 <a routerLink="current" appA11yTitle="{{'currentTab' | i18n}}">
@@ -10,6 +10,11 @@
             <li routerLinkActive="active">
                 <a routerLink="vault" appA11yTitle="{{'myVault' | i18n}}">
                     <i class="fa fa-lock fa-2x" aria-hidden="true"></i>{{'myVault' | i18n}}
+                </a>
+            </li>
+            <li routerLinkActive="active">
+                <a routerLink="send" appA11yTitle="{{'send' | i18n}}">
+                    <i class="fa fa-paper-plane fa-2x" aria-hidden="true"></i>{{'send' | i18n}}
                 </a>
             </li>
             <li routerLinkActive="active">

--- a/src/popup/tabs.component.html
+++ b/src/popup/tabs.component.html
@@ -1,6 +1,6 @@
 <div class="tab-page">
     <router-outlet></router-outlet>
-    <nav class="tabs" [ngClass]="{'tabs-4': !showCurrentTab}">
+    <nav class="tabs">
         <ul>
             <li routerLinkActive="active" *ngIf="showCurrentTab">
                 <a routerLink="current" appA11yTitle="{{'currentTab' | i18n}}">


### PR DESCRIPTION
## Objective
> Implement the Send navigation tab

## Code Changes
- **jslib**: Updated from **9ddec9b** to **859f317**
- **messages.json**: Added `send` string
- **app-routing.module.ts**: Added `send` to `tabs` path
- **app.module.ts**: Added `SendComponent` to list of registered modules
- **scss/base.scss**: Adjusted tabs scss to include a (potential) 5th tab
- **send/send.component.html**: Added skeleton class html
- **send/send.component.ts**: Added skeleton ts class
- **tabs.component.html**: Updated to use new scss classes based on number of tabs visible

## Screenshots
![0-send-tab](https://user-images.githubusercontent.com/26154748/106500435-70c12200-6487-11eb-94f7-1b5e850e8306.png)
![1-send-tab-selected-wip](https://user-images.githubusercontent.com/26154748/106500439-71f24f00-6487-11eb-82c0-d9e416219f06.png)
![2-tab-popout](https://user-images.githubusercontent.com/26154748/106500440-71f24f00-6487-11eb-825c-4290587423af.png)

## Testing Considerations
- Make sure the `Send` navigation tab is available and directs you to a temporary component
- Make sure the popout component only contains 4 navigations tabs (including send)