### PR TITLE
Fix launch buttons

### DIFF
--- a/src/popup/vault/groupings.component.html
+++ b/src/popup/vault/groupings.component.html
@@ -30,7 +30,7 @@
             </div>
             <div class="box-content">
                 <app-ciphers-list [ciphers]="favoriteCiphers" title="{{'viewItem' | i18n}}"
-                    (onSelected)="selectCipher($event)" (onDoubleSelected)="launchCipher($event)"></app-ciphers-list>
+                    (onSelected)="selectCipher($event)" (launchEvent)="launchCipher($event)"></app-ciphers-list>
             </div>
         </div>
         <div class="box list">
@@ -118,7 +118,7 @@
             </div>
             <div class="box-content">
                 <app-ciphers-list [ciphers]="noFolderCiphers" title="{{'viewItem' | i18n}}"
-                    (onSelected)="selectCipher($event)" (onDoubleSelected)="launchCipher($event)"></app-ciphers-list>
+                    (onSelected)="selectCipher($event)" (launchEvent)="launchCipher($event)"></app-ciphers-list>
             </div>
         </div>
         <div class="box list" *ngIf="deletedCount">
@@ -146,7 +146,7 @@
         <div class="box list full-list" *ngIf="ciphers && ciphers.length > 0">
             <div class="box-content">
                 <app-ciphers-list [ciphers]="ciphers" title="{{'viewItem' | i18n}}" (onSelected)="selectCipher($event)"
-                    (onDoubleSelected)="launchCipher($event)"></app-ciphers-list>
+                    (launchEvent)="launchCipher($event)"></app-ciphers-list>
             </div>
         </div>
     </ng-container>


### PR DESCRIPTION
## Objective
I broke the launch cipher button in various places as a result of #1576. This was picked up in QA.

## Code changes
In `ciphers-list.component`, I had renamed `onDoubleSelected` to `launchEvent`, but hadn't changed all references to this in other places in the code. This PR updates those references to un-break this component.