### PR TITLE
Fix copying TOTP not working in Safari

### DIFF
--- a/src/safari/safari/SafariWebExtensionHandler.swift
+++ b/src/safari/safari/SafariWebExtensionHandler.swift
@@ -21,6 +21,13 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
             let pasteboard = NSPasteboard.general
             response.userInfo = [ SFExtensionMessageKey: pasteboard.pasteboardItems?.first?.string(forType: .string) as Any ]
             break
+        case "copyToClipboard":
+            guard let msg = message?["data"] as? String else {
+                return
+            }
+            let pasteboard = NSPasteboard.general
+            pasteboard.clearContents()
+            pasteboard.setString(msg, forType: .string)
         case "showPopover":
             SFSafariApplication.getActiveWindow { win in
                 win?.getToolbarItem(completionHandler: { item in

--- a/src/services/browserPlatformUtils.service.ts
+++ b/src/services/browserPlatformUtils.service.ts
@@ -180,15 +180,6 @@ export default class BrowserPlatformUtilsService implements PlatformUtilsService
     }
 
     copyToClipboard(text: string, options?: any): void {
-        if (this.isSafari()) {
-            SafariApp.sendMessageToApp('copyToClipboard', text).then(() => {
-                if (!clearing && this.clipboardWriteCallback != null) {
-                    this.clipboardWriteCallback(text, clearMs);
-                }
-            });
-            return;
-        }
-
         let win = window;
         let doc = window.document;
         if (options && (options.window || options.win)) {
@@ -199,7 +190,14 @@ export default class BrowserPlatformUtilsService implements PlatformUtilsService
         }
         const clearing = options ? !!options.clearing : false;
         const clearMs: number = options && options.clearMs ? options.clearMs : null;
-        if (this.isFirefox() && (win as any).navigator.clipboard && (win as any).navigator.clipboard.writeText) {
+        
+        if (this.isSafari()) {
+            SafariApp.sendMessageToApp('copyToClipboard', text).then(() => {
+                if (!clearing && this.clipboardWriteCallback != null) {
+                    this.clipboardWriteCallback(text, clearMs);
+                }
+            });
+        } else if (this.isFirefox() && (win as any).navigator.clipboard && (win as any).navigator.clipboard.writeText) {
             (win as any).navigator.clipboard.writeText(text).then(() => {
                 if (!clearing && this.clipboardWriteCallback != null) {
                     this.clipboardWriteCallback(text, clearMs);

--- a/src/services/browserPlatformUtils.service.ts
+++ b/src/services/browserPlatformUtils.service.ts
@@ -180,6 +180,15 @@ export default class BrowserPlatformUtilsService implements PlatformUtilsService
     }
 
     copyToClipboard(text: string, options?: any): void {
+        if (this.isSafari()) {
+            SafariApp.sendMessageToApp('copyToClipboard', text).then(() => {
+                if (!clearing && this.clipboardWriteCallback != null) {
+                    this.clipboardWriteCallback(text, clearMs);
+                }
+            });
+            return;
+        }
+
         let win = window;
         let doc = window.document;
         if (options && (options.window || options.win)) {


### PR DESCRIPTION
Added `copyToClipboard` to the native swift code to handle an edge case where copying TOTP refused to work. Safari for some reason forgot a user triggered the event.