### PR TITLE
Fix nativeMessaging not being enabled in safari

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -192,6 +192,11 @@ function safariCopyBuild(source, dest) {
             .on('error', reject)
             .pipe(filter(['**'].concat(filters.fonts)))
             .pipe(gulpif('popup/index.html', replace('__BROWSER__', 'browser_safari')))
+            .pipe(gulpif('manifest.json', jeditor((manifest) => {
+                delete manifest.optional_permissions;
+                manifest.permissions.push("nativeMessaging");
+                return manifest;
+            })))
             .pipe(gulp.dest(dest))
             .on('end', resolve);
     });


### PR DESCRIPTION
Required to communicate with the native code in swift.