### PR TITLE
Set save dialog to be a floatingPanel

### DIFF
--- a/src/safari/safari/SafariWebExtensionHandler.swift
+++ b/src/safari/safari/SafariWebExtensionHandler.swift
@@ -45,6 +45,7 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
                 return
             }
             let panel = NSSavePanel()
+            panel.isFloatingPanel = true
             panel.canCreateDirectories = true
             panel.nameFieldStringValue = dlMsg.fileName
             panel.begin { response in


### PR DESCRIPTION
With the new Safari Web Extension the save dialog appeares behind the Safari window. Which is obviously not acceptable UI behaviour.

After reading documentation, articles I found the [`isFloatingPanel`](https://developer.apple.com/documentation/appkit/nspanel/1531901-isfloatingpanel) property which forces the `NSSavePanel` to appear on top of everything else. While appearing on top of everything is not perfect either it's in my opinion better than not showing up at all.

