### PR TITLE
Revert "Merge pull request #1589 from bitwarden/npm-xcode-script"

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "build:watch": "gulp build && webpack --watch",
     "build:prod": "gulp build && cross-env NODE_ENV=production webpack",
     "build:prod:watch": "gulp build && cross-env NODE_ENV=production webpack --watch",
-    "build:xcode": "npm run build && rsync -av build/./ src/safari/safari/app --exclude popup/index.html",
     "clean:l10n": "git push origin --delete l10n_master",
     "dist": "npm run build:prod && gulp dist",
     "dist:firefox": "npm run build:prod && gulp dist:firefox",


### PR DESCRIPTION
I added a helper script to copy build output into the Xcode directory, but [as Chad foreshadowed](https://github.com/bitwarden/browser/pull/1589), it was almost immediately deprecated. This PR removes that script to avoid confusion.

The recommended way to test in Safari is `npm run dist:safari:dmg`.

This reverts commit c99b716b209c3180c6831686d67aa580df53d414, reversing changes made to 8e20e483733d9be1ff50d495f88a29cdb6647ef7.