### PR TITLE
Hover cursor for disabled boxes forces to normal

### DIFF
--- a/src/popup/scss/box.scss
+++ b/src/popup/scss/box.scss
@@ -387,6 +387,7 @@
                         opacity: themed('disabledBoxOpacity');
                     }
                 }
+                cursor: default !important;
             }
         }
 


### PR DESCRIPTION
# Overview

Disabled Action buttons (The quick actions from tab or vault view) changed cursor to a selector despite being disabled. This forces a cursor icon for all disabled boxes, which matches button behavior.

# Files changed
* **box.scss**: The cursor behavior change

# Testing

Make sure cursor is hand for active and normal for all disabled buttons