### PR TITLE
Resolve safari not checking vault timeout every 10s

### DIFF
--- a/src/background/main.background.ts
+++ b/src/background/main.background.ts
@@ -19,7 +19,6 @@ import {
     TokenService,
     TotpService,
     UserService,
-    VaultTimeoutService,
 } from 'jslib/services';
 import { ConsoleLogService } from 'jslib/services/consoleLog.service';
 import { EventService } from 'jslib/services/event.service';
@@ -84,6 +83,7 @@ import BrowserMessagingService from '../services/browserMessaging.service';
 import BrowserPlatformUtilsService from '../services/browserPlatformUtils.service';
 import BrowserStorageService from '../services/browserStorage.service';
 import I18nService from '../services/i18n.service';
+import VaultTimeoutService from '../services/vaultTimeout.service';
 
 import { AutofillService as AutofillServiceAbstraction } from '../services/abstractions/autofill.service';
 

--- a/src/safari/safari/SafariWebExtensionHandler.swift
+++ b/src/safari/safari/SafariWebExtensionHandler.swift
@@ -73,6 +73,11 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
                 }
             }
             break
+        case "sleep":
+            DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
+                context.completeRequest(returningItems: [response], completionHandler: nil)
+            }
+            return
 
         default:
             return

--- a/src/services/vaultTimeout.service.ts
+++ b/src/services/vaultTimeout.service.ts
@@ -1,0 +1,28 @@
+import { VaultTimeoutService as BaseVaultTimeoutService } from 'jslib/services/vaultTimeout.service';
+import { SafariApp } from '../browser/safariApp';
+
+export default class VaultTimeoutService extends BaseVaultTimeoutService {
+
+    startCheck() {
+        this.checkVaultTimeout();
+        if (this.platformUtilsService.isSafari()) {
+            this.checkSafari();
+        } else {
+            setInterval(() => this.checkVaultTimeout(), 10 * 1000); // check every 10 seconds
+        }
+    }
+
+    // This is a work-around to safari adding an arbitary delay to setTimeout and
+    //  setIntervals. It works by calling the native extension which sleeps for 10s,
+    //  efficiently replicating setInterval.
+    async checkSafari() {
+        while(true) {
+            try {
+                await SafariApp.sendMessageToApp('sleep');
+                this.checkVaultTimeout();
+            } catch(e) {
+                console.log("Exception Safari VaultTimeout", e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Safari adds a delay to `setInterval` and `setTimeout` on the background page, which causes the vault to not lock within the expected time-frame. It could take up to 60s before the vault locked which differs significantly from the other browsers.

After exploring a few different alternatives it seems the only work-around is to replicate `setInterval` by using the native extension as a timer.

Depends on https://github.com/bitwarden/jslib/pull/275