### PR TITLE
[Send] Add/Edit functionality

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1506,7 +1506,7 @@
     "message": "Password protected"
   },
   "copySendLink": {
-    "message": "Copy Send Link",
+    "message": "Copy Send link",
     "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
   },
   "removePassword": {
@@ -1523,7 +1523,7 @@
     "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
   },
   "sendLink": {
-    "message": "Send Link",
+    "message": "Send link",
     "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
   },
   "disabled": {
@@ -1538,6 +1538,108 @@
   },
   "deleteSendConfirmation": {
     "message": "Are you sure you want to delete this Send?",
+    "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
+  },
+  "editSend": {
+    "message": "Edit Send",
+    "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
+  },
+  "sendTypeHeader": {
+    "message": "What type of Send is this?",
+    "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
+  },
+  "sendNameDesc": {
+    "message": "A friendly name to describe this Send.",
+    "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
+  },
+  "chooseFile": {
+    "message": "Choose File"
+  },
+  "noFileChosen": {
+    "message": "No file chosen"
+  },
+  "sendFileDesc": {
+    "message": "The file you want to send. Maximum file size is 100 MB."
+  },
+  "deletionDate": {
+    "message": "Deletion Date"
+  },
+  "deletionDateDesc": {
+    "message": "The Send will be permanently deleted on the specified date and time.",
+    "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
+  },
+  "expirationDate": {
+    "message": "Expiration Date"
+  },
+  "expirationDateDesc": {
+    "message": "If set, access to this Send will expire on the specified date and time.",
+    "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
+  },
+  "oneDay": {
+    "message": "1 day"
+  },
+  "days": {
+    "message": "$DAYS$ days",
+    "placeholders": {
+      "days": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "custom": {
+    "message": "Custom"
+  },
+  "maximumAccessCount": {
+    "message": "Maximum Access Count"
+  },
+  "maximumAccessCountDesc": {
+    "message": "If set, users will no longer be able to access this Send once the maximum access count is reached.",
+    "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
+  },
+  "sendPasswordDesc": {
+    "message": "Optionally require a password for users to access this Send.",
+    "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
+  },
+  "sendNotesDesc": {
+    "message": "Private notes about this Send.",
+    "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
+  },
+  "sendDisableDesc": {
+    "message": "Disable this Send so that no one can access it.",
+    "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
+  },
+  "sendShareDesc": {
+    "message": "Copy this Send's link to clipboard upon save.",
+    "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
+  },
+  "sendTextDesc": {
+    "message": "The text you want to send."
+  },
+  "sendHideText": {
+    "message": "Hide this Send's text by default.",
+    "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
+  },
+  "currentAccessCount": {
+    "message": "Current Access Count"
+  },
+  "createSend": {
+    "message": "Create New Send",
+    "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
+  },
+  "newPassword": {
+    "message": "New Password"
+  },
+  "sendDisabledWarning": {
+    "message": "Due to an enterprise policy, you are only able to delete an existing Send.",
+    "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
+  },
+  "createdSend": {
+    "message": "Created Send",
+    "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
+  },
+  "editedSend": {
+    "message": "Edited Send",
     "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
   }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1552,14 +1552,8 @@
     "message": "A friendly name to describe this Send.",
     "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
   },
-  "chooseFile": {
-    "message": "Choose File"
-  },
-  "noFileChosen": {
-    "message": "No file chosen"
-  },
   "sendFileDesc": {
-    "message": "The file you want to send. Maximum file size is 100 MB."
+    "message": "The file you want to send."
   },
   "deletionDate": {
     "message": "Deletion Date"
@@ -1641,5 +1635,14 @@
   "editedSend": {
     "message": "Edited Send",
     "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
+  },
+  "sendFirefoxFileWarning": {
+    "message": "In order to choose a file using Firefox, open the extension in the sidebar or pop out to a new window by clicking this banner."
+  },
+  "sendSafariFileWarning": {
+    "message": "In order to choose a file using Safari, pop out to a new window by clicking this banner."
+  },
+  "sendFileCalloutHeader": {
+    "message": "Before you start"
   }
 }

--- a/src/popup/app-routing.animations.ts
+++ b/src/popup/app-routing.animations.ts
@@ -190,4 +190,10 @@ export const routerTransition = trigger('routerTransition', [
 
     transition('tabs => send-type', inSlideLeft),
     transition('send-type => tabs', outSlideRight),
+
+    transition('tabs => add-send, send-type => add-send', inSlideUp),
+    transition('add-send => tabs, add-send => send-type', outSlideDown),
+
+    transition('tabs => edit-send, send-type => edit-send', inSlideUp),
+    transition('edit-send => tabs, edit-send => send-type', outSlideDown),
 ]);

--- a/src/popup/app-routing.module.ts
+++ b/src/popup/app-routing.module.ts
@@ -46,6 +46,7 @@ import { PasswordHistoryComponent } from './vault/password-history.component';
 import { ShareComponent } from './vault/share.component';
 import { ViewComponent } from './vault/view.component';
 
+import { SendAddEditComponent } from './send/send-add-edit.component';
 import { SendGroupingsComponent } from './send/send-groupings.component';
 import { SendTypeComponent } from './send/send-type.component';
 
@@ -242,6 +243,18 @@ const routes: Routes = [
         component: SendTypeComponent,
         canActivate: [AuthGuardService],
         data: { state: 'send-type' },
+    },
+    {
+        path: 'add-send',
+        component: SendAddEditComponent,
+        canActivate: [AuthGuardService],
+        data: { state: 'add-send' },
+    },
+    {
+        path: 'edit-send',
+        component: SendAddEditComponent,
+        canActivate: [AuthGuardService],
+        data: { state: 'edit-send' },
     },
     {
         path: 'tabs',

--- a/src/popup/app.component.ts
+++ b/src/popup/app.component.ts
@@ -145,6 +145,7 @@ export class AppComponent implements OnInit {
                 if (url.startsWith('/tabs/') && (window as any).previousPopupUrl != null &&
                     (window as any).previousPopupUrl.startsWith('/tabs/')) {
                     this.stateService.remove('GroupingsComponent');
+                    this.stateService.remove('GroupingsComponentScope');
                     this.stateService.remove('CiphersComponent');
                     this.stateService.remove('SendGroupingsComponent');
                     this.stateService.remove('SendGroupingsComponentScope');
@@ -152,7 +153,6 @@ export class AppComponent implements OnInit {
                 }
                 if (url.startsWith('/tabs/')) {
                     this.stateService.remove('addEditCipherInfo');
-                    // TODO Remove any Send add/edit state information (?)
                 }
                 (window as any).previousPopupUrl = url;
 

--- a/src/popup/app.module.ts
+++ b/src/popup/app.module.ts
@@ -52,6 +52,7 @@ import { PasswordHistoryComponent } from './vault/password-history.component';
 import { ShareComponent } from './vault/share.component';
 import { ViewComponent } from './vault/view.component';
 
+import { SendAddEditComponent } from './send/send-add-edit.component';
 import { SendGroupingsComponent } from './send/send-groupings.component';
 import { SendTypeComponent } from './send/send-type.component';
 
@@ -81,6 +82,7 @@ import { IconComponent } from 'jslib/angular/components/icon.component';
 
 import {
     CurrencyPipe,
+    DatePipe,
     registerLocaleData,
 } from '@angular/common';
 import localeBe from '@angular/common/locales/be';
@@ -213,6 +215,7 @@ registerLocaleData(localeZhTw, 'zh-TW');
         RegisterComponent,
         SearchCiphersPipe,
         SelectCopyDirective,
+        SendAddEditComponent,
         SendGroupingsComponent,
         SendListComponent,
         SendTypeComponent,
@@ -232,6 +235,7 @@ registerLocaleData(localeZhTw, 'zh-TW');
     entryComponents: [],
     providers: [
         CurrencyPipe,
+        DatePipe,
     ],
     bootstrap: [AppComponent],
 })

--- a/src/popup/scss/box.scss
+++ b/src/popup/scss/box.scss
@@ -19,6 +19,32 @@
         }
     }
 
+    .box-header-expandable {
+        margin: 0 10px 5px 10px;
+        text-transform: uppercase;
+        display: flex;
+
+        @include themify($themes) {
+            color: themed('headingColor');
+        }
+
+        &:hover, &:focus, &.active {
+            @include themify($themes) {
+                background-color: themed('boxBackgroundHoverColor');
+            }
+        }
+
+        .icon {
+            display: flex;
+            align-items: center;
+            margin-left: 5px;
+
+            @include themify($themes) {
+                color: themed('headingColor');
+            }
+        }
+    }
+
     .box-content {
         border-top: 1px solid #000000;
         border-bottom: 1px solid #000000;
@@ -199,6 +225,21 @@
 
         .sub-label {
             margin-left: 10px;
+        }
+    }
+
+    .flex-label {
+        font-size: $font-size-small;
+        display: flex;
+        flex-grow: 1;
+        margin-bottom: 5px;
+
+        @include themify($themes) {
+            color: themed('mutedColor');
+        }
+
+        > a {
+            flex-grow: 0;
         }
     }
 

--- a/src/popup/scss/box.scss
+++ b/src/popup/scss/box.scss
@@ -370,7 +370,7 @@
         }
     }
 
-    input:not([type="checkbox"]), textarea {
+    input:not([type="checkbox"]):not([type="radio"]), textarea {
         border: none;
         width: 100%;
         background-color: transparent !important;
@@ -585,6 +585,29 @@
             justify-content: center;
             white-space: nowrap;
             background-color: $brand-primary;
+        }
+    }
+
+    .radio-group {
+        display: flex;
+        justify-content: flex-start;
+        align-items: center;
+        margin-bottom: 5px;
+
+        input {
+            flex-grow: 0;
+        }
+
+        label {
+            margin: 0 0 0 5px;
+            flex-grow: 1;
+            font-size: $font-size-base;
+            display: block;
+            width: 100%;
+
+            @include themify($themes) {
+                color: themed('textColor');
+            }
         }
     }
 }

--- a/src/popup/scss/misc.scss
+++ b/src/popup/scss/misc.scss
@@ -302,6 +302,14 @@ app-vault-icon {
             }
         }
     }
+
+    &.clickable {
+        &:hover, &:focus, &.active {
+            @include themify($themes) {
+                background-color: themed('boxBackgroundHoverColor');
+            }
+        }
+    }
 }
 
 input[type="password"]::-ms-reveal {

--- a/src/popup/send/send-add-edit.component.html
+++ b/src/popup/send/send-add-edit.component.html
@@ -15,8 +15,9 @@
     </header>
     <content *ngIf="send">
         <!-- File Warning -->
-        <app-callout type="warning" icon="fa-external-link" title="{{'sendFileCalloutHeader' | i18n}}"
-            *ngIf="showFilePopoutMessage && send.type === sendType.File" (click)="popOutWindow()">
+        <app-callout type="warning" icon="fa fa-external-link fa-rotate-270 fa-fw" [clickable]="true"
+            title="{{'sendFileCalloutHeader' | i18n}}" *ngIf="showFilePopoutMessage && send.type === sendType.File"
+            (click)="popOutWindow()">
             <div *ngIf="showFirefoxFileWarning">{{'sendFirefoxFileWarning' | i18n}}</div>
             <div *ngIf="showSafariFileWarning">{{'sendSafariFileWarning' | i18n}}</div>
         </app-callout>
@@ -34,13 +35,17 @@
         </div>
         <!-- Type Options -->
         <div class="box" *ngIf="!editMode">
-            <div class="box-content">
-                <div class="box-content-row" appBoxRow>
+            <div class="box-content no-hover">
+                <div class="box-content-row">
                     <label for="sendTypeOptions">{{'sendTypeHeader' | i18n}}</label>
-                    <select id="sendTypeOptions" name="SendTypeOptions" [(ngModel)]="send.type"
-                        (change)="typeChanged()">
-                        <option *ngFor="let o of typeOptions" [ngValue]="o.value">{{o.name}}</option>
-                    </select>
+                    <div class="radio-group text-default" appBoxRow name="SendTypeOptions"
+                        *ngFor="let o of typeOptions">
+                        <input type="radio" [(ngModel)]="send.type" name="Type_{{o.value}}" id="type_{{o.value}}"
+                            [value]="o.value" (change)="typeChanged()" [checked]="send.type === o.value">
+                        <label for="type_{{o.value}}">
+                            {{o.name}}
+                        </label>
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/popup/send/send-add-edit.component.html
+++ b/src/popup/send/send-add-edit.component.html
@@ -1,0 +1,235 @@
+<form #form (ngSubmit)="submit()" [appApiAction]="formPromise">
+    <header>
+        <div class="left">
+            <button type="button" appBlurClick (click)="cancel()">{{'cancel' | i18n}}</button>
+        </div>
+        <div class="center">
+            <span class="title">{{title}}</span>
+        </div>
+        <div class="right">
+            <button type="submit" appBlurClick [disabled]="form.loading">
+                <span [hidden]="form.loading">{{'save' | i18n}}</span>
+                <i class="fa fa-spinner fa-lg fa-spin" [hidden]="!form.loading" aria-hidden="true"></i>
+            </button>
+        </div>
+    </header>
+    <content *ngIf="send">
+        <!-- Name -->
+        <div class="box">
+            <div class="box-content">
+                <div class="box-content-row" appBoxRow>
+                    <label for="name">{{'name' | i18n}}</label>
+                    <input id="name" type="text" name="Name" [(ngModel)]="send.name">
+                </div>
+            </div>
+            <div class="box-footer">
+                {{'sendNameDesc' | i18n}}
+            </div>
+        </div>
+        <!-- Type Options -->
+        <div class="box" *ngIf="!editMode">
+            <div class="box-content">
+                <div class="box-content-row" appBoxRow>
+                    <label for="sendTypeOptions">{{'sendTypeHeader' | i18n}}</label>
+                    <select id="sendTypeOptions" name="SendTypeOptions" [(ngModel)]="send.type"
+                        (change)="typeChanged()">
+                        <option *ngFor="let o of typeOptions" [ngValue]="o.value">{{o.name}}</option>
+                    </select>
+                </div>
+            </div>
+        </div>
+        <!-- File -->
+        <div class="box" *ngIf="send.type === sendType.File">
+            <div class="box-content no-hover">
+                <div class="box-content-row" *ngIf="editMode">
+                    <label for="file">{{'file' | i18n}}</label>
+                    <div class="row-main">{{send.file.fileName}} ({{send.file.sizeName}})</div>
+                </div>
+                <div class="box-content-row" *ngIf="!editMode">
+                    <label for="file">{{'file' | i18n}}</label>
+                    <input type="file" id="file" name="file" required>
+                </div>
+            </div>
+            <div class="box-footer" *ngIf="!editMode">
+                {{'sendFileDesc' | i18n}} {{'maxFileSize' | i18n}}
+            </div>
+        </div>
+        <!-- Text -->
+        <div class="box" *ngIf="send.type === sendType.Text">
+            <div class="box-content">
+                <div class="box-content-row" appBoxRow>
+                    <label for="text">{{'sendTypeText' | i18n}}</label>
+                    <textarea id="text" name="Text" rows="6" [(ngModel)]="send.text.text"></textarea>
+                </div>
+            </div>
+            <div class="box-footer">
+                {{'sendTextDesc' | i18n}}
+            </div>
+            <div class="box-content">
+                <div class="box-content-row box-content-row-checkbox" appBoxRow>
+                    <label for="hideText">{{'sendHideText' | i18n}}</label>
+                    <input id="hideText" type="checkbox" name="HideText" [(ngModel)]="send.text.hidden">
+                </div>
+            </div>
+        </div>
+        <!-- Share -->
+        <div class="box">
+            <div class="box-header">
+                {{'share' | i18n}}
+            </div>
+            <div class="box-content">
+                <!-- Copy Link on Save -->
+                <div class="box-content-row box-content-row-checkbox" appBoxRow>
+                    <label for="copyOnSave">{{'sendShareDesc' | i18n}}</label>
+                    <input id="copyOnSave" type="checkbox" name="CopyOnSave" [(ngModel)]="copyLink">
+                </div>
+            </div>
+        </div>
+        <!-- Options -->
+        <div class="box">
+            <div class="box-header-expandable" (click)="showOptions = !showOptions">
+                {{'options' | i18n}}
+                <i *ngIf="!showOptions" class="fa fa-chevron-down fa-sm icon"></i>
+                <i *ngIf="showOptions" class="fa fa-chevron-up fa-sm icon"></i>
+            </div>
+        </div>
+        <ng-container *ngIf="showOptions">
+            <!-- Deletion Date -->
+            <div class="box">
+                <div class="box-content">
+                    <div class="box-content-row" *ngIf="!editMode">
+                        <label for="deletionDate">{{'deletionDate' | i18n}}</label>
+                        <select id="deletionDate" name="DeletionDateSelect" [(ngModel)]="deletionDateSelect" required>
+                            <option *ngFor="let o of deletionDateOptions" [ngValue]="o.value">{{o.name}}
+                            </option>
+                        </select>
+                    </div>
+                    <div class="box-content-row" *ngIf="deletionDateSelect === 0 && !editMode">
+                        <input id="deletionDateCustom" type="datetime-local" name="DeletionDate"
+                            [(ngModel)]="deletionDate" required placeholder="MM/DD/YYYY HH:MM AM/PM">
+                    </div>
+                    <div class="box-content-row" *ngIf="editMode" appBoxRow>
+                        <label for="editDeletionDate">{{'deletionDate' | i18n}}</label>
+                        <input id="editDeletionDate" type="datetime-local" name="EditDeletionDate"
+                            [(ngModel)]="deletionDate" required placeholder="MM/DD/YYYY HH:MM AM/PM">
+                    </div>
+                </div>
+                <div class="box-footer">
+                    {{'deletionDateDesc' | i18n}}
+                </div>
+            </div>
+            <!-- Expiration Date -->
+            <div class="box">
+                <div class="box-content">
+                    <div class="box-content-row" *ngIf="!editMode">
+                        <label for="expirationDate">{{'expirationDate' | i18n}}</label>
+                        <select id="expirationDate" name="ExpirationDateSelect" [(ngModel)]="expirationDateSelect"
+                            required>
+                            <option *ngFor="let o of expirationDateOptions" [ngValue]="o.value">{{o.name}}
+                            </option>
+                        </select>
+                    </div>
+                    <div class="box-content-row" *ngIf="expirationDateSelect === 0 && !editMode">
+                        <input id="expirationDateCustom" type="datetime-local" name="ExpirationDate"
+                            [(ngModel)]="expirationDate" required placeholder="MM/DD/YYYY HH:MM AM/PM">
+                    </div>
+                    <div class="box-content-row" *ngIf="editMode" appBoxRow>
+                        <div class="flex-label">
+                            <label for="editExpirationDate">{{'expirationDate' | i18n}}</label>
+                            <a href="#" appStopClick (click)="clearExpiration()">
+                                {{'clear' | i18n}}
+                            </a>
+                        </div>
+                        <input id="editExpirationDate" type="datetime-local" name="EditExpirationDate"
+                            [(ngModel)]="expirationDate" placeholder="MM/DD/YYYY HH:MM AM/PM">
+                    </div>
+                </div>
+                <div class="box-footer">
+                    {{'expirationDateDesc' | i18n}}
+                </div>
+            </div>
+            <!-- Maximum Access Count -->
+            <div class="box">
+                <div class="box-content">
+                    <div class="box-content-row" appBoxRow>
+                        <label for="maximumAccessCount">{{'maximumAccessCount' | i18n}}</label>
+                        <input id="maximumAccessCount" min="1" type="number" name="MaximumAccessCount"
+                            [(ngModel)]="send.maxAccessCount">
+                    </div>
+                </div>
+                <div class="box-footer">
+                    {{'maximumAccessCountDesc' | i18n}}
+                </div>
+            </div>
+            <!-- Current Access Count -->
+            <div class="box" *ngIf="editMode">
+                <div class="box-content">
+                    <div class="box-content-row" appBoxRow>
+                        <label for="currentAccessCount">{{'currentAccessCount' | i18n}}</label>
+                        <input id="currentAccessCount" readonly type="number" name="CurrentAccessCount"
+                            [(ngModel)]="send.accessCount">
+                    </div>
+                </div>
+            </div>
+            <!-- Password -->
+            <div class="box">
+                <div class="box-content">
+                    <div class="box-content-row box-content-row-flex" appBoxRow>
+                        <div class="row-main">
+                            <label for="password" *ngIf="hasPassword">{{'newPassword' | i18n}}</label>
+                            <label for="password" *ngIf="!hasPassword">{{'password' | i18n}}</label>
+                            <input id="password" type="{{showPassword ? 'text' : 'password'}}" name="Password"
+                                class="monospaced" [(ngModel)]="password" appInputVerbatim>
+                        </div>
+                        <div class="action-buttons">
+                            <a class="row-btn" href="#" appStopClick appBlurClick
+                                appA11yTitle="{{'toggleVisibility' | i18n}}" (click)="togglePasswordVisible()">
+                                <i class="fa fa-lg" [ngClass]="{'fa-eye': !showPassword, 'fa-eye-slash': showPassword}"
+                                    aria-hidden="true"></i>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+                <div class="box-footer">
+                    {{'sendPasswordDesc' | i18n}}
+                </div>
+            </div>
+            <!-- Notes -->
+            <div class="box">
+                <div class="box-content">
+                    <div class="box-content-row" appBoxRow>
+                        <label for="notes">{{'notes' | i18n}}</label>
+                        <textarea id="notes" name="Notes" rows="6" [(ngModel)]="send.notes"></textarea>
+                    </div>
+                </div>
+                <div class="box-footer">
+                    {{'sendNotesDesc' | i18n}}
+                </div>
+            </div>
+            <!-- Disable Send -->
+            <div class="box">
+                <div class="box-content">
+                    <div class="box-content-row box-content-row-checkbox" appBoxRow>
+                        <label for="disableSend">{{'sendDisableDesc' | i18n}}</label>
+                        <input id="disableSend" type="checkbox" name="DisableSend" [(ngModel)]="send.disabled">
+                    </div>
+                </div>
+            </div>
+        </ng-container>
+        <!-- Delete -->
+        <div class="box list" *ngIf="editMode">
+            <div class="box-content single-line">
+                <a class="box-content-row" href="#" appStopClick appBlurClick (click)="delete()"
+                    [appApiAction]="deletePromise" #deleteBtn>
+                    <div class="row-main text-danger">
+                        <div class="icon text-danger" aria-hidden="true">
+                            <i class="fa fa-trash-o fa-lg fa-fw" [hidden]="deleteBtn.loading"></i>
+                            <i class="fa fa-spinner fa-spin fa-lg fa-fw" [hidden]="!deleteBtn.loading"></i>
+                        </div>
+                        <span>{{'deleteSend' | i18n}}</span>
+                    </div>
+                </a>
+            </div>
+        </div>
+    </content>
+</form>

--- a/src/popup/send/send-add-edit.component.html
+++ b/src/popup/send/send-add-edit.component.html
@@ -14,6 +14,12 @@
         </div>
     </header>
     <content *ngIf="send">
+        <!-- File Warning -->
+        <app-callout type="warning" icon="fa-external-link" title="{{'sendFileCalloutHeader' | i18n}}"
+            *ngIf="showFilePopoutMessage && send.type === sendType.File" (click)="popOutWindow()">
+            <div *ngIf="showFirefoxFileWarning">{{'sendFirefoxFileWarning' | i18n}}</div>
+            <div *ngIf="showSafariFileWarning">{{'sendSafariFileWarning' | i18n}}</div>
+        </app-callout>
         <!-- Name -->
         <div class="box">
             <div class="box-content">
@@ -39,18 +45,18 @@
             </div>
         </div>
         <!-- File -->
-        <div class="box" *ngIf="send.type === sendType.File">
+        <div class="box" *ngIf="send.type === sendType.File && (editMode || showFileSelector)">
             <div class="box-content no-hover">
                 <div class="box-content-row" *ngIf="editMode">
                     <label for="file">{{'file' | i18n}}</label>
                     <div class="row-main">{{send.file.fileName}} ({{send.file.sizeName}})</div>
                 </div>
-                <div class="box-content-row" *ngIf="!editMode">
+                <div class="box-content-row" *ngIf="showFileSelector">
                     <label for="file">{{'file' | i18n}}</label>
                     <input type="file" id="file" name="file" required>
                 </div>
             </div>
-            <div class="box-footer" *ngIf="!editMode">
+            <div class="box-footer" *ngIf="showFileSelector">
                 {{'sendFileDesc' | i18n}} {{'maxFileSize' | i18n}}
             </div>
         </div>

--- a/src/popup/send/send-add-edit.component.ts
+++ b/src/popup/send/send-add-edit.component.ts
@@ -1,0 +1,89 @@
+import {
+    DatePipe,
+    Location,
+} from '@angular/common';
+
+import { Component } from '@angular/core';
+
+import {
+    ActivatedRoute,
+    Router,
+} from '@angular/router';
+
+import { EnvironmentService } from 'jslib/abstractions/environment.service';
+import { I18nService } from 'jslib/abstractions/i18n.service';
+import { MessagingService } from 'jslib/abstractions/messaging.service';
+import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
+import { PolicyService } from 'jslib/abstractions/policy.service';
+import { SendService } from 'jslib/abstractions/send.service';
+import { UserService } from 'jslib/abstractions/user.service';
+
+import { PopupUtilsService } from '../services/popup-utils.service';
+
+import { AddEditComponent as BaseAddEditComponent } from 'jslib/angular/components/send/add-edit.component';
+
+@Component({
+    selector: 'app-send-add-edit',
+    templateUrl: 'send-add-edit.component.html',
+})
+export class SendAddEditComponent extends BaseAddEditComponent {
+    showAttachments = true;
+    showOptions = false;
+    openAttachmentsInPopup: boolean;
+
+    constructor(i18nService: I18nService, platformUtilsService: PlatformUtilsService,
+        userService: UserService, messagingService: MessagingService, policyService: PolicyService,
+        environmentService: EnvironmentService, datePipe: DatePipe, sendService: SendService,
+        private route: ActivatedRoute, private router: Router, private location: Location,
+        private popupUtilsService: PopupUtilsService) {
+        super(i18nService, platformUtilsService, environmentService, datePipe, sendService, userService,
+            messagingService, policyService);
+    }
+
+    async ngOnInit() {
+        const queryParamsSub = this.route.queryParams.subscribe(async (params) => {
+            if (params.sendId) {
+                this.sendId = params.sendId;
+            }
+            if (params.type) {
+                const type = parseInt(params.type, null);
+                this.type = type;
+            }
+            await this.load();
+
+            if (queryParamsSub != null) {
+                queryParamsSub.unsubscribe();
+            }
+
+            this.openAttachmentsInPopup = this.popupUtilsService.inPopup(window);
+        });
+
+        window.setTimeout(() => {
+            if (!this.editMode) {
+                document.getElementById('name').focus();
+            }
+        }, 200);
+    }
+
+    async submit(): Promise<boolean> {
+        if (await super.submit()) {
+            this.cancel();
+            return true;
+        }
+
+        return false;
+    }
+
+    async delete(): Promise<boolean> {
+        if (await super.delete()) {
+            this.cancel();
+            return true;
+        }
+
+        return false;
+    }
+
+    cancel() {
+        this.location.back();
+    }
+}

--- a/src/popup/send/send-groupings.component.ts
+++ b/src/popup/send/send-groupings.component.ts
@@ -5,7 +5,6 @@ import {
 } from '@angular/core';
 
 import {
-    ActivatedRoute,
     Router,
 } from '@angular/router';
 
@@ -50,7 +49,7 @@ export class SendGroupingsComponent extends BaseSendComponent {
         platformUtilsService: PlatformUtilsService, environmentService: EnvironmentService, ngZone: NgZone,
         policyService: PolicyService, userService: UserService, searchService: SearchService,
         private popupUtils: PopupUtilsService, private stateService: StateService,
-        private route: ActivatedRoute, private router: Router, private syncService: SyncService,
+        private router: Router, private syncService: SyncService,
         private changeDetectorRef: ChangeDetectorRef, private broadcasterService: BroadcasterService) {
         super(sendService, i18nService, platformUtilsService, environmentService, ngZone, searchService,
             policyService, userService);
@@ -122,11 +121,11 @@ export class SendGroupingsComponent extends BaseSendComponent {
     }
 
     async selectSend(s: SendView) {
-        // TODO -> Route to edit send
+        this.router.navigate(['/edit-send'], { queryParams: { sendId: s.id } });
     }
 
     async addSend() {
-        // TODO -> Route to create send
+        this.router.navigate(['/add-send']);
     }
 
     showSearching() {

--- a/src/popup/send/send-type.component.ts
+++ b/src/popup/send/send-type.component.ts
@@ -6,6 +6,7 @@ import {
 
 import {
     ActivatedRoute,
+    Router,
 } from '@angular/router';
 
 import { Location } from '@angular/common';
@@ -47,7 +48,7 @@ export class SendTypeComponent extends BaseSendComponent {
         policyService: PolicyService, userService: UserService, searchService: SearchService,
         private popupUtils: PopupUtilsService, private stateService: StateService,
         private route: ActivatedRoute, private location: Location, private changeDetectorRef: ChangeDetectorRef,
-        private broadcasterService: BroadcasterService) {
+        private broadcasterService: BroadcasterService, private router: Router) {
         super(sendService, i18nService, platformUtilsService, environmentService, ngZone, searchService,
             policyService, userService);
         super.onSuccessfulLoad = async () => {
@@ -127,11 +128,11 @@ export class SendTypeComponent extends BaseSendComponent {
     }
 
     async selectSend(s: SendView) {
-        // TODO -> Route to edit send
+        this.router.navigate(['/edit-send'], { queryParams: { sendId: s.id } });
     }
 
     async addSend() {
-        // TODO -> Route to create send
+        this.router.navigate(['/add-send'], { queryParams: { type: this.type } });
     }
 
     back() {


### PR DESCRIPTION
## Objective
> Implement the `add` and `edit` flow for Send.

## Code Changes
- **jslib**: Updated to 8a3b551
- **messages.json**: Fixed `Link vs link` debacle. Added new strings.
- **routing-animations**: Added animation routes for both adding and editing Sends (to/from)
- **app-routing.module.ts**: Added `add-send` and `edit-send` to routing paths
- **app.component.ts**: Added scope cleanup for `vault/GroupingsComponentScope`.  Removed unnecessary `TODO`
- **app.module.ts**: Added `SendAddEditComponent`. Added `DatePipe` provider that is used within the new component.
- **box.scss**: Added `box-header-exapandble` and `flex-label` stylings. Adjusted `input` to not include radio styling. Added `radio-group` styling.
- **misc.scss**: Added `clickable` class styling to add hover states for `app-callout`
- **send-add-edit.component.html/ts**: Created new component.
- **send-groupings.component.ts**: Removed unused import/constructor init. Added routing to `add/edit` component.
- **send-type.component.ts**: Added routing to `add/edit` component.

## Notes
- **File/Text selector**: ~~The extension doesn't use radio buttons currently, so for the sake of existing patterns the `SendType` selector is a dropdown menu. Let me know if we still want to change it to radio buttons (or some variation of that).~~
- **File Warning callout**: Firefox/Safari have issues with opening finder windows/dismissing popup focus so I've used an `app-callout` banner to alert the user (under certain circumstances) that they need to pop out the window in order to choose a file. I didn't want to automatically pop the window out (like we will do in the next release for Attachments) because the user could simply change the `SendType`. I also didn't want to use a dialog for the same reason. The UX is much smoother with the warning banner and voluntary click. 
- **Strings**: I've shortened a few strings (those used with right justified checkboxes) for a nicer look (no wrapping)

## Screenshots
![14-add-file-collapsed](https://user-images.githubusercontent.com/26154748/108882754-5c75ce00-75ca-11eb-8b69-691498053238.png)
![15-add-text-collapsed](https://user-images.githubusercontent.com/26154748/108882759-5da6fb00-75ca-11eb-91cb-e5770f849cac.png)
![16-add-text-expanded](https://user-images.githubusercontent.com/26154748/108574787-e4fc2200-72dd-11eb-9fd9-4aa468fb21dc.png)
![17-add-text-expanded](https://user-images.githubusercontent.com/26154748/108574788-e62d4f00-72dd-11eb-928e-10904e8139e2.png)
![18-edit-text-collapsed](https://user-images.githubusercontent.com/26154748/108574789-e62d4f00-72dd-11eb-88f5-b4ed1963cdb4.png)
![19-edit-text-expanded](https://user-images.githubusercontent.com/26154748/108574791-e6c5e580-72dd-11eb-9a3e-b21650dc9811.png)
![20-edit-text-expanded](https://user-images.githubusercontent.com/26154748/108574792-e75e7c00-72dd-11eb-80be-e2ebb787b2d0.png)
![21-firefox-file-warning](https://user-images.githubusercontent.com/26154748/108882782-64357280-75ca-11eb-9fbe-82daf19e7bee.png)

## Testing Considerations
- `Add` send from both `groupings` and `type` components
- `Edit` send from both `groupings` and `type` components
- `Add File` send works from all browser platforms (chromium, firefox, safari)
- `Delete` existing send from `Edit` component
- All options are functioning properly
