### PR TITLE
fix popup height

### DIFF
--- a/src/popup/services/services.module.ts
+++ b/src/popup/services/services.module.ts
@@ -79,10 +79,14 @@ export function initFactory(platformUtilsService: PlatformUtilsService, i18nServ
     return async () => {
         if (!popupUtilsService.inPopup(window)) {
             window.document.body.classList.add('body-full');
-        } else if (window.screen.availHeight < 600) {
-            window.document.body.classList.add('body-xs');
-        } else if (window.screen.availHeight <= 800) {
-            window.document.body.classList.add('body-sm');
+        } else {
+            if (window.screen.availHeight < 600) {
+                window.document.body.classList.add('body-xs');
+            } else if (window.screen.availHeight <= 800) {
+                window.document.body.classList.add('body-sm');
+            }
+
+            document.body.style.setProperty('height',`${window.innerHeight}px`,'important');
         }
 
         if (BrowserApi.getBackgroundPage() != null) {


### PR DESCRIPTION
I encountered the same problem on  Chrome and ms edge
I write this fix, I have tested on the latest versions of Firefox, chrome, and ms edge, It works.
Indeed, firefox doesn't limit the popup height like this. 
This method should not break anything.

Fixes https://github.com/bitwarden/browser/issues/1008
Fixes https://github.com/bitwarden/browser/issues/1030
Fixes https://github.com/bitwarden/browser/issues/1650

### Before: ( blue empty area exists, between app-root and body )
![image](https://user-images.githubusercontent.com/44745432/108643262-e3d41c00-74ba-11eb-9745-bdd7b2cde3f2.png)
![image](https://user-images.githubusercontent.com/44745432/108683694-012cd880-7503-11eb-8e21-cb9b93018332.png)

### After:
![image](https://user-images.githubusercontent.com/44745432/108643276-f8b0af80-74ba-11eb-864d-764df3e30627.png)

### Off-topic
Also, I think this `innerHeight` can be used for other sizes instead of "-sm" and "-xs". 
The best popup ratio is known.
