### PR TITLE
Resolve safari not refreshing badge correctly

### DIFF
--- a/src/background/main.background.ts
+++ b/src/background/main.background.ts
@@ -738,6 +738,10 @@ export default class MainBackground {
 
         if (this.platformUtilsService.isFirefox()) {
             await theAction.setIcon(options);
+        } else if (this.platformUtilsService.isSafari()) {
+            // Workaround since Safari 14.0.3 returns a pending promise
+            // which doesn't resolve within a reasonable time.
+            theAction.setIcon(options);
         } else {
             return new Promise(resolve => {
                 theAction.setIcon(options, () => resolve());


### PR DESCRIPTION
## Objective
When locking the browser extension on Safari, the badges tend to persist for a while, I found that switching from Safari to another app and back usually resolves it. This is not exactly the desired behavior, and it seems to be caused by some incorrect behavior with Safari not reliably resolving `chrome.browserAction.setIcon` which prevents subsequent code from running.

## Code Changes
- **main.background.ts**: Added a separate behavior for Safari where we don't wait for `setIcon` to resolve before continuing. From my testing this doesn't seem to negatively affect anything else.