### PR TITLE
[Send] Updated current access input type to text

### DIFF
--- a/src/popup/send/send-add-edit.component.html
+++ b/src/popup/send/send-add-edit.component.html
@@ -186,7 +186,7 @@
                 <div class="box-content">
                     <div class="box-content-row" appBoxRow>
                         <label for="currentAccessCount">{{'currentAccessCount' | i18n}}</label>
-                        <input id="currentAccessCount" readonly type="number" name="CurrentAccessCount"
+                        <input id="currentAccessCount" readonly type="text" name="CurrentAccessCount"
                             [(ngModel)]="send.accessCount">
                     </div>
                 </div>


### PR DESCRIPTION
## Objective
> `Current Access Count` input field gives the impression that the value (at some point) could be changed on Firefox and Safari because the action bars are not hidden when `readonly`. 

## Code Changes
- **send/add-edit.component.html**: Changed `accessCount` input type from `number` to `text`

## Screenshots
![1-browser-readonly](https://user-images.githubusercontent.com/26154748/109514526-bd3e5400-7a6b-11eb-8723-bb21ea863c24.png)

