### PR TITLE
Enable FIDO U2F on Edge

### DIFF
--- a/src/services/browserPlatformUtils.service.ts
+++ b/src/services/browserPlatformUtils.service.ts
@@ -131,7 +131,7 @@ export default class BrowserPlatformUtilsService implements PlatformUtilsService
             return true;
         }
 
-        return this.isChrome() || this.isOpera() || this.isVivaldi();
+        return this.isChrome() || this.isOpera() || this.isVivaldi() || this.isEdge();
     }
 
     supportsDuo(): boolean {


### PR DESCRIPTION
## Objective
Fix #1658. I updated our web vault to support FIDO U2F in Edge (https://github.com/bitwarden/web/pull/804) but didn't update the browser extension as well.

## Code changes
`browserPlatformUtils`: Add Edge to the list of browsers that support U2F. No other changes are required, we just have to stop blocking it.