### PR TITLE
Send Date Fallback QA Fixes

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1651,5 +1651,32 @@
   },
   "sendFileCalloutHeader": {
     "message": "Before you start"
+  },
+  "sendFirefoxCustomDatePopoutMessage1": {
+    "message": "To use a calendar style date picker",
+    "description": "This will be used as part of a larger sentence, broken up to include links. The full sentence will read '**To use a calendar style date picker ** click here to pop out your window.'"
+  },
+  "sendFirefoxCustomDatePopoutMessage2": {
+    "message": "click here",
+    "description": "This will be used as part of a larger sentence, broken up to include links. The full sentence will read 'To use a calendar style date picker **click here** to pop out your window.'"
+  },
+  "sendFirefoxCustomDatePopoutMessage3": {
+    "message": "to pop out your window.",
+    "description": "This will be used as part of a larger sentence, broken up to include links. The full sentence will read 'To use a calendar style date picker click here **to pop out your window.**'"
+  },
+  "expirationDateIsInvalid": {
+    "message": "The expiration date provided is not valid."
+  },
+  "deletionDateIsInvalid": {
+    "message": "The deletion date provided is not valid."
+  },
+  "expirationDateAndTimeRequired": {
+    "message": "An expiration date and time are required."
+  },
+  "deletionDateAndTimeRequired": {
+    "message": "A deletion date and time are required."
+  },
+  "dateParsingError": {
+    "message": "There was an error saving your deletion and expiration dates."
   }
 }

--- a/src/popup/send/send-add-edit.component.html
+++ b/src/popup/send/send-add-edit.component.html
@@ -154,6 +154,9 @@
                 </div>
                 <div class="box-footer">
                     {{'deletionDateDesc' | i18n}}
+                    <ng-container *ngIf="isFirefox && (this.editMode || (deletionDateSelect === 0 && !editMode))">
+                        <br>{{'sendFirefoxCustomDatePopoutMessage1' | i18n}} <a (click)="popOutWindow()">{{'sendFirefoxCustomDatePopoutMessage2' | i18n}}</a> {{'sendFirefoxCustomDatePopoutMessage3' | i18n}}
+                    </ng-container>
                 </div>
             </div>
             <!-- Expiration Date -->
@@ -168,7 +171,7 @@
                         <div class="flex flex-grow" *ngIf="!isDateTimeLocalSupported">
                             <input id="expirationDateCustomFallback" type="date"
                                 name="ExpirationDateFallback" [(ngModel)]="expirationDateFallback" [required]="!editMode"
-                                placeholder="MM/DD/YYYY" [readOnly]="disableSend">
+                                placeholder="MM/DD/YYYY" [readOnly]="disableSend" (change)="expirationDateFallbackChanged()">
                             <input *ngIf="!isSafari" id="expirationTimeCustomFallback" type="time"
                                 name="ExpirationTimeFallback" [(ngModel)]="expirationTimeFallback" [required]="!editMode"
                                 placeholder="HH:MM AM/PM" [readOnly]="disableSend">
@@ -200,6 +203,9 @@
                 </div>
                 <div class="box-footer">
                     {{'expirationDateDesc' | i18n}}
+                    <ng-container *ngIf="isFirefox && (this.editMode || (deletionDateSelect === 0 && !editMode))">
+                        <br>{{'sendFirefoxCustomDatePopoutMessage1' | i18n}} <a (click)="popOutWindow()">{{'sendFirefoxCustomDatePopoutMessage2' | i18n}}</a> {{'sendFirefoxCustomDatePopoutMessage3' | i18n}}
+                    </ng-container>
                 </div>
             </div>
             <!-- Maximum Access Count -->

--- a/src/popup/send/send-add-edit.component.html
+++ b/src/popup/send/send-add-edit.component.html
@@ -154,7 +154,7 @@
                 </div>
                 <div class="box-footer">
                     {{'deletionDateDesc' | i18n}}
-                    <ng-container *ngIf="isFirefox && (this.editMode || (deletionDateSelect === 0 && !editMode))">
+                    <ng-container *ngIf="(!inPopout && isFirefox) && (this.editMode || (deletionDateSelect === 0 && !editMode))">
                         <br>{{'sendFirefoxCustomDatePopoutMessage1' | i18n}} <a (click)="popOutWindow()">{{'sendFirefoxCustomDatePopoutMessage2' | i18n}}</a> {{'sendFirefoxCustomDatePopoutMessage3' | i18n}}
                     </ng-container>
                 </div>
@@ -203,7 +203,7 @@
                 </div>
                 <div class="box-footer">
                     {{'expirationDateDesc' | i18n}}
-                    <ng-container *ngIf="isFirefox && (this.editMode || (deletionDateSelect === 0 && !editMode))">
+                    <ng-container *ngIf="(!inPopout && isFirefox) && (this.editMode || (deletionDateSelect === 0 && !editMode))">
                         <br>{{'sendFirefoxCustomDatePopoutMessage1' | i18n}} <a (click)="popOutWindow()">{{'sendFirefoxCustomDatePopoutMessage2' | i18n}}</a> {{'sendFirefoxCustomDatePopoutMessage3' | i18n}}
                     </ng-container>
                 </div>


### PR DESCRIPTION
https://github.com/bitwarden/jslib/pull/300
https://github.com/bitwarden/web/pull/879

QA requested a few fix ups to the send date fallbacks.

1. The calendar popup for `<input type="date">` doesn't work in the Firefox browser plugin. This is for the same reason `<input type="file">` popups don't work, and has been handled in a similar way by adding some subtext telling users to pop out the extension to use the picker. The text based date input works as expected regardless of being in a popup or not.
2. Better error messages for input validation. Placeholders were created for messages in jslib but they didn't get added to clients.
3. We should auto populate `expirationTime` if `expirationDate` is set and no time is already present. Not doing so was causing confusion when trying to just set a date and click submit.  

Changes made to `browser`:
1. Added a message w/link under custom expiration/deletion dates saying to use the calendar picker users should pop out their window (if they aren't already popped out).
2. Added error messages for Send input validation
3. Hooked in to the new expirationDate change event in jslib to auto populate time if it is empty.