### PR TITLE
Resolve FF < 77 not working

### DIFF
--- a/src/background/nativeMessaging.background.ts
+++ b/src/background/nativeMessaging.background.ts
@@ -36,7 +36,7 @@ export class NativeMessagingBackground {
         private messagingService: MessagingService, private appIdService: AppIdService) {
             this.storageService.save(ConstantsService.biometricFingerprintValidated, false);
 
-            if (BrowserApi.isChromeApi) {
+            if (chrome?.permissions?.onAdded) {
                 // Reload extension to activate nativeMessaging
                 chrome.permissions.onAdded.addListener(permissions => {
                     BrowserApi.reloadExtension(null);


### PR DESCRIPTION
## Summary
Firefox < 77 doesn't support `chrome.permisisons.onAdded`. Since this event is only relevant for when Browser Biometrics is enabled we can safely ignore it for older versions of FF.

Resolves #1699 