### PR TITLE
Revert "Merge pull request #1627 from emindeniz99/master"

### DIFF
--- a/src/popup/services/services.module.ts
+++ b/src/popup/services/services.module.ts
@@ -74,14 +74,10 @@ export function initFactory(platformUtilsService: PlatformUtilsService, i18nServ
     return async () => {
         if (!popupUtilsService.inPopup(window)) {
             window.document.body.classList.add('body-full');
-        } else {
-            if (window.screen.availHeight < 600) {
-                window.document.body.classList.add('body-xs');
-            } else if (window.screen.availHeight <= 800) {
-                window.document.body.classList.add('body-sm');
-            }
-
-            document.body.style.setProperty('height', `${window.innerHeight}px`, 'important');
+        } else if (window.screen.availHeight < 600) {
+            window.document.body.classList.add('body-xs');
+        } else if (window.screen.availHeight <= 800) {
+            window.document.body.classList.add('body-sm');
         }
 
         if (BrowserApi.getBackgroundPage() != null) {


### PR DESCRIPTION
## Objective

PR #1627 introduced the following bugs:
* In Firefox on Mac, the browser extension does not consistently open/render when the Bitwarden icon is clicked.  Sometimes a gray box will briefly pop up before disappearing. 
* The browser extension in Safari does not open/expand correctly, leaving the extension nearly unusable unless the user manages to open the Pop Up. The extension window is so small and cannot easily be expanded.

The PR used `window.innerHeight` to set the height of the `body` element, but `window.innerHeight` is not reliable - sometimes it equals 0px (in Firefox) or 50px (in Safari), which is why the popup is not opening to its proper size.

## Code changes
PR #1627 was intended to fix duplicate/unnecessary scrollbars appearing in the popup window (see #1008, #1030, #1650). As an extra scrollbar is a low-priority issue, but the popup not opening is a high-priority issue, I think the best course of action is to revert this fix and revisit the original bug.

I wanted to propose an alternative fix, but I was unable to reproduce the original bug, so I'll put it through our usual triage workflow first.

This reverts commit 9063a98949f0b2656feafe19c64ecf6f2802b43d, reversing changes made to 540ca5d204e12126ad3cc29e3503f2a246188a4e.