### PR TITLE
fixing the source issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,17 +93,11 @@ jobs:
       - name: gulp
         run: gulp ci
 
-      - name: make source directory
-        run: mkdir dist/Source
-
-      - name: checkout repo
-        uses: actions/checkout@v2
-        with: 
-          path: 'dist/Source'
-
       - name: Build sources for reviewers
         shell: cmd
         run: |
+          mkdir dist\Source
+          call git clone %REPO_URL% dist\Source
           cd dist\Source
           call git checkout %GITHUB_SHA%
           call git submodule update --init --recursive


### PR DESCRIPTION
## Summary
The issue of the empty source zip had something to do with how we were originally cloning it. That fix broke something else. Reverted to a slightly altered version.

## Files Changed
- .github/workflows/release.yml

## Notes
- Tested via `npm i`