### PR TITLE
Hide autofill buttons for certain cipher types

### DIFF
--- a/src/popup/vault/view.component.html
+++ b/src/popup/vault/view.component.html
@@ -269,7 +269,7 @@
     <div class="box list">
         <div class="box-content single-line">
             <a class="box-content-row" href="#" appStopClick appBlurClick (click)="fillCipher()"
-                *ngIf="!cipher.isDeleted && !inPopout">
+                *ngIf="cipher.type !== cipherType.SecureNote && !cipher.isDeleted && !inPopout">
                 <div class="row-main text-primary">
                     <div class="icon text-primary" aria-hidden="true">
                         <i class="fa fa-pencil-square-o fa-lg fa-fw"></i>
@@ -278,7 +278,7 @@
                 </div>
             </a>
             <a class="box-content-row" href="#" appStopClick appBlurClick (click)="fillCipherAndSave()"
-                *ngIf="!cipher.isDeleted && !inPopout">
+                *ngIf="cipher.type === cipherType.Login && !cipher.isDeleted && !inPopout">
                 <div class="row-main text-primary">
                     <div class="icon text-primary" aria-hidden="true">
                         <i class="fa fa-bookmark fa-lg fa-fw"></i>

--- a/src/popup/vault/view.component.ts
+++ b/src/popup/vault/view.component.ts
@@ -29,6 +29,8 @@ import { BrowserApi } from '../../browser/browserApi';
 import { AutofillService } from '../../services/abstractions/autofill.service';
 import { PopupUtilsService } from '../services/popup-utils.service';
 
+import { CipherType } from 'jslib/enums';
+
 const BroadcasterSubscriptionId = 'ChildViewComponent';
 
 @Component({
@@ -41,6 +43,7 @@ export class ViewComponent extends BaseViewComponent {
     tab: any;
     loadPageDetailsTimeout: number;
     inPopout = false;
+    cipherType = CipherType;
 
     constructor(cipherService: CipherService, totpService: TotpService,
         tokenService: TokenService, i18nService: I18nService,


### PR DESCRIPTION
## Objective
This is a minor UI bug that has been bothering me: the "Autofill" and "Autofill and Save" buttons currently appear for all item types, even those that do not support those operations.

## Code changes
* Hide Autofill button for secure notes (as they cannot be autofilled)
* Only show Autofill and Save button for logins (as only logins have a saved URI list)