### PR TITLE
update service params

### DIFF
--- a/src/background/main.background.ts
+++ b/src/background/main.background.ts
@@ -23,6 +23,7 @@ import {
 import { ConsoleLogService } from 'jslib/services/consoleLog.service';
 import { EventService } from 'jslib/services/event.service';
 import { ExportService } from 'jslib/services/export.service';
+import { FileUploadService } from 'jslib/services/fileUpload.service';
 import { NotificationsService } from 'jslib/services/notifications.service';
 import { PolicyService } from 'jslib/services/policy.service';
 import { SearchService } from 'jslib/services/search.service';
@@ -56,6 +57,7 @@ import {
 import { CryptoFunctionService as CryptoFunctionServiceAbstraction } from 'jslib/abstractions/cryptoFunction.service';
 import { EventService as EventServiceAbstraction } from 'jslib/abstractions/event.service';
 import { ExportService as ExportServiceAbstraction } from 'jslib/abstractions/export.service';
+import { FileUploadService as FileUploadServiceAbstraction } from 'jslib/abstractions/fileUpload.service';
 import { NotificationsService as NotificationsServiceAbstraction } from 'jslib/abstractions/notifications.service';
 import { PolicyService as PolicyServiceAbstraction } from 'jslib/abstractions/policy.service';
 import { SearchService as SearchServiceAbstraction } from 'jslib/abstractions/search.service';
@@ -124,6 +126,7 @@ export default class MainBackground {
     analytics: Analytics;
     popupUtilsService: PopupUtilsService;
     sendService: SendServiceAbstraction;
+    fileUploadService: FileUploadServiceAbstraction;
 
     onUpdatedRan: boolean;
     onReplacedRan: boolean;
@@ -187,8 +190,9 @@ export default class MainBackground {
         this.collectionService = new CollectionService(this.cryptoService, this.userService, this.storageService,
             this.i18nService);
         this.searchService = new SearchService(this.cipherService, this.consoleLogService);
-        this.sendService = new SendService(this.cryptoService, this.userService, this.apiService, this.storageService,
-            this.i18nService, this.cryptoFunctionService);
+        this.fileUploadService = new FileUploadService(this.consoleLogService, this.apiService);
+        this.sendService = new SendService(this.cryptoService, this.userService, this.apiService, this.fileUploadService,
+            this.storageService, this.i18nService, this.cryptoFunctionService);
         this.stateService = new StateService();
         this.policyService = new PolicyService(this.userService, this.storageService);
         this.vaultTimeoutService = new VaultTimeoutService(this.cipherService, this.folderService,


### PR DESCRIPTION
## Objective
PR #1740 broke the MacOS build and probably should have broken the other builds as well. The build error showed up in the MacOS build of the Desktop app [here](https://github.com/bitwarden/desktop/runs/2214142256?check_suite_focus=true) (given that it bundles the browser extension).

The cause of the error is that the params to `sendService` needed to be updated to match the latest `jslib`.

## Code changes
Replicated @addisonbeck's changes to the service params in the other repos, e.g. [here](https://github.com/bitwarden/desktop/pull/812).