### PR TITLE
Fix bgcolor of option els when in FF sidebar

### DIFF
--- a/src/popup/scss/misc.scss
+++ b/src/popup/scss/misc.scss
@@ -341,6 +341,8 @@ input[type="password"]::-ms-reveal {
 
 // Workaround for rendering error in Firefox sidebar
 // option elements will not render background-color correctly if identical to parent background-color
-html.theme_dark select option, html.theme_nord select option {
-    background-color: adjust-color(map-get(map-get($themes, dark), inputBackgroundColor), +1);
+select option {
+    @include themify($themes) {
+        background-color: adjust-color(themed('inputBackgroundColor'), +1);
+    }
 }

--- a/src/popup/scss/misc.scss
+++ b/src/popup/scss/misc.scss
@@ -339,8 +339,8 @@ input[type="password"]::-ms-reveal {
     }
 }
 
-// Workaround for rendering error in Firefox sidebar when in dark mode
+// Workaround for rendering error in Firefox sidebar
 // option elements will not render background-color correctly if identical to parent background-color
-html.theme_dark select option {
+html.theme_dark select option, html.theme_nord select option {
     background-color: adjust-color(map-get(map-get($themes, dark), inputBackgroundColor), +1);
 }

--- a/src/popup/scss/misc.scss
+++ b/src/popup/scss/misc.scss
@@ -338,3 +338,9 @@ input[type="password"]::-ms-reveal {
         }
     }
 }
+
+// Workaround for rendering error in Firefox sidebar when in dark mode
+// option elements will not render background-color correctly if identical to parent background-color
+html.theme_dark select option {
+    background-color: adjust-color(map-get(map-get($themes, dark), inputBackgroundColor), +1);
+}


### PR DESCRIPTION
## Objective
Fix #1700: `<option>` elements do not render correctly in FF sidebar when using the dark or node themes. e.g.

![Screen Shot 2021-04-02 at 2 57 07 pm](https://user-images.githubusercontent.com/31796059/113381997-b9338800-93c3-11eb-9990-1a702fcc564d.png)

I presume it also affects the light theme, it's just less obvious.

## Code changes
There appears to be a FF rendering bug where the `<option>` background color will not be rendered correctly if it's identical to the background color of the parent `<select>` element. This only occurs in sidebar mode.

After some experimenting, I couldn't think of a better way to solve it than to offset the background-color value slightly for all `<option>` elements. This is enough to work around the FF bug, while not being visually distinct to users. Also, it's only visible when the user has a `<select>` element open, which is very brief.

This fix does not distinguish between browsers or popup vs. sidebar. I'm not aware of any way to do this in the scss and I didn't think it was worth introducing extra code for.

Yes, I know this is hacky. I'm using scss to do terrible things.