### PR TITLE
Increase popup width on linux during WebAuthn process

### DIFF
--- a/src/browser/browserApi.ts
+++ b/src/browser/browserApi.ts
@@ -176,4 +176,13 @@ export class BrowserApi {
             chrome.permissions.request(permission, resolve);
         });
     }
+
+    static getPlatformInfo(): Promise<browser.runtime.PlatformInfo | chrome.runtime.PlatformInfo> {
+        if (BrowserApi.isWebExtensionsApi) {
+            return browser.runtime.getPlatformInfo();
+        }
+        return new Promise((resolve) => {
+            chrome.runtime.getPlatformInfo(resolve);
+        });
+    }
 }

--- a/src/popup/accounts/two-factor.component.ts
+++ b/src/popup/accounts/two-factor.component.ts
@@ -74,8 +74,9 @@ export class TwoFactorComponent extends BaseTwoFactorComponent {
             return;
         }
 
-        const platformInfo = await BrowserApi.getPlatformInfo();
-        if (this.selectedProviderType === TwoFactorProviderType.WebAuthn && platformInfo.os == "linux") {
+        // WebAuthn prompt appears inside the popup on linux, and requires a larger popup width
+        // than usual to avoid cutting off the dialog.
+        if (this.selectedProviderType === TwoFactorProviderType.WebAuthn && await this.isLinux()) {
             document.body.classList.add('linux-webauthn');
         }
 
@@ -106,8 +107,7 @@ export class TwoFactorComponent extends BaseTwoFactorComponent {
     async ngOnDestroy() {
         this.broadcasterService.unsubscribe(BroadcasterSubscriptionId);
 
-        const platformInfo = await BrowserApi.getPlatformInfo();
-        if (this.selectedProviderType === TwoFactorProviderType.WebAuthn && platformInfo.os == "linux") {
+        if (this.selectedProviderType === TwoFactorProviderType.WebAuthn && await this.isLinux()) {
             document.body.classList.remove('linux-webauthn');
         }
         super.ngOnDestroy();
@@ -115,5 +115,9 @@ export class TwoFactorComponent extends BaseTwoFactorComponent {
 
     anotherMethod() {
         this.router.navigate(['2fa-options']);
+    }
+
+    async isLinux() {
+        return (await BrowserApi.getPlatformInfo()).os === "linux";
     }
 }

--- a/src/popup/accounts/two-factor.component.ts
+++ b/src/popup/accounts/two-factor.component.ts
@@ -74,6 +74,11 @@ export class TwoFactorComponent extends BaseTwoFactorComponent {
             return;
         }
 
+        const platformInfo = await BrowserApi.getPlatformInfo();
+        if (this.selectedProviderType === TwoFactorProviderType.WebAuthn && platformInfo.os == "linux") {
+            document.body.classList.add('linux-webauthn');
+        }
+
         if (this.selectedProviderType === TwoFactorProviderType.Email &&
             this.popupUtilsService.inPopup(window)) {
             const confirmed = await this.platformUtilsService.showDialog(this.i18nService.t('popup2faCloseMessage'),
@@ -98,8 +103,13 @@ export class TwoFactorComponent extends BaseTwoFactorComponent {
         });
     }
 
-    ngOnDestroy() {
+    async ngOnDestroy() {
         this.broadcasterService.unsubscribe(BroadcasterSubscriptionId);
+
+        const platformInfo = await BrowserApi.getPlatformInfo();
+        if (this.selectedProviderType === TwoFactorProviderType.WebAuthn && platformInfo.os == "linux") {
+            document.body.classList.remove('linux-webauthn');
+        }
         super.ngOnDestroy();
     }
 

--- a/src/popup/scss/misc.scss
+++ b/src/popup/scss/misc.scss
@@ -189,6 +189,16 @@ p.lead {
     }
 }
 
+body.linux-webauthn {
+    width: 485px !important;
+    #web-authn-frame {
+        iframe {
+            width: 375px;
+            margin: 0 55px;
+        }
+    }
+}
+
 app-root > #loading {
     display: flex;
     text-align: center;


### PR DESCRIPTION
## Objective
On linux the WebAuthn browser controlled dialog appears inside the popup, which causes it to be cut off due to our limited popup width. To work around this I increase the width temporarily.

## Files Changed
* **src/browser/browserApi.ts**: Added `getPlatformInfo` to figure out which os the browser is running on.
* **src/popup/accounts/two-factor.component.ts**: Add a temporary class `.linux-webauthn` to the body if on linux and using WebAuthn.
* **src/popup/scss/misc.scss**: Add `.linux-webauthn` class which expands the width to 490px which is slightly larger than the prompt.