### PR TITLE
Show file picker warning in chromium on Mac 11

### DIFF
--- a/src/popup/send/send-add-edit.component.html
+++ b/src/popup/send/send-add-edit.component.html
@@ -25,7 +25,7 @@
         <app-callout type="warning" icon="fa fa-external-link fa-rotate-270 fa-fw" [clickable]="true"
             title="{{'sendFileCalloutHeader' | i18n}}"
             *ngIf="showFilePopoutMessage && send.type === sendType.File && !disableSend" (click)="popOutWindow()">
-            <div *ngIf="showLinuxChromiumFileWarning">{{'sendLinuxChromiumFileWarning' | i18n}}</div>
+            <div *ngIf="showChromiumFileWarning">{{'sendLinuxChromiumFileWarning' | i18n}}</div>
             <div *ngIf="showFirefoxFileWarning">{{'sendFirefoxFileWarning' | i18n}}</div>
             <div *ngIf="showSafariFileWarning">{{'sendSafariFileWarning' | i18n}}</div>
         </app-callout>

--- a/src/popup/send/send-add-edit.component.ts
+++ b/src/popup/send/send-add-edit.component.ts
@@ -34,6 +34,7 @@ export class SendAddEditComponent extends BaseAddEditComponent {
     inPopout = false;
     inSidebar = false;
     isLinux = false;
+    isUnsupportedMac = false;
 
     constructor(i18nService: I18nService, platformUtilsService: PlatformUtilsService,
         userService: UserService, messagingService: MessagingService, policyService: PolicyService,
@@ -45,14 +46,14 @@ export class SendAddEditComponent extends BaseAddEditComponent {
     }
 
     get showFileSelector(): boolean {
-        return !this.editMode && (!this.isFirefox && !this.isSafari && !this.isLinux) ||
+        return !this.editMode && (!this.isFirefox && !this.isSafari && !this.isLinux && !this.isUnsupportedMac) ||
             (this.isFirefox && (this.inSidebar || this.inPopout)) ||
             (this.isSafari && this.inPopout) ||
-            (this.isLinux && !this.isFirefox && (this.inSidebar || this.inPopout));
+            ((this.isLinux || this.isUnsupportedMac) && !this.isFirefox && (this.inSidebar || this.inPopout));
     }
 
     get showFilePopoutMessage(): boolean {
-        return !this.editMode && (this.showFirefoxFileWarning || this.showSafariFileWarning || this.showLinuxChromiumFileWarning);
+        return !this.editMode && (this.showFirefoxFileWarning || this.showSafariFileWarning || this.showChromiumFileWarning);
     }
 
     get showFirefoxFileWarning(): boolean {
@@ -63,9 +64,9 @@ export class SendAddEditComponent extends BaseAddEditComponent {
         return this.isSafari && !this.inPopout;
     }
 
-    // Only show this for Chromium based browsers in Linux
-    get showLinuxChromiumFileWarning(): boolean {
-        return this.isLinux && !this.isFirefox && !(this.inSidebar || this.inPopout);
+    // Only show this for Chromium based browsers in Linux and Mac > Big Sur
+    get showChromiumFileWarning(): boolean {
+        return (this.isLinux || this.isUnsupportedMac) && !this.isFirefox && !(this.inSidebar || this.inPopout);
     }
 
     popOutWindow() {
@@ -78,6 +79,7 @@ export class SendAddEditComponent extends BaseAddEditComponent {
         this.inPopout = this.popupUtilsService.inPopout(window);
         this.inSidebar = this.popupUtilsService.inSidebar(window);
         this.isLinux = window?.navigator?.userAgent.indexOf('Linux') !== -1;
+        this.isUnsupportedMac = this.platformUtilsService.isChrome() && window?.navigator?.appVersion.includes('Mac OS X 11');
 
         const queryParamsSub = this.route.queryParams.subscribe(async params => {
             if (params.sendId) {


### PR DESCRIPTION
## Objective
There is a bug in chromium which prevents the file picker from working correctly on Mac 11+. Temporarily adding the warning until this has been resolved. Once fixed we can revert this PR.