### PR TITLE
Simplify and fix file picker logic

### DIFF
--- a/src/popup/send/send-add-edit.component.ts
+++ b/src/popup/send/send-add-edit.component.ts
@@ -46,10 +46,7 @@ export class SendAddEditComponent extends BaseAddEditComponent {
     }
 
     get showFileSelector(): boolean {
-        return !this.editMode && (!this.isFirefox && !this.isSafari && !this.isLinux && !this.isUnsupportedMac) ||
-            (this.isFirefox && (this.inSidebar || this.inPopout)) ||
-            (this.isSafari && this.inPopout) ||
-            ((this.isLinux || this.isUnsupportedMac) && !this.isFirefox && (this.inSidebar || this.inPopout));
+        return !(this.editMode || this.showFilePopoutMessage);
     }
 
     get showFilePopoutMessage(): boolean {


### PR DESCRIPTION
# Overview

Fix https://app.asana.com/0/0/1200155711369722/f.

The actual issue here is a missing set of parenthesis, but simplifying the logic to _not_ show the picker whenever a popup warning message is displayed.

# Files Changed
* **send-add-edit.component.ts**: simplify logic

# Testing
This will require full regression testing across browsers. The expected behavior is:
* firefox: file picker hidden and warning message displayed in popup, not in side bar or popout -- for all OSes
* linux: file picker hidden and warning displayed in popups across all browsers
* safari: file picker hidden and warning displayed in popup, not in popout -- only relevant to mac
In all clients across all OSes, the file picker show never be displayed in `edit` mode.