### PR TITLE
Don't use tokenService to manage emailVerified

### DIFF
--- a/src/popup/send/send-add-edit.component.ts
+++ b/src/popup/send/send-add-edit.component.ts
@@ -16,7 +16,6 @@ import { MessagingService } from 'jslib/abstractions/messaging.service';
 import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
 import { PolicyService } from 'jslib/abstractions/policy.service';
 import { SendService } from 'jslib/abstractions/send.service';
-import { TokenService } from 'jslib/abstractions/token.service';
 import { UserService } from 'jslib/abstractions/user.service';
 
 import { PopupUtilsService } from '../services/popup-utils.service';

--- a/src/popup/send/send-add-edit.component.ts
+++ b/src/popup/send/send-add-edit.component.ts
@@ -41,9 +41,9 @@ export class SendAddEditComponent extends BaseAddEditComponent {
         userService: UserService, messagingService: MessagingService, policyService: PolicyService,
         environmentService: EnvironmentService, datePipe: DatePipe, sendService: SendService,
         private route: ActivatedRoute, private router: Router, private location: Location,
-        private popupUtilsService: PopupUtilsService, tokenService: TokenService) {
+        private popupUtilsService: PopupUtilsService) {
         super(i18nService, platformUtilsService, environmentService, datePipe, sendService, userService,
-            messagingService, policyService, tokenService);
+            messagingService, policyService);
     }
 
     get showFileSelector(): boolean {


### PR DESCRIPTION
## Objective

Bump jslib and remove `tokenService` from the send `add-edit` component. Required for https://github.com/bitwarden/jslib/pull/344.