### PR TITLE
Revert "Popover arrow background color"

### DIFF
--- a/src/popup/scss/base.scss
+++ b/src/popup/scss/base.scss
@@ -22,7 +22,7 @@ body {
 
     @include themify($themes) {
         color: themed('textColor');
-        background-color: themed('headerBackgroundColor');
+        background-color: themed('backgroundColor');
     }
 
     &.body-sm {


### PR DESCRIPTION
## Objective
Firefox 89 includes the "Proton" redesign which changes how the extension is displayed. The popup arrow is removed and the extension has rounded corners. Unfortunately the bottom corners contains an ugly blue bleed-through. This reverts the previous PR which changed the background color to be the same as the header, which should mitigate most of the issue. However we still have a bit of bleed-though on the top instead but it's less noticeable.

### Screenshots

Before:
![before](https://user-images.githubusercontent.com/137855/115553555-d3b79d80-a2ad-11eb-87c2-7bf9bfd704e4.png)

After:
![after](https://user-images.githubusercontent.com/137855/115553641-f1850280-a2ad-11eb-8176-8e2a556d0072.png)