### PR TITLE
Change biometric prompt to use the same logic as electron

### DIFF
--- a/src/safari/safari/SafariWebExtensionHandler.swift
+++ b/src/safari/safari/SafariWebExtensionHandler.swift
@@ -95,10 +95,21 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
                         ],
                     ],
                 ]
-                break;
+                break
             }
 
-            let accessControl = SecAccessControlCreateWithFlags(nil, kSecAttrAccessibleWhenUnlockedThisDeviceOnly, [.privateKeyUsage, .userPresence], nil)!
+            guard let accessControl = SecAccessControlCreateWithFlags(nil, kSecAttrAccessibleWhenUnlockedThisDeviceOnly, [.privateKeyUsage, .userPresence], nil) else {
+                response.userInfo = [
+                    SFExtensionMessageKey: [
+                        "message": [
+                            "command": "biometricUnlock",
+                            "response": "not supported",
+                            "timestamp": Int64(NSDate().timeIntervalSince1970 * 1000),
+                        ],
+                    ],
+                ]
+                break
+            }
             laContext.evaluateAccessControl(accessControl, operation: .useKeySign, localizedReason: "Bitwarden Safari Extension") { (success, error) in
                 if success {
                     let passwordName = "key"
@@ -135,7 +146,7 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
                 context.completeRequest(returningItems: [response], completionHandler: nil)
             }
             
-            return;
+            return
         default:
             return
         }

--- a/src/safari/safari/SafariWebExtensionHandler.swift
+++ b/src/safari/safari/SafariWebExtensionHandler.swift
@@ -98,7 +98,8 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
                 break;
             }
 
-            laContext.evaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, localizedReason: "Bitwarden Safari Extension") { (success, error) in
+            let accessControl = SecAccessControlCreateWithFlags(nil, kSecAttrAccessibleWhenUnlockedThisDeviceOnly, [.privateKeyUsage, .userPresence], nil)!
+            laContext.evaluateAccessControl(accessControl, operation: .useKeySign, localizedReason: "Bitwarden Safari Extension") { (success, error) in
                 if success {
                     let passwordName = "key"
                     var passwordLength: UInt32 = 0

--- a/src/safari/safari/SafariWebExtensionHandler.swift
+++ b/src/safari/safari/SafariWebExtensionHandler.swift
@@ -87,7 +87,7 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
             
             laContext.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error)
             
-            if (error != nil && error!.code != kLAErrorBiometryLockout) {
+            if let e = error, e.code != kLAErrorBiometryLockout {
                 response.userInfo = [
                     SFExtensionMessageKey: [
                         "message": [

--- a/src/safari/safari/SafariWebExtensionHandler.swift
+++ b/src/safari/safari/SafariWebExtensionHandler.swift
@@ -85,7 +85,9 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
             var error: NSError?
             let laContext = LAContext()
             
-            guard laContext.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error) else {
+            laContext.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error)
+            
+            if (error != nil && error!.code != kLAErrorBiometryLockout) {
                 response.userInfo = [
                     SFExtensionMessageKey: [
                         "message": [


### PR DESCRIPTION
## Objective
We had a slightly different logic for biometric unlock on Safari. Changed to use the exact same logic as Electron does to provide similar UX across all platforms. (It adds a password fallback)

### Testing Considerations
We should re-test Safari biometric unlock to verify everything still works.