### PR TITLE
Fix typo in webAuthnAuthenticate

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -806,7 +806,7 @@
     "message": "Continue the WebAuthn 2FA verification in the new tab."
   },
   "webAuthnAuthenticate": {
-    "message": "Authenticate WebAutn"
+    "message": "Authenticate WebAuthn"
   },
   "loginUnavailable": {
     "message": "Login Unavailable"


### PR DESCRIPTION
As reported by user in Crowdin (https://crowdin.com/translate/bitwarden-browser/26/en-de#4816), the source string had a small typo. This PR fixes it.