### PR TITLE
Add to extName description to limit to 40 chars

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -4,7 +4,7 @@
   },
   "extName": {
     "message": "Bitwarden - Free Password Manager",
-    "description": "Extension name"
+    "description": "Extension name, MUST be less than 40 characters (Safari restriction)"
   },
   "extDesc": {
     "message": "A secure and free password manager for all of your devices.",


### PR DESCRIPTION
Safari gets angry when you try to submit an appex in your desktop app when submitting to MAS if the extension name (localized) is greater than 40 characters. This adds a description asking translators to not exceed this.