### PR TITLE
Bump Node Version from 8 to 14 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The Bitwarden browser extension is written using the Web Extension API and Angul
 
 **Requirements**
 
-- [Node.js](https://nodejs.org) v8.11 or greater
+- [Node.js](https://nodejs.org) v14.17 or greater
 - [Gulp](https://gulpjs.com/) (`npm install --global gulp-cli`)
 - Chrome (preferred), Opera, or Firefox browser
 


### PR DESCRIPTION
With @Hinton bumping node to 14 recently, I've adjusted the README to show the need for Node 14.17 (LTS) 