### PR TITLE
[Autofill on Page Load options] Change default per-item setting to "autofill"

### DIFF
--- a/src/popup/settings/options.component.ts
+++ b/src/popup/settings/options.component.ts
@@ -77,7 +77,7 @@ export class OptionsComponent implements OnInit {
             ConstantsService.enableAutoFillOnPageLoadKey);
         
         this.autoFillOnPageLoadDefault = await this.storageService.get<boolean>(
-            ConstantsService.autoFillOnPageLoadDefaultKey) ?? false;
+            ConstantsService.autoFillOnPageLoadDefaultKey) ?? true;
 
         this.disableAddLoginNotification = await this.storageService.get<boolean>(
             ConstantsService.disableAddLoginNotificationKey);


### PR DESCRIPTION
## Objective

With the new per-item Autofill On Page Load settings, I had intended that all logins continue to autofill by default, so that anyone currently using the feature will not experience any change in behaviour after upgrading their client. (Assuming that they have opted-in to the Autofill On Page Load feature to begin with.)

However, for some reason I had set it to NOT autofill login items by default, which QA picked up in testing.

## Code changes

If saved storage value for `autoFillOnPageLoadDefault` is `null` or `undefined`, default to `true` (autofill logins by default) instead of `false` (do not autofill logins by default).