### PR TITLE
Remove unsafe-inline from Content Security Policy in manifest.json

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -94,7 +94,7 @@
   "optional_permissions": [
     "nativeMessaging"
   ],
-  "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
+  "content_security_policy": "script-src 'self'; object-src 'self'",
   "commands": {
     "_execute_browser_action": {
       "suggested_key": {


### PR DESCRIPTION
In addition to being less than ideal for security, it appears the bitwarden extension does not actually use any functions that require `unsafe-eval` to be allowed in the CSP.

I searched for `eval`, the `Function` constructor, `execScript`, and the `setTimeout`, `setInterval`,  & `setImmediate` functions with string literals passed as arguments, and found no examples of any of these in the codebase.

Therefore, the best option would be to remove this directive, which is exactly what this PR does :)

Please let me know if I'm mistaken, thanks!