### PR TITLE
Convert sets to arrays before saving in storage

### DIFF
--- a/src/services/browserStorage.service.ts
+++ b/src/services/browserStorage.service.ts
@@ -29,6 +29,10 @@ export default class BrowserStorageService implements StorageService {
             });
         }
 
+        if (obj instanceof Set) {
+            obj = Array.from(obj);
+        }
+
         const keyedObj = { [key]: obj };
         return new Promise<void>(resolve => {
             this.chromeStorageApi.set(keyedObj, () => {


### PR DESCRIPTION
## Objective
Replicating this fix for browser: https://github.com/bitwarden/web/pull/1012

This is a pre-emptive fix - I'm not aware of it causing issues in browser currently, but it's caused issues in the other Angular clients, so replicating the code here won't hurt when someone inevitably goes to save a Set to localStorage.