### PR TITLE
Don't start popup services if in private mode

### DIFF
--- a/src/popup/services/services.module.ts
+++ b/src/popup/services/services.module.ts
@@ -65,12 +65,14 @@ function getBgService<T>(service: string) {
     };
 }
 
+const isPrivateMode = BrowserApi.getBackgroundPage() == null;
+
 const stateService = new StateService();
 const messagingService = new BrowserMessagingService();
-const searchService = new PopupSearchService(getBgService<SearchService>('searchService')(),
+const searchService = isPrivateMode ? null : new PopupSearchService(getBgService<SearchService>('searchService')(),
     getBgService<CipherService>('cipherService')(), getBgService<ConsoleLogService>('consoleLogService')(),
     getBgService<I18nService>('i18nService')());
-const passwordRepromptService = new PasswordRepromptService(getBgService<I18nService>('i18nService')(),
+const passwordRepromptService = isPrivateMode ? null : new PasswordRepromptService(getBgService<I18nService>('i18nService')(),
     getBgService<CryptoService>('cryptoService')(), getBgService<PlatformUtilsService>('platformUtilsService')());
 
 export function initFactory(platformUtilsService: PlatformUtilsService, i18nService: I18nService, storageService: StorageService,
@@ -84,7 +86,7 @@ export function initFactory(platformUtilsService: PlatformUtilsService, i18nServ
             window.document.body.classList.add('body-sm');
         }
 
-        if (BrowserApi.getBackgroundPage() != null) {
+        if (!isPrivateMode) {
             await stateService.save(ConstantsService.disableFaviconKey,
                 await storageService.get<boolean>(ConstantsService.disableFaviconKey));
 


### PR DESCRIPTION
## Objective

Fix the following bug: when opening the popup in Firefox private browsing mode, it displays an infinite spinner instead of the private-mode.component (i.e. the warning page stating that private mode is not supported).

## Code changes
`searchService` and `passwordRepromptService` are instantiated in the popup, but their constructors take services started in the background. In private mode, these background services evaluate to `null`, which was throwing errors as soon as the popup services tried to use them.

Solved by checking for private mode before instantiating `searchService` and `passwordRepromptService` .