### PR TITLE
Fix Deprecation Issue on addListener

### DIFF
--- a/src/services/browserPlatformUtils.service.ts
+++ b/src/services/browserPlatformUtils.service.ts
@@ -344,7 +344,7 @@ export default class BrowserPlatformUtilsService implements PlatformUtilsService
     }
 
     onDefaultSystemThemeChange(callback: ((theme: 'light' | 'dark') => unknown)) {
-        this.prefersColorSchemeDark.addListener(({ matches }) => {
+        this.prefersColorSchemeDark.addEventListener('change', ({ matches }) => {
             callback(matches ? 'dark' : 'light');
         });
     }


### PR DESCRIPTION
# Change
Updated the deprecated `addListener` to `addEventListener` to match [Web #1017](https://github.com/bitwarden/web/pull/1017)

# Testing
Set the extension to the `Default` theme. Ensure the theme updates between dark and light when changing system theme. Needs testing on multiple OS' and browsers