### PR TITLE
Must await to get stored value

### DIFF
--- a/src/services/browserStorage.service.ts
+++ b/src/services/browserStorage.service.ts
@@ -20,7 +20,7 @@ export default class BrowserStorageService implements StorageService {
     }
 
     async has(key: string): Promise<boolean> {
-        return this.get(key) != null;
+        return await this.get(key) != null;
     }
 
     async save(key: string, obj: any): Promise<any> {


### PR DESCRIPTION
# Overview

Fix issue where we aren't awaiting `get` to return its value rather than the promise of one.

FYI, this is a regression item and will be cherry-picked into `rc` upon merger to master. Please evaluate accordingly.

# Testing.

I wasn't able to produce a defect for this, but it should have to do with refreshing the popup, sidebar, or popout. It's possible this produces no visible issue, though.