### PR TITLE
[Toast] - BUG - Fixed styles

### DIFF
--- a/src/popup/scss/plugins.scss
+++ b/src/popup/scss/plugins.scss
@@ -8,36 +8,29 @@ $fa-font-path: "~font-awesome/fonts";
 
 // Toaster
 
-#toast-container {
-    .toast-close-button {
-        right: -0.15em;
-    }
-
+.toast-container {
     &.toast-bottom-full-width div.toast {
         margin: 0 10px 10px;
         width: calc(100% - 20px);
+        box-shadow: 0 0 8px rgba(0, 0, 0, 0.35);
+
+         &:hover {
+            box-shadow: 0 0 10px rgba(0, 0, 0, 0.6);
+        }
     }
 
     .toast {
-        opacity: 1 !important;
-        background-image: none !important;
-        border-radius: $border-radius;
-        box-shadow: 0 0 8px rgba(0, 0, 0, 0.35);
-        display: flex;
-        align-items: center;
-
-        &:hover {
-            box-shadow: 0 0 10px rgba(0, 0, 0, 0.6);
-        }
-
         &:before {
             font-family: FontAwesome;
             font-size: 25px;
             line-height: 20px;
             float: left;
             color: #ffffff;
-            padding-right: 10px;
-            margin: auto 0 auto -36px;
+            margin: auto 0 auto 15px;
+        }
+
+        .toast-content {
+            padding: 15px;
         }
 
         .toaster-icon {
@@ -63,7 +56,6 @@ $fa-font-path: "~font-awesome/fonts";
 
             &:before {
                 content: "\f0e7";
-                margin-left: -30px;
             }
         }
 


### PR DESCRIPTION
## Objective
> A recent update to the `angular2-toast` library cause our custom styling to not be applied properly.

## Code Changes
- **plugins.scss**: The `toast-container` object is now a `class` and not an `id`. Updated some padding/margin to more closely match the current production toasts style. Removed unnecessary `toast` styles, they were breaking the animation.

## Screenshots
![2-browser-warning-success](https://user-images.githubusercontent.com/26154748/122268739-0d69e680-cea2-11eb-90cd-ca360a759814.png)
![3-browser-error](https://user-images.githubusercontent.com/26154748/122268742-0e027d00-cea2-11eb-9a6b-0693f9117d5d.png)
![4-browser-info](https://user-images.githubusercontent.com/26154748/122268743-0e027d00-cea2-11eb-8fe1-903f07424618.png)

