### PR TITLE
Redefine cipher "share" to "move to organization"

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -635,7 +635,7 @@
     "message": "Learn about Organizations"
   },
   "learnOrgConfirmation": {
-    "message": "Bitwarden allows you to share your vault items with others by using an organization account. Would you like to visit the bitwarden.com website to learn more?"
+    "message": "Bitwarden allows you to share your vault items with others by using an organization. Would you like to visit the bitwarden.com website to learn more?"
   },
   "moveToOrganization": {
     "message": "Move to Organization"

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -150,6 +150,9 @@
   "save": {
     "message": "Save"
   },
+  "move": {
+    "message": "Move"
+  },
   "addFolder": {
     "message": "Add Folder"
   },
@@ -628,23 +631,33 @@
   "shared": {
     "message": "Shared"
   },
-  "shareVault": {
-    "message": "Share Your Vault"
+  "learnOrg": {
+    "message": "Learn about Organizations"
   },
-  "shareVaultConfirmation": {
-    "message": "Bitwarden allows you to share your vault with others by using an organization account. Would you like to visit the bitwarden.com website to learn more?"
+  "learnOrgConfirmation": {
+    "message": "Bitwarden allows you to share your vault items with others by using an organization account. Would you like to visit the bitwarden.com website to learn more?"
   },
-  "shareItem": {
-    "message": "Share Item"
+  "moveToOrganization": {
+    "message": "Move to Organization"
   },
   "share": {
     "message": "Share"
   },
-  "sharedItem": {
-    "message": "Shared Item"
+  "movedItemToOrg": {
+    "message": "$ITEMNAME$ moved to $ORGNAME$",
+    "placeholders": {
+      "itemname": {
+        "content": "$1",
+        "example": "Secret Item"
+      },
+      "orgname": {
+        "content": "$2",
+        "example": "Company Name"
+      }
+    }
   },
-  "shareDesc": {
-    "message": "Choose an organization that you wish to share this item with. Sharing transfers ownership of the item to the organization. You will no longer be the direct owner of this item once it has been shared."
+  "moveToOrgDesc": {
+    "message": "Choose an organization that you wish to move this item to. Moving to an organization transfers ownership of the item to that organization. You will no longer be the direct owner of this item once it has been moved."
   },
   "learnMore": {
     "message": "Learn more"

--- a/src/popup/components/cipher-row.component.html
+++ b/src/popup/components/cipher-row.component.html
@@ -6,7 +6,7 @@
             <span class="text">
                 {{cipher.name}}
                 <ng-container *ngIf="cipher.organizationId">
-                    <i class="fa fa-share-alt text-muted" title="{{'shared' | i18n}}" aria-hidden="true"></i>
+                    <i class="fa fa-cube text-muted" title="{{'shared' | i18n}}" aria-hidden="true"></i>
                     <span class="sr-only">{{'shared' | i18n}}</span>
                 </ng-container>
                 <ng-container *ngIf="cipher.hasAttachments">

--- a/src/popup/settings/settings.component.html
+++ b/src/popup/settings/settings.component.html
@@ -103,11 +103,6 @@
                 <i class="fa fa-chevron-right fa-lg row-sub-icon" aria-hidden="true"></i>
             </a>
             <a class="box-content-row box-content-row-flex text-default" href="#" appStopClick appBlurClick
-                (click)="share()">
-                <div class="row-main">{{'shareVault' | i18n}}</div>
-                <i class="fa fa-chevron-right fa-lg row-sub-icon" aria-hidden="true"></i>
-            </a>
-            <a class="box-content-row box-content-row-flex text-default" href="#" appStopClick appBlurClick
                 (click)="webVault()">
                 <div class="row-main">{{'bitWebVault' | i18n}}</div>
                 <i class="fa fa-chevron-right fa-lg row-sub-icon" aria-hidden="true"></i>
@@ -124,6 +119,10 @@
             <a class="box-content-row box-content-row-flex text-default" href="#" appStopClick appBlurClick
                 (click)="about()">
                 <div class="row-main">{{'about' | i18n}}</div>
+                <i class="fa fa-chevron-right fa-lg row-sub-icon" aria-hidden="true"></i>
+            </a>
+            <a class="box-content-row box-content-row-flex text-default" href="#" appStopClick appBlurClick (click)="share()">
+                <div class="row-main">{{'learnOrg' | i18n}}</div>
                 <i class="fa fa-chevron-right fa-lg row-sub-icon" aria-hidden="true"></i>
             </a>
             <a class="box-content-row box-content-row-flex text-default" href="#" appStopClick appBlurClick

--- a/src/popup/settings/settings.component.html
+++ b/src/popup/settings/settings.component.html
@@ -121,7 +121,8 @@
                 <div class="row-main">{{'about' | i18n}}</div>
                 <i class="fa fa-chevron-right fa-lg row-sub-icon" aria-hidden="true"></i>
             </a>
-            <a class="box-content-row box-content-row-flex text-default" href="#" appStopClick appBlurClick (click)="share()">
+            <a class="box-content-row box-content-row-flex text-default" href="#" appStopClick appBlurClick
+                (click)="share()">
                 <div class="row-main">{{'learnOrg' | i18n}}</div>
                 <i class="fa fa-chevron-right fa-lg row-sub-icon" aria-hidden="true"></i>
             </a>

--- a/src/popup/settings/settings.component.ts
+++ b/src/popup/settings/settings.component.ts
@@ -310,7 +310,7 @@ export class SettingsComponent implements OnInit {
 
     async share() {
         const confirmed = await this.platformUtilsService.showDialog(
-            this.i18nService.t('shareVaultConfirmation'), this.i18nService.t('shareVault'),
+            this.i18nService.t('learnOrgConfirmation'), this.i18nService.t('learnOrg'),
             this.i18nService.t('yes'), this.i18nService.t('cancel'));
         if (confirmed) {
             BrowserApi.createNewTab('https://help.bitwarden.com/article/what-is-an-organization/');

--- a/src/popup/vault/share.component.html
+++ b/src/popup/vault/share.component.html
@@ -4,12 +4,12 @@
             <button type="button" appBlurClick (click)="cancel()">{{'cancel' | i18n}}</button>
         </div>
         <div class="center">
-            <span class="title">{{'share' | i18n}}</span>
+            <span class="title">{{'moveToOrganization' | i18n}}</span>
         </div>
         <div class="right">
             <button type="submit" appBlurClick [disabled]="form.loading || !canSave"
                 *ngIf="organizations && organizations.length">
-                <span [hidden]="form.loading">{{'save' | i18n}}</span>
+                <span [hidden]="form.loading">{{'move' | i18n}}</span>
                 <i class="fa fa-spinner fa-lg fa-spin" [hidden]="!form.loading" aria-hidden="true"></i>
             </button>
         </div>
@@ -31,7 +31,7 @@
                 </div>
             </div>
             <div class="box-footer">
-                {{'shareDesc' | i18n}}
+                {{'moveToOrgDesc' | i18n}}
             </div>
         </div>
         <div class="box" *ngIf="organizations && organizations.length">

--- a/src/popup/vault/view.component.html
+++ b/src/popup/vault/view.component.html
@@ -304,9 +304,9 @@
             <a class="box-content-row" href="#" appStopClick appBlurClick (click)="share()" *ngIf="!cipher.organizationId">
                 <div class="row-main text-primary">
                     <div class="icon text-primary" aria-hidden="true">
-                        <i class="fa fa-share-alt fa-lg fa-fw"></i>
+                        <i class="fa fa-arrow-circle-o-right fa-lg fa-fw"></i>
                     </div>
-                    <span>{{'shareItem' | i18n}}</span>
+                    <span>{{'moveToOrganization' | i18n}}</span>
                 </div>
             </a>
             <a class="box-content-row" href="#" appStopClick appBlurClick (click)="restore()" *ngIf="cipher.isDeleted">


### PR DESCRIPTION
# Overview

The term "Share" is confusing to users because it implies maintaining ownership and control of a cipher while allowing others to access it as well. It also implies the ability to revoke access or to stop sharing -- neither of these things is true.

In addition to the share term being misleading, the [`fa-share-alt`](https://fontawesome.com/v4.7/icon/share-alt) icon implies a forking of the cipher item rather than transferring ownership.

When a cipher is "shared" it is irrevocably taken over by an organization. This occurs for good cryptographic and security reasons. The better solution to this is to revise the communication around "sharing." To that end, this work changes the term "share" to "move to organization" and the icon is changed to [`fa-cube`](https://fontawesome.com/v4.7/icon/cube), which is used to indicate a collection. The act of moving an item to an organization is denoted by [`fa-arrow-circle-o-right`](https://fontawesome.com/v4.7/icon/arrow-circle-o-right) rather than `fa-share-alt`.

# Screen shots
#### Organization owned item in list
<img width="432" alt="image" src="https://user-images.githubusercontent.com/18214891/122432633-1a96dc00-cf5b-11eb-9799-0d01b655852e.png">

#### Move to organization action
<img width="432" alt="image" src="https://user-images.githubusercontent.com/18214891/122432842-49ad4d80-cf5b-11eb-80c0-e5184f984fb0.png">

#### Move to organization component
<img width="432" alt="image" src="https://user-images.githubusercontent.com/18214891/122432992-69dd0c80-cf5b-11eb-82ff-dac1f80997b1.png">

#### Move to organization success toast
<img width="432" alt="image" src="https://user-images.githubusercontent.com/18214891/122433046-76f9fb80-cf5b-11eb-8c92-71d6279ac421.png">

#### Settings learn about organizations change
<img width="440" alt="image" src="https://user-images.githubusercontent.com/18214891/122440331-115d3d80-cf62-11eb-830d-e8768eba63fb.png">
<img width="440" alt="image" src="https://user-images.githubusercontent.com/18214891/122440447-2c2fb200-cf62-11eb-93e3-49bf205e4012.png">