### PR TITLE
Get either 'Bitwarden' and 'Bitwarden_biometric' keys.

### DIFF
--- a/src/background/main.background.ts
+++ b/src/background/main.background.ts
@@ -10,7 +10,6 @@ import {
     CollectionService,
     ConstantsService,
     ContainerService,
-    CryptoService,
     EnvironmentService,
     FolderService,
     PasswordGenerationService,
@@ -82,6 +81,7 @@ import WindowsBackground from './windows.background';
 
 import { PopupUtilsService } from '../popup/services/popup-utils.service';
 import AutofillService from '../services/autofill.service';
+import { BrowserCryptoService } from '../services/browserCrypto.service';
 import BrowserMessagingService from '../services/browserMessaging.service';
 import BrowserPlatformUtilsService from '../services/browserPlatformUtils.service';
 import BrowserStorageService from '../services/browserStorage.service';
@@ -173,7 +173,7 @@ export default class MainBackground {
         this.i18nService = new I18nService(BrowserApi.getUILanguage(window));
         this.cryptoFunctionService = new WebCryptoFunctionService(window, this.platformUtilsService);
         this.consoleLogService = new ConsoleLogService(false);
-        this.cryptoService = new CryptoService(this.storageService, this.secureStorageService,
+        this.cryptoService = new BrowserCryptoService(this.storageService, this.secureStorageService,
             this.cryptoFunctionService, this.platformUtilsService, this.consoleLogService);
         this.tokenService = new TokenService(this.storageService);
         this.appIdService = new AppIdService(this.storageService);

--- a/src/safari/safari/SafariWebExtensionHandler.swift
+++ b/src/safari/safari/SafariWebExtensionHandler.swift
@@ -4,6 +4,7 @@ import LocalAuthentication
 
 let SFExtensionMessageKey = "message"
 let ServiceName = "Bitwarden"
+let ServiceNameBiometric = ServiceName + "_biometric"
 
 class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
 
@@ -118,7 +119,7 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
                     var passwordLength: UInt32 = 0
                     var passwordPtr: UnsafeMutableRawPointer? = nil
                     
-                    var status = SecKeychainFindGenericPassword(nil, UInt32(ServiceName.utf8.count), ServiceName + "_biometric", UInt32(passwordName.utf8.count), passwordName, &passwordLength, &passwordPtr, nil)
+                    var status = SecKeychainFindGenericPassword(nil, UInt32(ServiceNameBiometric.utf8.count), ServiceNameBiometric, UInt32(passwordName.utf8.count), passwordName, &passwordLength, &passwordPtr, nil)
                     if status != errSecSuccess {
                         status = SecKeychainFindGenericPassword(nil, UInt32(ServiceName.utf8.count), ServiceName, UInt32(passwordName.utf8.count), passwordName, &passwordLength, &passwordPtr, nil)
                     }

--- a/src/safari/safari/SafariWebExtensionHandler.swift
+++ b/src/safari/safari/SafariWebExtensionHandler.swift
@@ -118,8 +118,11 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
                     var passwordLength: UInt32 = 0
                     var passwordPtr: UnsafeMutableRawPointer? = nil
                     
-                    let status = SecKeychainFindGenericPassword(nil, UInt32(ServiceName.utf8.count), ServiceName, UInt32(passwordName.utf8.count), passwordName, &passwordLength, &passwordPtr, nil)
-                    
+                    let status = SecKeychainFindGenericPassword(nil, UInt32(ServiceName.utf8.count), ServiceName + "_biometric", UInt32(passwordName.utf8.count), passwordName, &passwordLength, &passwordPtr, nil)
+                    if status != errSecSuccess {
+                        status = SecKeychainFindGenericPassword(nil, UInt32(ServiceName.utf8.count), ServiceName, UInt32(passwordName.utf8.count), passwordName, &passwordLength, &passwordPtr, nil)
+                    }
+    
                     if status == errSecSuccess {
                         let result = NSString(bytes: passwordPtr!, length: Int(passwordLength), encoding: String.Encoding.utf8.rawValue) as String?
                                     SecKeychainItemFreeContent(nil, passwordPtr)

--- a/src/safari/safari/SafariWebExtensionHandler.swift
+++ b/src/safari/safari/SafariWebExtensionHandler.swift
@@ -118,7 +118,7 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
                     var passwordLength: UInt32 = 0
                     var passwordPtr: UnsafeMutableRawPointer? = nil
                     
-                    let status = SecKeychainFindGenericPassword(nil, UInt32(ServiceName.utf8.count), ServiceName + "_biometric", UInt32(passwordName.utf8.count), passwordName, &passwordLength, &passwordPtr, nil)
+                    var status = SecKeychainFindGenericPassword(nil, UInt32(ServiceName.utf8.count), ServiceName + "_biometric", UInt32(passwordName.utf8.count), passwordName, &passwordLength, &passwordPtr, nil)
                     if status != errSecSuccess {
                         status = SecKeychainFindGenericPassword(nil, UInt32(ServiceName.utf8.count), ServiceName, UInt32(passwordName.utf8.count), passwordName, &passwordLength, &passwordPtr, nil)
                     }

--- a/src/services/browserCrypto.service.ts
+++ b/src/services/browserCrypto.service.ts
@@ -5,7 +5,7 @@ export class BrowserCryptoService extends CryptoService {
     protected async retrieveKeyFromStorage(keySuffix: KeySuffixOptions) {
         if (keySuffix === 'biometric') {
             await this.platformUtilService.authenticateBiometric();
-            return (await this.getKey()).keyB64;
+            return (await this.getKey())?.keyB64;
         }
 
         return await super.retrieveKeyFromStorage(keySuffix);

--- a/src/services/browserCrypto.service.ts
+++ b/src/services/browserCrypto.service.ts
@@ -1,0 +1,14 @@
+import { KeySuffixOptions } from 'jslib-common/abstractions/storage.service';
+import { CryptoService } from 'jslib-common/services/crypto.service';
+
+export class BrowserCryptoService extends CryptoService {
+    protected async retrieveKeyFromStorage(keySuffix: KeySuffixOptions) {
+        if (keySuffix === 'biometric') {
+            await this.platformUtilService.authenticateBiometric();
+            return (await this.getKey()).keyB64;
+        }
+
+        return await super.retrieveKeyFromStorage(keySuffix);
+    }
+
+}


### PR DESCRIPTION
# Overview

Fixes a few issues with browser biometric integration. Swift fixes for Safari and browserCryptoService changes for all.

> Note: This will be cherry-picked into `rc`, please evaluate accordingly

# Files Changed
* **main.background.ts**: Use new browserCryptoService
* **browserCrypto.service.ts**: child class that specifically retrieves biometric key from Desktop using `BrowserPlatformUtils`. Note, Desktop sets the key in IPC communications so we return the key existing on `CryptoService`
* **SafariWebExtensionHandler.swift**: Try `Bitwarden_biometric` first, but fallback to `Bitwarden` without complaint. Upgrades to keys should be handled by the desktop application.