### PR TITLE
Hide biometric setting when running in Android

### DIFF
--- a/src/services/browserPlatformUtils.service.ts
+++ b/src/services/browserPlatformUtils.service.ts
@@ -314,6 +314,11 @@ export default class BrowserPlatformUtilsService implements PlatformUtilsService
     }
 
     async supportsBiometric() {
+        const platformInfo = await BrowserApi.getPlatformInfo();
+        if (platformInfo.os === 'android') {
+            return false;
+        }
+
         if (this.isFirefox()) {
             return parseInt((await browser.runtime.getBrowserInfo()).version.split('.')[0], 10) >= 87;
         }


### PR DESCRIPTION
## Objective
The biometric settings is visible when using the Bitwarden extension in Firefox for Android. Since we cannot communicate with the desktop applicaton on mobile, we should hide the setting.

## Testing consideration
I haven't had an opportunity to verify this PR on a mobile device.

Resolves https://github.com/bitwarden/browser/issues/1846