### PR TITLE
Use password field with toggle to set PIN

### DIFF
--- a/src/popup/scss/plugins.scss
+++ b/src/popup/scss/plugins.scss
@@ -157,6 +157,26 @@ $fa-font-path: "~font-awesome/fonts";
                 }
             }
         }
+
+        .swal2-password-input-group {
+            display: flex;
+            align-items: center;
+
+            a[role=button] {
+                margin-top: 1em;
+                margin-left: 1em;
+                
+                @include themify($themes) {
+                    color: themed('boxRowButtonColor');
+                }
+
+                &:hover, &:focus {
+                    @include themify($themes) {
+                        color: themed('boxRowButtonHoverColor');
+                    }
+                }
+            }
+        }
     }
 
     i.swal-custom-icon {

--- a/src/popup/settings/settings.component.ts
+++ b/src/popup/settings/settings.component.ts
@@ -179,17 +179,10 @@ export class SettingsComponent implements OnInit {
             (div.querySelector('#toggle-btn') as HTMLInputElement).addEventListener('click', event => {
                 event.preventDefault();
                 showPin = !showPin;
-                if (showPin) {
-                    pinInput.setAttribute('type', 'text');
-                    toggleIcon.classList.remove('fa-eye');
-                    toggleIcon.classList.add('fa-eye-slash');
-                    pinInput.focus();
-                } else {
-                    pinInput.setAttribute('type', 'password');
-                    toggleIcon.classList.remove('fa-eye-slash');
-                    toggleIcon.classList.add('fa-eye');
-                    pinInput.focus();
-                }
+                pinInput.setAttribute('type', showPin ? 'text' : 'password');
+                toggleIcon.classList.remove(showPin ? 'fa-eye' : 'fa-eye-slash');
+                toggleIcon.classList.add(showPin ? 'fa-eye-slash' : 'fa-eye');
+                pinInput.focus();
             });
 
             div.appendChild(label);

--- a/src/popup/settings/settings.component.ts
+++ b/src/popup/settings/settings.component.ts
@@ -183,10 +183,12 @@ export class SettingsComponent implements OnInit {
                     pinInput.setAttribute('type', 'text');
                     toggleIcon.classList.remove('fa-eye');
                     toggleIcon.classList.add('fa-eye-slash');
+                    pinInput.focus();
                 } else {
                     pinInput.setAttribute('type', 'password');
                     toggleIcon.classList.remove('fa-eye-slash');
                     toggleIcon.classList.add('fa-eye');
+                    pinInput.focus();
                 }
             });
 

--- a/src/popup/settings/settings.component.ts
+++ b/src/popup/settings/settings.component.ts
@@ -151,6 +151,8 @@ export class SettingsComponent implements OnInit {
     }
 
     async updatePin() {
+        let showPin: boolean = false;
+
         if (this.pin) {
             const div = document.createElement('div');
             const label = document.createElement('label');
@@ -162,11 +164,32 @@ export class SettingsComponent implements OnInit {
             label.appendChild(checkboxText);
 
             div.innerHTML =
-                `<div class="swal2-text">${this.i18nService.t('setYourPinCode')}</div>` +
-                '<input type="text" class="swal2-input" id="pin-val" autocomplete="off" ' +
-                'autocapitalize="none" autocorrect="none" spellcheck="false" inputmode="verbatim">';
+                `<div class="swal2-text">${this.i18nService.t('setYourPinCode')}</div>
+                <div class="swal2-password-input-group">
+                    <input type="password" class="swal2-input" id="pin-input" autocomplete="off"
+                        autocapitalize="none" autocorrect="none" spellcheck="false" inputmode="verbatim"
+                        placeholder="${this.i18nService.t('pin')}">
+                    <a id="toggle-btn" href="#" role="button" aria-label="${this.i18nService.t('toggleVisibility')}">
+                        <i id="toggle-icon" class="fa fa-lg fa-eye" aria-hidden="true"></i>
+                    </a>
+                </div>`;
 
-            (div.querySelector('#pin-val') as HTMLInputElement).placeholder = this.i18nService.t('pin');
+            const pinInput = div.querySelector('#pin-input') as HTMLInputElement;
+            const toggleIcon = div.querySelector('#toggle-icon') as HTMLInputElement;
+            (div.querySelector('#toggle-btn') as HTMLInputElement).addEventListener('click', event => {
+                event.preventDefault();
+                showPin = !showPin;
+                if (showPin) {
+                    pinInput.setAttribute('type', 'text');
+                    toggleIcon.classList.remove('fa-eye');
+                    toggleIcon.classList.add('fa-eye-slash');
+                } else {
+                    pinInput.setAttribute('type', 'password');
+                    toggleIcon.classList.remove('fa-eye-slash');
+                    toggleIcon.classList.add('fa-eye');
+                }
+            });
+
             div.appendChild(label);
 
             const submitted = await Swal.fire({
@@ -182,7 +205,7 @@ export class SettingsComponent implements OnInit {
             let pin: string = null;
             let masterPassOnRestart: boolean = null;
             if (submitted.value) {
-                pin = (document.getElementById('pin-val') as HTMLInputElement).value;
+                pin = (document.getElementById('pin-input') as HTMLInputElement).value;
                 masterPassOnRestart = (document.getElementById('master-pass-restart') as HTMLInputElement).checked;
             }
             if (pin != null && pin.trim() !== '') {


### PR DESCRIPTION
## Objective
Fix #887: 
>The PIN input screen is insecure in the sense that you can read what you input into it. The screen to input your PIN to unlock it is secure though. I figure that this is an oversight.

## Code changes
* `settings.component.ts` - expand the template literal we use for the swal2 dialog, add event handler for show/hide logic
* `plugins.scss` - minor styling to make the elements sit inline. Bootstrap styles (e.g. `form-inline`) didn't seem to work here.

I don't like constructing the swal2 template within the component like this, but despite much messing around with swal2 was unable to find a better way. 