### PR TITLE
Don't start i18n service if in private mode

### DIFF
--- a/src/popup/services/services.module.ts
+++ b/src/popup/services/services.module.ts
@@ -181,7 +181,7 @@ export function initFactory(platformUtilsService: PlatformUtilsService, i18nServ
         },
         {
             provide: LOCALE_ID,
-            useFactory: () => getBgService<I18nService>('i18nService')().translationLocale,
+            useFactory: () => isPrivateMode ? null : getBgService<I18nService>('i18nService')().translationLocale,
             deps: [],
         },
         { provide: PasswordRepromptServiceAbstraction, useValue: passwordRepromptService },


### PR DESCRIPTION
## Objective

Follow up to #1886, in which I falsely claimed to fix the infinite spinner that appears in Firefox private mode. This time I promise that I've fixed it.

## Code changes

#1886 was the right approach, but I'd missed `i18nService`. Add a private mode check there so that we don't refer to `translationLocale` on a `null` object.

Note that `private-mode.component` still works even though `i18nService` is not set in the popup. It uses the chrome api instead - I assume this is by design.