### PR TITLE
disabling the broken coverage asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,6 +200,7 @@ jobs:
           asset_content_type: application/zip
 
       - name: upload coverage release asset
+        if: false
         uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Disabling coverage asset upload because it does not exist. The [dependency bump](https://github.com/bitwarden/cli/actions/runs/979910489) broke it.