### PR TITLE
Format 16-digit credit card numbers in groups of 4

### DIFF
--- a/src/popup/app.module.ts
+++ b/src/popup/app.module.ts
@@ -41,6 +41,7 @@ import { AddEditComponent } from './vault/add-edit.component';
 import { AttachmentsComponent } from './vault/attachments.component';
 import { CiphersComponent } from './vault/ciphers.component';
 import { CollectionsComponent } from './vault/collections.component';
+import { CreditCardNumberPipe } from './vault/credit-card-number.pipe';
 import { CurrentTabComponent } from './vault/current-tab.component';
 import { GroupingsComponent } from './vault/groupings.component';
 import { PasswordHistoryComponent } from './vault/password-history.component';
@@ -190,6 +191,7 @@ registerLocaleData(localeZhTw, 'zh-TW');
         CiphersComponent,
         CollectionsComponent,
         ColorPasswordPipe,
+        CreditCardNumberPipe,
         CurrentTabComponent,
         EnvironmentComponent,
         ExcludedDomainsComponent,

--- a/src/popup/vault/credit-card-number.pipe.ts
+++ b/src/popup/vault/credit-card-number.pipe.ts
@@ -1,0 +1,23 @@
+import {
+  Pipe,
+  PipeTransform
+} from '@angular/core';
+
+@Pipe({ name: 'creditCardNumber' })
+export class CreditCardNumberPipe implements PipeTransform {
+  transform(creditCardNumber: string): string {
+    // See https://baymard.com/checkout-usability/credit-card-patterns for
+    // all possible credit card spacing patterns. For now, we just handle
+    // the common 4-4-4-4 spacing of 16-digit card numbers.
+    if (creditCardNumber.length === 16) {
+      return [
+        creditCardNumber.slice(0, 4),
+        creditCardNumber.slice(4, 8),
+        creditCardNumber.slice(8, 12),
+        creditCardNumber.slice(12),
+      ].join(' ');
+    }
+
+    return creditCardNumber;
+  }
+}

--- a/src/popup/vault/view.component.html
+++ b/src/popup/vault/view.component.html
@@ -100,7 +100,7 @@
                     <div class="row-main">
                         <span class="row-label">{{'number' | i18n}}</span>
                         <span [hidden]="showCardNumber" class="monospaced">{{cipher.card.maskedNumber}}</span>
-                        <span [hidden]="!showCardNumber" class="monospaced">{{cipher.card.number}}</span>
+                        <span [hidden]="!showCardNumber" class="monospaced">{{cipher.card.number | creditCardNumber }}</span>
                     </div>
                     <div class="action-buttons">
                         <a class="row-btn" href="#" appStopClick appA11yTitle="{{'toggleVisibility' | i18n}}"


### PR DESCRIPTION
# Objective

This PR formats 16-digit credit card numbers in 4 groups of 4 digits each for better readability.

## Community Forum Posts

Feature request post: https://community.bitwarden.com/t/display-card-numbers-in-groups-to-make-them-easier-to-read/12042

GitHub contribution post: https://community.bitwarden.com/t/display-card-numbers-in-groups-to-make-them-easier-to-read/31541

## Before & After Screenshots

<div>
<img width="200" alt="Screen Shot 2021-07-07 at 12 58 56 PM" src="https://user-images.githubusercontent.com/10874225/124821057-3e3aba00-df3c-11eb-9ab4-8d50bfc9455f.png">
&nbsp;&nbsp;
<img width="200" alt="Screen Shot 2021-07-07 at 12 57 45 PM" src="https://user-images.githubusercontent.com/10874225/124820911-121f3900-df3c-11eb-9236-ce87fdc6d886.png">
</div>

## Potential Todos

For this PR, or another future PR:

- Should the `CreditCardNumberPipe` file be put in `jslib`? It looks like other pipes are in `jslib` rather than in the `browser` repo
- Support other credit card formats listed in https://baymard.com/checkout-usability/credit-card-patterns
