### PR TITLE
[readme] enable desktop communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ You can now load the extension into your browser through the browser's extension
   1. Type `about:debugging` in your address bar to bring up the add-ons page.
   2. Click the `Load Temporary Add-on` button, navigate to the `build/manifest.json` file, and "Open".
 
+**Desktop communication**
+
+Native Messaging (communication between the desktop application and browser extension) works by having the browser start a lightweight proxy baked into our desktop application.
+
+Out of the box, the desktop application can only communicate with the production browser extension. When you enable browser integration in the desktop application, the application generates manifests which contain the production IDs of the browser extensions. To enable communication between the desktop application and development versions of browser extensions, add the development IDs to the `allowed_extensions` section of the corresponding manifests.
+
+Manifests are located in the `browser` subdirectory of the Bitwarden configuration directory. For instance, on Windows the manifests are located at `C:\Users\<user>\AppData\Roaming\Bitwarden\browsers`. Note that disabling the desktop integration will delete the manifests, and the files will need to be updated again.
+
 # Contribute
 
 Code contributions are welcome! Please commit any pull requests against the `master` branch. Learn more about how to contribute by reading the [`CONTRIBUTING.md`](CONTRIBUTING.md) file.


### PR DESCRIPTION
I was working on a feature that required biometric unlocking in the browser, and was really confused because the browser extension kept throwing an error about not being able to communicate with the desktop application.

I discovered this is because the desktop application hardcodes production extension IDs into manifest files, and these IDs need to be updated to work with development versions of the browser extension.

Putting this up front in the README will hopefully save future newcomers some grief.

This is partly captured in the [desktop readme](https://github.com/bitwarden/desktop/blob/master/README.md), but it's not very clear, and it's not the first place that a browser developer would look (since you don't need to build the desktop application to make it work, just modify the manifest files).