### PR TITLE
Update manifest info in readme.md for desktop comm

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Native Messaging (communication between the desktop application and browser exte
 
 Out of the box, the desktop application can only communicate with the production browser extension. When you enable browser integration in the desktop application, the application generates manifests which contain the production IDs of the browser extensions. To enable communication between the desktop application and development versions of browser extensions, add the development IDs to the `allowed_extensions` section of the corresponding manifests.
 
-Manifests are located in the `browser` subdirectory of the Bitwarden configuration directory. For instance, on Windows the manifests are located at `C:\Users\<user>\AppData\Roaming\Bitwarden\browsers`. Note that disabling the desktop integration will delete the manifests, and the files will need to be updated again.
+Manifests are located in the `browser` subdirectory of the Bitwarden configuration directory. For instance, on Windows the manifests are located at `C:\Users\<user>\AppData\Roaming\Bitwarden\browsers` and on macOS these are in `Application Support` for various browsers ([for example](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_manifests#manifest_location)). Note that disabling the desktop integration will delete the manifests, and the files will need to be updated again.
 
 # Contribute
 


### PR DESCRIPTION
Prior PR that I approved and merged in, https://github.com/bitwarden/browser/pull/1951, needed a little bit more info that Oscar had pointed out to help with other OS's regarding manifest locations such as macOS. This is not an exhaustive reference but at least points the person in the right direction.