### PR TITLE
Keyboard up/down arrow navigation

### DIFF
--- a/src/directives/arrow-nav.directive.ts
+++ b/src/directives/arrow-nav.directive.ts
@@ -16,7 +16,14 @@ export class ArrowNavDirective {
     @Output() navReset = new EventEmitter();
 
     @HostListener('keydown', ['$event']) onKeyDown($event: KeyboardEvent) {
-        this.getEventEmitter($event.code)?.emit();
+        const eventEmitter = this.getEventEmitter($event.code);
+        if (!eventEmitter)
+            return;
+
+        if (eventEmitter !== this.navReset)
+            $event.preventDefault();
+
+        eventEmitter.emit();
     }
 
     private getEventEmitter(code: string) {

--- a/src/directives/arrow-nav.directive.ts
+++ b/src/directives/arrow-nav.directive.ts
@@ -1,0 +1,35 @@
+import {
+    Directive,
+    EventEmitter,
+    HostListener,
+    Output,
+} from '@angular/core';
+
+@Directive({
+    selector: '[appArrowNav]',
+})
+export class ArrowNavDirective {
+    @Output() navDown = new EventEmitter();
+    @Output() navUp = new EventEmitter();
+    @Output() navLeft = new EventEmitter();
+    @Output() navRight = new EventEmitter();
+
+    @HostListener('keydown', ['$event']) onKeyDown($event: KeyboardEvent) {
+        this.getEventEmitter($event.code)?.emit();
+    }
+
+    private getEventEmitter(code: string) {
+        switch (code) {
+            case 'ArrowDown':
+                return this.navDown;
+            case 'ArrowUp':
+                return this.navUp;
+            case 'ArrowLeft':
+                return this.navLeft;
+            case 'ArrowRight':
+                return this.navRight;
+            default:
+                return null;
+        }
+    }
+}

--- a/src/directives/arrow-nav.directive.ts
+++ b/src/directives/arrow-nav.directive.ts
@@ -13,6 +13,7 @@ export class ArrowNavDirective {
     @Output() navUp = new EventEmitter();
     @Output() navLeft = new EventEmitter();
     @Output() navRight = new EventEmitter();
+    @Output() navReset = new EventEmitter();
 
     @HostListener('keydown', ['$event']) onKeyDown($event: KeyboardEvent) {
         this.getEventEmitter($event.code)?.emit();
@@ -28,6 +29,8 @@ export class ArrowNavDirective {
                 return this.navLeft;
             case 'ArrowRight':
                 return this.navRight;
+            case 'Tab':
+                return this.navReset;
             default:
                 return null;
         }

--- a/src/directives/focus.directive.ts
+++ b/src/directives/focus.directive.ts
@@ -1,0 +1,43 @@
+import {
+    Directive,
+    ElementRef,
+    Input,
+} from '@angular/core';
+
+@Directive({
+    selector: '[appFocus]',
+})
+export class FocusDirective {
+    @Input() focus: boolean;
+
+    constructor(private el: ElementRef) { }
+
+    ngOnChanges() {
+        if (!this.focus)
+            return;
+
+        this.getFocusableElement(this.el.nativeElement)?.focus();
+    }
+
+    private getFocusableElement(el: Element): HTMLElement {
+        if (this.isFocusableElement(el))
+            return el as HTMLElement;
+
+        for (let i = 0; i < el.children.length; i++) {
+            const focusable = this.getFocusableElement(el.children[i]);
+            if (focusable) {
+                return focusable;
+            }
+        }
+
+        return null;
+    }
+
+    private isFocusableElement(el: Element): boolean {
+        return el instanceof HTMLInputElement ||
+            el instanceof HTMLSelectElement ||
+            el instanceof HTMLTextAreaElement ||
+            el instanceof HTMLAnchorElement ||
+            el instanceof HTMLButtonElement;
+    }
+}

--- a/src/popup/app.module.ts
+++ b/src/popup/app.module.ts
@@ -53,6 +53,8 @@ import { SendGroupingsComponent } from './send/send-groupings.component';
 import { SendTypeComponent } from './send/send-type.component';
 
 import { ArrowNavDirective } from '../directives/arrow-nav.directive';
+import { FocusDirective } from '../directives/focus.directive';
+
 import { A11yTitleDirective } from 'jslib-angular/directives/a11y-title.directive';
 import { ApiActionDirective } from 'jslib-angular/directives/api-action.directive';
 import { AutofocusDirective } from 'jslib-angular/directives/autofocus.directive';
@@ -201,6 +203,7 @@ registerLocaleData(localeZhTw, 'zh-TW');
         ExcludedDomainsComponent,
         ExportComponent,
         FallbackSrcDirective,
+        FocusDirective,
         FolderAddEditComponent,
         FoldersComponent,
         GroupingsComponent,

--- a/src/popup/app.module.ts
+++ b/src/popup/app.module.ts
@@ -52,6 +52,7 @@ import { SendAddEditComponent } from './send/send-add-edit.component';
 import { SendGroupingsComponent } from './send/send-groupings.component';
 import { SendTypeComponent } from './send/send-type.component';
 
+import { ArrowNavDirective } from '../directives/arrow-nav.directive';
 import { A11yTitleDirective } from 'jslib-angular/directives/a11y-title.directive';
 import { ApiActionDirective } from 'jslib-angular/directives/api-action.directive';
 import { AutofocusDirective } from 'jslib-angular/directives/autofocus.directive';
@@ -185,6 +186,7 @@ registerLocaleData(localeZhTw, 'zh-TW');
         AddEditComponent,
         ApiActionDirective,
         AppComponent,
+        ArrowNavDirective,
         AttachmentsComponent,
         AutofocusDirective,
         BlurClickDirective,

--- a/src/popup/services/arrow-nav.service.ts
+++ b/src/popup/services/arrow-nav.service.ts
@@ -43,8 +43,9 @@ export class ArrowNavService {
     }
 
     reset() {
-        this.navIndex = -1;
         this.navType = null;
+        this.navIndex = -1;
+        this.navTypeIndex = -1;
     }
 
     private getNextNavType() {

--- a/src/popup/services/arrow-nav.service.ts
+++ b/src/popup/services/arrow-nav.service.ts
@@ -1,0 +1,74 @@
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class ArrowNavService {
+    navType: string = null;
+    navIndex: number = -1;
+
+    private allNavTypes: NavType[] = [];
+    private navTypeIndex: number = -1;
+
+    init(navTypes: NavType[]) {
+        this.allNavTypes = navTypes;
+    }
+
+    down() {
+        this.navIndex++;
+
+        if (!this.navType)
+            this.navType = this.getNextNavType();
+
+        while (this.navIndex >= this.getNavLength()) {
+            const navType = this.navType;
+            this.navType = this.getNextNavType();
+            this.navIndex = 0;
+            if (this.navType === navType)
+                return;
+        }
+    }
+
+    up() {
+        this.navIndex--;
+
+        if (!this.navType)
+            this.navType = this.getPrevNavType();
+
+        while (this.navIndex < 0) {
+            const navType = this.navType;
+            this.navType = this.getPrevNavType();
+            this.navIndex = this.getNavLength() - 1;
+            if (this.navType === navType)
+                return;
+        }
+    }
+
+    reset() {
+        this.navIndex = -1;
+        this.navType = null;
+    }
+
+    private getNextNavType() {
+        this.navTypeIndex++;
+        if (this.navTypeIndex >= this.allNavTypes.length)
+            this.navTypeIndex = 0;
+
+        return this.allNavTypes[this.navTypeIndex].name;
+    }
+
+    private getPrevNavType() {
+        this.navTypeIndex--;
+        if (this.navTypeIndex < 0)
+            this.navTypeIndex = this.allNavTypes.length - 1;
+
+        return this.allNavTypes[this.navTypeIndex].name;
+    }
+
+    private getNavLength() {
+        return this.allNavTypes[this.navTypeIndex].length;
+    }
+}
+
+interface NavType {
+    name: string;
+    length: number;
+}

--- a/src/popup/vault/ciphers.component.html
+++ b/src/popup/vault/ciphers.component.html
@@ -1,4 +1,4 @@
-<header appArrowNav (navDown)="navDown()" (navUp)="navUp()">
+<header appArrowNav (navDown)="navDown()" (navUp)="navUp()" (navReset)="navReset()">
     <div class="left">
         <button type="button" appBlurClick (click)="back()">
             <span class="header-icon"><i class="fa fa-chevron-left" aria-hidden="true"></i></span>
@@ -18,7 +18,7 @@
     </div>
 </header>
 <content [ngClass]="{'stacked-boxes': showGroupings()}"
-    appArrowNav (navDown)="navDown()" (navUp)="navUp()">
+    appArrowNav (navDown)="navDown()" (navUp)="navUp()" (navReset)="navReset()">
     <ng-container *ngIf="showGroupings()">
         <div class="box list" *ngIf="nestedFolders && nestedFolders.length">
             <div class="box-header">

--- a/src/popup/vault/ciphers.component.html
+++ b/src/popup/vault/ciphers.component.html
@@ -1,4 +1,4 @@
-<header appArrowNav (navDown)="navDown()" (navUp)="navUp()" (navReset)="navReset()">
+<header appArrowNav (navDown)="arrowNav.down()" (navUp)="arrowNav.up()" (navReset)="arrowNav.reset()">
     <div class="left">
         <button type="button" appBlurClick (click)="back()">
             <span class="header-icon"><i class="fa fa-chevron-left" aria-hidden="true"></i></span>
@@ -18,7 +18,7 @@
     </div>
 </header>
 <content [ngClass]="{'stacked-boxes': showGroupings()}"
-    appArrowNav (navDown)="navDown()" (navUp)="navUp()" (navReset)="navReset()">
+    appArrowNav (navDown)="arrowNav.down()" (navUp)="arrowNav.up()" (navReset)="arrowNav.reset()">
     <ng-container *ngIf="showGroupings()">
         <div class="box list" *ngIf="nestedFolders && nestedFolders.length">
             <div class="box-header">
@@ -27,7 +27,7 @@
             <div class="box-content single-line">
                 <a *ngFor="let f of nestedFolders" href="#" class="box-content-row" appStopClick appBlurClick
                     (click)="selectFolder(f.node)" appFocus
-                    [focus]="navType === 'folders' && nestedFolders[navIndex] === f">
+                    [focus]="arrowNav.navType === 'folders' && nestedFolders[arrowNav.navIndex] === f">
                     <div class="row-main">
                         <div class="icon">
                             <i class="fa fa-fw fa-lg" aria-hidden="true"
@@ -46,7 +46,7 @@
             <div class="box-content single-line">
                 <a *ngFor="let c of nestedCollections" href="#" class="box-content-row" appStopClick appBlurClick
                     (click)="selectCollection(c.node)" appFocus
-                    [focus]="navType === 'collections' && nestedCollections[navIndex] === c">
+                    [focus]="arrowNav.navType === 'collections' && nestedCollections[arrowNav.navIndex] === c">
                     <div class="row-main">
                         <div class="icon"><i class="fa fa-fw fa-lg fa-cube" aria-hidden="true"></i></div>
                         <span class="text">{{c.node.name}}</span>
@@ -75,7 +75,7 @@
                 <div class="box-content">
                     <app-cipher-row *cdkVirtualFor="let c of ciphers" [cipher]="c" title="{{'viewItem' | i18n}}"
                         (onSelected)="selectCipher($event)" (launchEvent)="launchCipher($event)" appFocus
-                        [focus]="navType === 'ciphers' && ciphers[navIndex] === c">
+                        [focus]="arrowNav.navType === 'ciphers' && ciphers[arrowNav.navIndex] === c">
                     </app-cipher-row>
                 </div>
             </div>

--- a/src/popup/vault/ciphers.component.html
+++ b/src/popup/vault/ciphers.component.html
@@ -1,4 +1,4 @@
-<header>
+<header appArrowNav (navDown)="navDown()" (navUp)="navUp()">
     <div class="left">
         <button type="button" appBlurClick (click)="back()">
             <span class="header-icon"><i class="fa fa-chevron-left" aria-hidden="true"></i></span>
@@ -17,7 +17,8 @@
         </button>
     </div>
 </header>
-<content [ngClass]="{'stacked-boxes': showGroupings()}">
+<content [ngClass]="{'stacked-boxes': showGroupings()}"
+    appArrowNav (navDown)="navDown()" (navUp)="navUp()">
     <ng-container *ngIf="showGroupings()">
         <div class="box list" *ngIf="nestedFolders && nestedFolders.length">
             <div class="box-header">
@@ -25,7 +26,8 @@
             </div>
             <div class="box-content single-line">
                 <a *ngFor="let f of nestedFolders" href="#" class="box-content-row" appStopClick appBlurClick
-                    (click)="selectFolder(f.node)">
+                    (click)="selectFolder(f.node)" appFocus
+                    [focus]="navType === 'folders' && nestedFolders[navIndex] === f">
                     <div class="row-main">
                         <div class="icon">
                             <i class="fa fa-fw fa-lg" aria-hidden="true"
@@ -43,7 +45,8 @@
             </div>
             <div class="box-content single-line">
                 <a *ngFor="let c of nestedCollections" href="#" class="box-content-row" appStopClick appBlurClick
-                    (click)="selectCollection(c.node)">
+                    (click)="selectCollection(c.node)" appFocus
+                    [focus]="navType === 'collections' && nestedCollections[navIndex] === c">
                     <div class="row-main">
                         <div class="icon"><i class="fa fa-fw fa-lg fa-cube" aria-hidden="true"></i></div>
                         <span class="text">{{c.node.name}}</span>
@@ -71,7 +74,9 @@
                 </div>
                 <div class="box-content">
                     <app-cipher-row *cdkVirtualFor="let c of ciphers" [cipher]="c" title="{{'viewItem' | i18n}}"
-                        (onSelected)="selectCipher($event)" (launchEvent)="launchCipher($event)"></app-cipher-row>
+                        (onSelected)="selectCipher($event)" (launchEvent)="launchCipher($event)" appFocus
+                        [focus]="navType === 'ciphers' && ciphers[navIndex] === c">
+                    </app-cipher-row>
                 </div>
             </div>
         </cdk-virtual-scroll-viewport>

--- a/src/popup/vault/ciphers.component.html
+++ b/src/popup/vault/ciphers.component.html
@@ -8,7 +8,7 @@
     <div class="search">
         <input type="{{searchTypeSearch ? 'search' : 'text'}}"
             placeholder="{{searchPlaceholder || ('searchVault' | i18n)}}" id="search" [(ngModel)]="searchText"
-            (input)="search(200)" autocomplete="off" appAutofocus>
+            (input)="search(200)" autocomplete="off" appAutofocus appFocus [focus]="arrowNav.navType === 'search'">
         <i class="fa fa-search" aria-hidden="true"></i>
     </div>
     <div class="right">

--- a/src/popup/vault/ciphers.component.ts
+++ b/src/popup/vault/ciphers.component.ts
@@ -33,10 +33,10 @@ import { BroadcasterService } from 'jslib-angular/services/broadcaster.service';
 
 import { CiphersComponent as BaseCiphersComponent } from 'jslib-angular/components/ciphers.component';
 
+import { ArrowNavService } from '../services/arrow-nav.service';
 import { PopupUtilsService } from '../services/popup-utils.service';
 
 const ComponentId = 'CiphersComponent';
-const NavTypes = ['folders', 'collections', 'ciphers'];
 
 @Component({
     selector: 'app-vault-ciphers',
@@ -51,8 +51,7 @@ export class CiphersComponent extends BaseCiphersComponent implements OnInit, On
     nestedFolders: TreeNode<FolderView>[];
     nestedCollections: TreeNode<CollectionView>[];
     searchTypeSearch = false;
-    navType: string = null;
-    navIndex: number = -1;
+    arrowNav = new ArrowNavService();
 
     private selectedTimeout: number;
     private preventSelected = false;
@@ -133,6 +132,12 @@ export class CiphersComponent extends BaseCiphersComponent implements OnInit, On
                 this.groupingTitle = this.i18nService.t('allItems');
                 await this.load();
             }
+
+            this.arrowNav.init([
+                { name: 'folders', length: this.nestedFolders?.length ?? 0 },
+                { name: 'collections', length: this.nestedCollections?.length ?? 0 },
+                { name: 'ciphers', length: this.ciphers?.length ?? 0 },
+            ]);
 
             if (this.applySavedState && this.state != null) {
                 window.setTimeout(() => this.popupUtils.setContentScrollY(window, this.state.scrollY,
@@ -227,70 +232,6 @@ export class CiphersComponent extends BaseCiphersComponent implements OnInit, On
         return !this.isSearching() &&
             ((this.nestedFolders && this.nestedFolders.length) ||
                 (this.nestedCollections && this.nestedCollections.length));
-    }
-
-    navDown() {
-        this.navIndex++;
-
-        if (!this.navType)
-            this.navType = this.getNextNavType();
-
-        while (this.navIndex >= this.getNavLength()) {
-            const navType = this.navType;
-            this.navType = this.getNextNavType();
-            this.navIndex = 0;
-            if (this.navType === navType)
-                return;
-        }
-    }
-
-    navUp() {
-        this.navIndex--;
-
-        if (!this.navType)
-            this.navType = this.getPrevNavType();
-
-        while (this.navIndex < 0) {
-            const navType = this.navType;
-            this.navType = this.getPrevNavType();
-            this.navIndex = this.getNavLength() - 1;
-            if (this.navType === navType)
-                return;
-        }
-    }
-
-    navReset() {
-        this.navIndex = -1;
-        this.navType = null;
-    }
-
-    private getNextNavType() {
-        let nextIndex = NavTypes.indexOf(this.navType) + 1;
-        if (nextIndex >= NavTypes.length)
-            nextIndex = 0;
-
-        return NavTypes[nextIndex];
-    }
-
-    private getPrevNavType() {
-        let prevIndex = NavTypes.indexOf(this.navType) - 1;
-        if (prevIndex < 0)
-            prevIndex = NavTypes.length - 1;
-
-        return NavTypes[prevIndex];
-    }
-
-    private getNavLength() {
-        switch (this.navType) {
-            case 'folders':
-                return this.nestedFolders?.length ?? 0;
-            case 'collections':
-                return this.nestedCollections?.length ?? 0;
-            case 'ciphers':
-                return this.ciphers?.length ?? 0;
-            default:
-                return 0;
-        }
     }
 
     private async saveState() {

--- a/src/popup/vault/ciphers.component.ts
+++ b/src/popup/vault/ciphers.component.ts
@@ -236,14 +236,11 @@ export class CiphersComponent extends BaseCiphersComponent implements OnInit, On
             this.navType = this.getNextNavType();
 
         while (this.navIndex >= this.getNavLength()) {
-            const nextType = this.getNextNavType();
-            if (this.navType === nextType) {
-                this.navReset();
-                return;
-            }
-
-            this.navType = nextType;
+            const navType = this.navType;
+            this.navType = this.getNextNavType();
             this.navIndex = 0;
+            if (this.navType === navType)
+                return;
         }
     }
 
@@ -254,14 +251,11 @@ export class CiphersComponent extends BaseCiphersComponent implements OnInit, On
             this.navType = this.getPrevNavType();
 
         while (this.navIndex < 0) {
-            const prevType = this.getPrevNavType();
-            if (this.navType === prevType) {
-                this.navReset();
-                return;
-            }
-
-            this.navType = prevType;
+            const navType = this.navType;
+            this.navType = this.getPrevNavType();
             this.navIndex = this.getNavLength() - 1;
+            if (this.navType === navType)
+                return;
         }
     }
 

--- a/src/popup/vault/ciphers.component.ts
+++ b/src/popup/vault/ciphers.component.ts
@@ -36,6 +36,7 @@ import { CiphersComponent as BaseCiphersComponent } from 'jslib-angular/componen
 import { PopupUtilsService } from '../services/popup-utils.service';
 
 const ComponentId = 'CiphersComponent';
+const NavTypes = ['folders', 'collections', 'ciphers'];
 
 @Component({
     selector: 'app-vault-ciphers',
@@ -50,6 +51,8 @@ export class CiphersComponent extends BaseCiphersComponent implements OnInit, On
     nestedFolders: TreeNode<FolderView>[];
     nestedCollections: TreeNode<CollectionView>[];
     searchTypeSearch = false;
+    navType: string = null;
+    navIndex: number = -1;
 
     private selectedTimeout: number;
     private preventSelected = false;
@@ -224,6 +227,71 @@ export class CiphersComponent extends BaseCiphersComponent implements OnInit, On
         return !this.isSearching() &&
             ((this.nestedFolders && this.nestedFolders.length) ||
                 (this.nestedCollections && this.nestedCollections.length));
+    }
+
+    navDown() {
+        this.navIndex++;
+
+        if (!this.navType)
+            this.navType = this.getNextNavType();
+
+        while (this.navIndex >= this.getNavLength()) {
+            const nextType = this.getNextNavType();
+            if (this.navType === nextType) {
+                this.navReset();
+                return;
+            }
+
+            this.navType = nextType;
+            this.navIndex = 0;
+        }
+    }
+
+    navUp() {
+        this.navIndex--;
+
+        if (!this.navType)
+            this.navType = this.getPrevNavType();
+
+        while (this.navIndex < 0) {
+            const prevType = this.getPrevNavType();
+            if (this.navType === prevType) {
+                this.navReset();
+                return;
+            }
+
+            this.navType = prevType;
+            this.navIndex = this.getNavLength() - 1;
+        }
+    }
+
+    private getNextNavType() {
+        let nextIndex = NavTypes.indexOf(this.navType) + 1;
+        if (nextIndex >= NavTypes.length)
+            nextIndex = 0;
+
+        return NavTypes[nextIndex];
+    }
+
+    private getPrevNavType() {
+        let prevIndex = NavTypes.indexOf(this.navType) - 1;
+        if (prevIndex < 0)
+            prevIndex = NavTypes.length - 1;
+
+        return NavTypes[prevIndex];
+    }
+
+    private getNavLength() {
+        switch (this.navType) {
+            case 'folders':
+                return this.nestedFolders?.length ?? 0;
+            case 'collections':
+                return this.nestedCollections?.length ?? 0;
+            case 'ciphers':
+                return this.ciphers?.length ?? 0;
+            default:
+                return 0;
+        }
     }
 
     private async saveState() {

--- a/src/popup/vault/ciphers.component.ts
+++ b/src/popup/vault/ciphers.component.ts
@@ -137,6 +137,7 @@ export class CiphersComponent extends BaseCiphersComponent implements OnInit, On
                 { name: 'folders', length: this.nestedFolders?.length ?? 0 },
                 { name: 'collections', length: this.nestedCollections?.length ?? 0 },
                 { name: 'ciphers', length: this.ciphers?.length ?? 0 },
+                { name: 'search', length: 1 },
             ]);
 
             if (this.applySavedState && this.state != null) {

--- a/src/popup/vault/ciphers.component.ts
+++ b/src/popup/vault/ciphers.component.ts
@@ -265,6 +265,11 @@ export class CiphersComponent extends BaseCiphersComponent implements OnInit, On
         }
     }
 
+    navReset() {
+        this.navIndex = -1;
+        this.navType = null;
+    }
+
     private getNextNavType() {
         let nextIndex = NavTypes.indexOf(this.navType) + 1;
         if (nextIndex >= NavTypes.length)

--- a/src/popup/vault/current-tab.component.html
+++ b/src/popup/vault/current-tab.component.html
@@ -1,4 +1,4 @@
-<header appArrowNav (navDown)="navDown()" (navUp)="navUp()" (navReset)="navReset()">
+<header appArrowNav (navDown)="arrowNav.down()" (navUp)="arrowNav.up()" (navReset)="arrowNav.reset()">
     <div class="left">
         <app-pop-out [show]="!inSidebar"></app-pop-out>
         <button type="button" appBlurClick (click)="refresh()" appA11yTitle="{{'refresh' | i18n}}" *ngIf="inSidebar">
@@ -16,7 +16,7 @@
         </button>
     </div>
 </header>
-<content appArrowNav (navDown)="navDown()" (navUp)="navUp()" (navReset)="navReset()">
+<content appArrowNav (navDown)="arrowNav.down()" (navUp)="arrowNav.up()" (navReset)="arrowNav.reset()">
     <div class="no-items" *ngIf="!loaded">
         <i class="fa fa-spinner fa-spin fa-3x" aria-hidden="true"></i>
     </div>
@@ -30,7 +30,7 @@
                 <app-cipher-row *ngFor="let loginCipher of loginCiphers" [cipher]="loginCipher" 
                     title="{{'autoFill' | i18n}}" [showView]="true" (onSelected)="fillCipher($event)" 
                     (onView)="viewCipher($event)" appFocus
-                    [focus]="navType === 'typeLogins' && loginCiphers[navIndex] === loginCipher">
+                    [focus]="arrowNav.navType === 'typeLogins' && loginCiphers[arrowNav.navIndex] === loginCipher">
                 </app-cipher-row>
                 <div class="box-content-row padded no-hover" *ngIf="!loginCiphers.length">
                     <p class="text-center">{{'autoFillInfo' | i18n}}</p>
@@ -48,7 +48,7 @@
             <div class="box-content">
                 <app-cipher-row *ngFor="let cardCipher of cardCiphers" [cipher]="cardCipher" title="{{'autoFill' | i18n}}" [showView]="true"
                     (onSelected)="fillCipher($event)" (onView)="viewCipher($event)" appFocus
-                    [focus]="navType === 'cards' && cardCiphers[navIndex] === cardCipher">
+                    [focus]="arrowNav.navType === 'cards' && cardCiphers[arrowNav.navIndex] === cardCipher">
                 </app-cipher-row>
             </div>
         </div>
@@ -60,7 +60,7 @@
             <div class="box-content">
                 <app-cipher-row *ngFor="let identityCipher of identityCiphers" [cipher]="identityCipher" title="{{'autoFill' | i18n}}" [showView]="true"
                     (onSelected)="fillCipher($event)" (onView)="viewCipher($event)" appFocus
-                    [focus]="navType === 'identities' && identityCiphers[navIndex] === identityCipher">
+                    [focus]="arrowNav.navType === 'identities' && identityCiphers[arrowNav.navIndex] === identityCipher">
                 </app-cipher-row>
             </div>
         </div>

--- a/src/popup/vault/current-tab.component.html
+++ b/src/popup/vault/current-tab.component.html
@@ -1,4 +1,4 @@
-<header>
+<header appArrowNav (navDown)="navDown()" (navUp)="navUp()">
     <div class="left">
         <app-pop-out [show]="!inSidebar"></app-pop-out>
         <button type="button" appBlurClick (click)="refresh()" appA11yTitle="{{'refresh' | i18n}}" *ngIf="inSidebar">
@@ -16,7 +16,7 @@
         </button>
     </div>
 </header>
-<content>
+<content appArrowNav (navDown)="navDown()" (navUp)="navUp()">
     <div class="no-items" *ngIf="!loaded">
         <i class="fa fa-spinner fa-spin fa-3x" aria-hidden="true"></i>
     </div>
@@ -29,7 +29,8 @@
             <div class="box-content">
                 <app-cipher-row *ngFor="let loginCipher of loginCiphers" [cipher]="loginCipher" 
                     title="{{'autoFill' | i18n}}" [showView]="true" (onSelected)="fillCipher($event)" 
-                    (onView)="viewCipher($event)">
+                    (onView)="viewCipher($event)" appFocus
+                    [focus]="navType === 'typeLogins' && loginCiphers[navIndex] === loginCipher">
                 </app-cipher-row>
                 <div class="box-content-row padded no-hover" *ngIf="!loginCiphers.length">
                     <p class="text-center">{{'autoFillInfo' | i18n}}</p>
@@ -46,7 +47,9 @@
             </div>
             <div class="box-content">
                 <app-cipher-row *ngFor="let cardCipher of cardCiphers" [cipher]="cardCipher" title="{{'autoFill' | i18n}}" [showView]="true"
-                    (onSelected)="fillCipher($event)" (onView)="viewCipher($event)"></app-cipher-row>
+                    (onSelected)="fillCipher($event)" (onView)="viewCipher($event)" appFocus
+                    [focus]="navType === 'cards' && cardCiphers[navIndex] === cardCipher">
+                </app-cipher-row>
             </div>
         </div>
         <div class="box list" *ngIf="identityCiphers && identityCiphers.length">
@@ -56,7 +59,9 @@
             </div>
             <div class="box-content">
                 <app-cipher-row *ngFor="let identityCipher of identityCiphers" [cipher]="identityCipher" title="{{'autoFill' | i18n}}" [showView]="true"
-                    (onSelected)="fillCipher($event)" (onView)="viewCipher($event)"></app-cipher-row>
+                    (onSelected)="fillCipher($event)" (onView)="viewCipher($event)" appFocus
+                    [focus]="navType === 'identities' && identityCiphers[navIndex] === identityCipher">
+                </app-cipher-row>
             </div>
         </div>
     </ng-container>

--- a/src/popup/vault/current-tab.component.html
+++ b/src/popup/vault/current-tab.component.html
@@ -1,4 +1,4 @@
-<header appArrowNav (navDown)="navDown()" (navUp)="navUp()">
+<header appArrowNav (navDown)="navDown()" (navUp)="navUp()" (navReset)="navReset()">
     <div class="left">
         <app-pop-out [show]="!inSidebar"></app-pop-out>
         <button type="button" appBlurClick (click)="refresh()" appA11yTitle="{{'refresh' | i18n}}" *ngIf="inSidebar">
@@ -16,7 +16,7 @@
         </button>
     </div>
 </header>
-<content appArrowNav (navDown)="navDown()" (navUp)="navUp()">
+<content appArrowNav (navDown)="navDown()" (navUp)="navUp()" (navReset)="navReset()">
     <div class="no-items" *ngIf="!loaded">
         <i class="fa fa-spinner fa-spin fa-3x" aria-hidden="true"></i>
     </div>

--- a/src/popup/vault/current-tab.component.html
+++ b/src/popup/vault/current-tab.component.html
@@ -7,7 +7,8 @@
     </div>
     <div class="search">
         <input type="{{searchTypeSearch ? 'search' : 'text'}}" placeholder="{{'searchVault' | i18n}}" id="search"
-            [(ngModel)]="searchText" (input)="searchVault()" autocomplete="off" (keydown)="closeOnEsc($event)">
+            [(ngModel)]="searchText" (input)="searchVault()" autocomplete="off" (keydown)="closeOnEsc($event)"
+            appFocus [focus]="arrowNav.navType === 'search'">
         <i class="fa fa-search" aria-hidden="true"></i>
     </div>
     <div class="right">

--- a/src/popup/vault/current-tab.component.ts
+++ b/src/popup/vault/current-tab.component.ts
@@ -224,6 +224,11 @@ export class CurrentTabComponent implements OnInit, OnDestroy {
         }
     }
 
+    navReset() {
+        this.navIndex = -1;
+        this.navType = null;
+    }
+
     private getNextNavType() {
         let nextIndex = NavTypes.indexOf(this.navType) + 1;
         if (nextIndex >= NavTypes.length)

--- a/src/popup/vault/current-tab.component.ts
+++ b/src/popup/vault/current-tab.component.ts
@@ -243,6 +243,7 @@ export class CurrentTabComponent implements OnInit, OnDestroy {
             { name: 'typeLogins', length: this.loginCiphers?.length ?? 0 },
             { name: 'cards', length: this.cardCiphers?.length ?? 0 },
             { name: 'identities', length: this.identityCiphers?.length ?? 0 },
+            { name: 'search', length: 1 },
         ]);
 
         this.loginCiphers = this.loginCiphers.sort((a, b) => this.cipherService.sortCiphersByLastUsedThenName(a, b));

--- a/src/popup/vault/current-tab.component.ts
+++ b/src/popup/vault/current-tab.component.ts
@@ -36,6 +36,7 @@ import { PopupUtilsService } from '../services/popup-utils.service';
 import { Utils } from 'jslib-common/misc/utils';
 
 const BroadcasterSubscriptionId = 'CurrentTabComponent';
+const NavTypes = ['typeLogins', 'cards', 'identities'];
 
 @Component({
     selector: 'app-current-tab',
@@ -52,6 +53,8 @@ export class CurrentTabComponent implements OnInit, OnDestroy {
     inSidebar = false;
     searchTypeSearch = false;
     loaded = false;
+    navType: string = null;
+    navIndex: number = -1;
 
     private totpCode: string;
     private totpTimeout: number;
@@ -182,6 +185,71 @@ export class CurrentTabComponent implements OnInit, OnDestroy {
         // If input not empty, use browser default behavior of clearing input instead
         if (e.key === 'Escape' && (this.searchText == null || this.searchText === '')) {
             BrowserApi.closePopup(window);
+        }
+    }
+
+    navDown() {
+        this.navIndex++;
+
+        if (!this.navType)
+            this.navType = this.getNextNavType();
+
+        while (this.navIndex >= this.getNavLength()) {
+            const nextType = this.getNextNavType();
+            if (this.navType === nextType) {
+                this.navReset();
+                return;
+            }
+
+            this.navType = nextType;
+            this.navIndex = 0;
+        }
+    }
+
+    navUp() {
+        this.navIndex--;
+
+        if (!this.navType)
+            this.navType = this.getPrevNavType();
+
+        while (this.navIndex < 0) {
+            const prevType = this.getPrevNavType();
+            if (this.navType === prevType) {
+                this.navReset();
+                return;
+            }
+
+            this.navType = prevType;
+            this.navIndex = this.getNavLength() - 1;
+        }
+    }
+
+    private getNextNavType() {
+        let nextIndex = NavTypes.indexOf(this.navType) + 1;
+        if (nextIndex >= NavTypes.length)
+            nextIndex = 0;
+
+        return NavTypes[nextIndex];
+    }
+
+    private getPrevNavType() {
+        let prevIndex = NavTypes.indexOf(this.navType) - 1;
+        if (prevIndex < 0)
+            prevIndex = NavTypes.length - 1;
+
+        return NavTypes[prevIndex];
+    }
+
+    private getNavLength() {
+        switch (this.navType) {
+            case 'typeLogins':
+                return this.loginCiphers?.length ?? 0;
+            case 'cards':
+                return this.cardCiphers?.length ?? 0;
+            case 'identities':
+                return this.identityCiphers?.length ?? 0;
+            default:
+                return 0;
         }
     }
 

--- a/src/popup/vault/current-tab.component.ts
+++ b/src/popup/vault/current-tab.component.ts
@@ -195,14 +195,11 @@ export class CurrentTabComponent implements OnInit, OnDestroy {
             this.navType = this.getNextNavType();
 
         while (this.navIndex >= this.getNavLength()) {
-            const nextType = this.getNextNavType();
-            if (this.navType === nextType) {
-                this.navReset();
-                return;
-            }
-
-            this.navType = nextType;
+            const navType = this.navType;
+            this.navType = this.getNextNavType();
             this.navIndex = 0;
+            if (this.navType === navType)
+                return;
         }
     }
 
@@ -213,14 +210,11 @@ export class CurrentTabComponent implements OnInit, OnDestroy {
             this.navType = this.getPrevNavType();
 
         while (this.navIndex < 0) {
-            const prevType = this.getPrevNavType();
-            if (this.navType === prevType) {
-                this.navReset();
-                return;
-            }
-
-            this.navType = prevType;
+            const navType = this.navType;
+            this.navType = this.getPrevNavType();
             this.navIndex = this.getNavLength() - 1;
+            if (this.navType === navType)
+                return;
         }
     }
 

--- a/src/popup/vault/current-tab.component.ts
+++ b/src/popup/vault/current-tab.component.ts
@@ -31,12 +31,12 @@ import { ConstantsService } from 'jslib-common/services/constants.service';
 
 import { AutofillService } from '../../services/abstractions/autofill.service';
 
+import { ArrowNavService } from '../services/arrow-nav.service';
 import { PopupUtilsService } from '../services/popup-utils.service';
 
 import { Utils } from 'jslib-common/misc/utils';
 
 const BroadcasterSubscriptionId = 'CurrentTabComponent';
-const NavTypes = ['typeLogins', 'cards', 'identities'];
 
 @Component({
     selector: 'app-current-tab',
@@ -53,8 +53,7 @@ export class CurrentTabComponent implements OnInit, OnDestroy {
     inSidebar = false;
     searchTypeSearch = false;
     loaded = false;
-    navType: string = null;
-    navIndex: number = -1;
+    arrowNav = new ArrowNavService();
 
     private totpCode: string;
     private totpTimeout: number;
@@ -188,70 +187,6 @@ export class CurrentTabComponent implements OnInit, OnDestroy {
         }
     }
 
-    navDown() {
-        this.navIndex++;
-
-        if (!this.navType)
-            this.navType = this.getNextNavType();
-
-        while (this.navIndex >= this.getNavLength()) {
-            const navType = this.navType;
-            this.navType = this.getNextNavType();
-            this.navIndex = 0;
-            if (this.navType === navType)
-                return;
-        }
-    }
-
-    navUp() {
-        this.navIndex--;
-
-        if (!this.navType)
-            this.navType = this.getPrevNavType();
-
-        while (this.navIndex < 0) {
-            const navType = this.navType;
-            this.navType = this.getPrevNavType();
-            this.navIndex = this.getNavLength() - 1;
-            if (this.navType === navType)
-                return;
-        }
-    }
-
-    navReset() {
-        this.navIndex = -1;
-        this.navType = null;
-    }
-
-    private getNextNavType() {
-        let nextIndex = NavTypes.indexOf(this.navType) + 1;
-        if (nextIndex >= NavTypes.length)
-            nextIndex = 0;
-
-        return NavTypes[nextIndex];
-    }
-
-    private getPrevNavType() {
-        let prevIndex = NavTypes.indexOf(this.navType) - 1;
-        if (prevIndex < 0)
-            prevIndex = NavTypes.length - 1;
-
-        return NavTypes[prevIndex];
-    }
-
-    private getNavLength() {
-        switch (this.navType) {
-            case 'typeLogins':
-                return this.loginCiphers?.length ?? 0;
-            case 'cards':
-                return this.cardCiphers?.length ?? 0;
-            case 'identities':
-                return this.identityCiphers?.length ?? 0;
-            default:
-                return 0;
-        }
-    }
-
     private async load() {
         const tab = await BrowserApi.getTabFromCurrentWindow();
         if (tab != null) {
@@ -303,6 +238,12 @@ export class CurrentTabComponent implements OnInit, OnDestroy {
                     break;
             }
         });
+
+        this.arrowNav.init([
+            { name: 'typeLogins', length: this.loginCiphers?.length ?? 0 },
+            { name: 'cards', length: this.cardCiphers?.length ?? 0 },
+            { name: 'identities', length: this.identityCiphers?.length ?? 0 },
+        ]);
 
         this.loginCiphers = this.loginCiphers.sort((a, b) => this.cipherService.sortCiphersByLastUsedThenName(a, b));
         this.loaded = true;

--- a/src/popup/vault/groupings.component.html
+++ b/src/popup/vault/groupings.component.html
@@ -33,7 +33,7 @@
                 <app-cipher-row *ngFor="let favoriteCipher of favoriteCiphers" [cipher]="favoriteCipher"
                     title="{{'viewItem' | i18n}}" (onSelected)="selectCipher($event)"
                     (launchEvent)="launchCipher($event)" appFocus
-                    [focus]="arrowNav.navType === 'favorite' && favoriteCiphers[arrowNav.navIndex] === favoriteCipher">
+                    [focus]="arrowNav.navType === 'favorites' && favoriteCiphers[arrowNav.navIndex] === favoriteCipher">
                 </app-cipher-row>
             </div>
         </div>

--- a/src/popup/vault/groupings.component.html
+++ b/src/popup/vault/groupings.component.html
@@ -141,7 +141,7 @@
             </div>
             <div class="box-content single-line">
                 <a href="#" class="box-content-row" appStopClick appBlurClick
-                    (click)="selectTrash()">
+                    (click)="selectTrash()" appFocus [focus]="arrowNav.navType === 'trash'">
                     <div class="row-main">
                         <div class="icon"><i class="fa fa-fw fa-lg fa-trash-o"></i></div>
                         <span class="text">{{'trash' | i18n}}</span>

--- a/src/popup/vault/groupings.component.html
+++ b/src/popup/vault/groupings.component.html
@@ -1,4 +1,4 @@
-<header appArrowNav (navDown)="navDown()" (navUp)="navUp()" (navReset)="navReset()">
+<header appArrowNav (navDown)="arrowNav.down()" (navUp)="arrowNav.up()" (navReset)="arrowNav.reset()">
     <div class="left">
         <app-pop-out></app-pop-out>
     </div>
@@ -13,7 +13,7 @@
         </button>
     </div>
 </header>
-<content appArrowNav (navDown)="navDown()" (navUp)="navUp()" (navReset)="navReset()">
+<content appArrowNav (navDown)="arrowNav.down()" (navUp)="arrowNav.up()" (navReset)="arrowNav.reset()">
     <div class="no-items" *ngIf="(!ciphers || !ciphers.length) && !showSearching()">
         <i class="fa fa-spinner fa-spin fa-3x" *ngIf="!loaded"></i>
         <ng-container *ngIf="loaded">
@@ -32,7 +32,7 @@
                 <app-cipher-row *ngFor="let favoriteCipher of favoriteCiphers" [cipher]="favoriteCipher"
                     title="{{'viewItem' | i18n}}" (onSelected)="selectCipher($event)"
                     (launchEvent)="launchCipher($event)" appFocus
-                    [focus]="navType === 'favorite' && favoriteCiphers[navIndex] === favoriteCipher">
+                    [focus]="arrowNav.navType === 'favorite' && favoriteCiphers[arrowNav.navIndex] === favoriteCipher">
                 </app-cipher-row>
             </div>
         </div>
@@ -43,7 +43,7 @@
             </div>
             <div class="box-content single-line">
                 <a href="#" class="box-content-row" appStopClick appBlurClick (click)="selectType(cipherType.Login)"
-                    appFocus [focus]="navType === 'types' && navIndex === 0">
+                    appFocus [focus]="arrowNav.navType === 'types' && arrowNav.navIndex === 0">
                     <div class="row-main">
                         <div class="icon"><i class="fa fa-fw fa-lg fa-globe"></i></div>
                         <span class="text">{{'typeLogin' | i18n}}</span>
@@ -52,7 +52,7 @@
                     <span><i class="fa fa-chevron-right fa-lg row-sub-icon"></i></span>
                 </a>
                 <a href="#" class="box-content-row" appStopClick appBlurClick (click)="selectType(cipherType.Card)"
-                    appFocus [focus]="navType === 'types' && navIndex === 1">
+                    appFocus [focus]="arrowNav.navType === 'types' && arrowNav.navIndex === 1">
                     <div class="row-main">
                         <div class="icon"><i class="fa fa-fw fa-lg fa-credit-card"></i></div>
                         <span class="text">{{'typeCard' | i18n}}</span>
@@ -61,7 +61,7 @@
                     <span><i class="fa fa-chevron-right fa-lg row-sub-icon"></i></span>
                 </a>
                 <a href="#" class="box-content-row" appStopClick appBlurClick (click)="selectType(cipherType.Identity)"
-                    appFocus [focus]="navType === 'types' && navIndex === 2">
+                    appFocus [focus]="arrowNav.navType === 'types' && arrowNav.navIndex === 2">
                     <div class="row-main">
                         <div class="icon"><i class="fa fa-fw fa-lg fa-id-card-o"></i></div>
                         <span class="text">{{'typeIdentity' | i18n}}</span>
@@ -71,7 +71,7 @@
                 </a>
                 <a href="#" class="box-content-row" appStopClick appBlurClick
                     (click)="selectType(cipherType.SecureNote)" appFocus
-                    [focus]="navType === 'types' && navIndex === 3">
+                    [focus]="arrowNav.navType === 'types' && arrowNav.navIndex === 3">
                     <div class="row-main">
                         <div class="icon"><i class="fa fa-fw fa-lg fa-sticky-note-o"></i></div>
                         <span class="text">{{'typeSecureNote' | i18n}}</span>
@@ -89,7 +89,7 @@
             <div class="box-content single-line">
                 <a *ngFor="let f of nestedFolders" href="#" class="box-content-row" appStopClick appBlurClick
                     (click)="selectFolder(f.node)" appFocus
-                    [focus]="navType === 'folders' && nestedFolders[navIndex] === f">
+                    [focus]="arrowNav.navType === 'folders' && nestedFolders[arrowNav.navIndex] === f">
                     <div class="row-main">
                         <div class="icon">
                             <i class="fa fa-fw fa-lg"
@@ -110,7 +110,7 @@
             <div class="box-content single-line">
                 <a *ngFor="let nestedCollection of nestedCollections" href="#" class="box-content-row"
                     appStopClick appBlurClick (click)="selectCollection(nestedCollection.node)" appFocus
-                    [focus]="navType === 'collections' && nestedCollections[navIndex] === nestedCollection">
+                    [focus]="arrowNav.navType === 'collections' && nestedCollections[arrowNav.navIndex] === nestedCollection">
                     <div class="row-main">
                         <div class="icon"><i class="fa fa-fw fa-lg fa-cube"></i></div>
                         <span class="text">{{nestedCollection.node.name}}</span>
@@ -129,7 +129,7 @@
                 <app-cipher-row *ngFor="let noFolderCipher of noFolderCiphers" [cipher]="noFolderCipher"
                     title="{{'viewItem' | i18n}}" (onSelected)="selectCipher($event)"
                     (launchEvent)="launchCipher($event)" appFocus
-                    [focus]="navType === 'noFolder' && noFolderCiphers[navIndex] === noFolderCipher">
+                    [focus]="arrowNav.navType === 'noFolder' && noFolderCiphers[arrowNav.navIndex] === noFolderCipher">
                 </app-cipher-row>
             </div>
         </div>
@@ -161,7 +161,7 @@
                     <app-cipher-row *cdkVirtualFor="let searchedCipher of ciphers" [cipher]="searchedCipher"
                         title="{{'viewItem' | i18n}}" (onSelected)="selectCipher($event)"
                         (launchEvent)="launchCipher($event)" appFocus
-                        [focus]="navType === 'search' && ciphers[navIndex] === searchedCipher">
+                        [focus]="arrowNav.navType === 'searchCiphers' && ciphers[arrowNav.navIndex] === searchedCipher">
                     </app-cipher-row>
                 </div>
             </div>

--- a/src/popup/vault/groupings.component.html
+++ b/src/popup/vault/groupings.component.html
@@ -1,4 +1,4 @@
-<header appArrowNav (navDown)="navDown()" (navUp)="navUp()">
+<header appArrowNav (navDown)="navDown()" (navUp)="navUp()" (navReset)="navReset()">
     <div class="left">
         <app-pop-out></app-pop-out>
     </div>
@@ -13,7 +13,7 @@
         </button>
     </div>
 </header>
-<content appArrowNav (navDown)="navDown()" (navUp)="navUp()">
+<content appArrowNav (navDown)="navDown()" (navUp)="navUp()" (navReset)="navReset()">
     <div class="no-items" *ngIf="(!ciphers || !ciphers.length) && !showSearching()">
         <i class="fa fa-spinner fa-spin fa-3x" *ngIf="!loaded"></i>
         <ng-container *ngIf="loaded">

--- a/src/popup/vault/groupings.component.html
+++ b/src/popup/vault/groupings.component.html
@@ -4,7 +4,8 @@
     </div>
     <div class="search">
         <input type="{{searchTypeSearch ? 'search' : 'text'}}" placeholder="{{'searchVault' | i18n}}" id="search"
-            [(ngModel)]="searchText" (input)="search(200)" autocomplete="off" appAutofocus (keydown)="closeOnEsc($event)">
+            [(ngModel)]="searchText" (input)="search(200)" autocomplete="off" appAutofocus (keydown)="closeOnEsc($event)"
+            appFocus [focus]="arrowNav.navType === 'search'">
         <i class="fa fa-search"></i>
     </div>
     <div class="right">

--- a/src/popup/vault/groupings.component.html
+++ b/src/popup/vault/groupings.component.html
@@ -1,4 +1,4 @@
-<header>
+<header appArrowNav (navDown)="navDown()" (navUp)="navUp()">
     <div class="left">
         <app-pop-out></app-pop-out>
     </div>
@@ -13,7 +13,7 @@
         </button>
     </div>
 </header>
-<content>
+<content appArrowNav (navDown)="navDown()" (navUp)="navUp()">
     <div class="no-items" *ngIf="(!ciphers || !ciphers.length) && !showSearching()">
         <i class="fa fa-spinner fa-spin fa-3x" *ngIf="!loaded"></i>
         <ng-container *ngIf="loaded">
@@ -31,7 +31,9 @@
             <div class="box-content">
                 <app-cipher-row *ngFor="let favoriteCipher of favoriteCiphers" [cipher]="favoriteCipher"
                     title="{{'viewItem' | i18n}}" (onSelected)="selectCipher($event)"
-                    (launchEvent)="launchCipher($event)"></app-cipher-row>
+                    (launchEvent)="launchCipher($event)" appFocus
+                    [focus]="navType === 'favorite' && favoriteCiphers[navIndex] === favoriteCipher">
+                </app-cipher-row>
             </div>
         </div>
         <div class="box list">
@@ -40,7 +42,8 @@
                 <span class="flex-right">4</span>
             </div>
             <div class="box-content single-line">
-                <a href="#" class="box-content-row" appStopClick appBlurClick (click)="selectType(cipherType.Login)">
+                <a href="#" class="box-content-row" appStopClick appBlurClick (click)="selectType(cipherType.Login)"
+                    appFocus [focus]="navType === 'types' && navIndex === 0">
                     <div class="row-main">
                         <div class="icon"><i class="fa fa-fw fa-lg fa-globe"></i></div>
                         <span class="text">{{'typeLogin' | i18n}}</span>
@@ -48,7 +51,8 @@
                     <span class="row-sub-label">{{typeCounts.get(cipherType.Login) || 0}}</span>
                     <span><i class="fa fa-chevron-right fa-lg row-sub-icon"></i></span>
                 </a>
-                <a href="#" class="box-content-row" appStopClick appBlurClick (click)="selectType(cipherType.Card)">
+                <a href="#" class="box-content-row" appStopClick appBlurClick (click)="selectType(cipherType.Card)"
+                    appFocus [focus]="navType === 'types' && navIndex === 1">
                     <div class="row-main">
                         <div class="icon"><i class="fa fa-fw fa-lg fa-credit-card"></i></div>
                         <span class="text">{{'typeCard' | i18n}}</span>
@@ -56,7 +60,8 @@
                     <span class="row-sub-label">{{typeCounts.get(cipherType.Card) || 0}}</span>
                     <span><i class="fa fa-chevron-right fa-lg row-sub-icon"></i></span>
                 </a>
-                <a href="#" class="box-content-row" appStopClick appBlurClick (click)="selectType(cipherType.Identity)">
+                <a href="#" class="box-content-row" appStopClick appBlurClick (click)="selectType(cipherType.Identity)"
+                    appFocus [focus]="navType === 'types' && navIndex === 2">
                     <div class="row-main">
                         <div class="icon"><i class="fa fa-fw fa-lg fa-id-card-o"></i></div>
                         <span class="text">{{'typeIdentity' | i18n}}</span>
@@ -65,7 +70,8 @@
                     <span><i class="fa fa-chevron-right fa-lg row-sub-icon"></i></span>
                 </a>
                 <a href="#" class="box-content-row" appStopClick appBlurClick
-                    (click)="selectType(cipherType.SecureNote)">
+                    (click)="selectType(cipherType.SecureNote)" appFocus
+                    [focus]="navType === 'types' && navIndex === 3">
                     <div class="row-main">
                         <div class="icon"><i class="fa fa-fw fa-lg fa-sticky-note-o"></i></div>
                         <span class="text">{{'typeSecureNote' | i18n}}</span>
@@ -82,7 +88,8 @@
             </div>
             <div class="box-content single-line">
                 <a *ngFor="let f of nestedFolders" href="#" class="box-content-row" appStopClick appBlurClick
-                    (click)="selectFolder(f.node)">
+                    (click)="selectFolder(f.node)" appFocus
+                    [focus]="navType === 'folders' && nestedFolders[navIndex] === f">
                     <div class="row-main">
                         <div class="icon">
                             <i class="fa fa-fw fa-lg"
@@ -102,7 +109,8 @@
             </div>
             <div class="box-content single-line">
                 <a *ngFor="let nestedCollection of nestedCollections" href="#" class="box-content-row"
-                    appStopClick appBlurClick (click)="selectCollection(nestedCollection.node)">
+                    appStopClick appBlurClick (click)="selectCollection(nestedCollection.node)" appFocus
+                    [focus]="navType === 'collections' && nestedCollections[navIndex] === nestedCollection">
                     <div class="row-main">
                         <div class="icon"><i class="fa fa-fw fa-lg fa-cube"></i></div>
                         <span class="text">{{nestedCollection.node.name}}</span>
@@ -120,7 +128,9 @@
             <div class="box-content">
                 <app-cipher-row *ngFor="let noFolderCipher of noFolderCiphers" [cipher]="noFolderCipher"
                     title="{{'viewItem' | i18n}}" (onSelected)="selectCipher($event)"
-                    (launchEvent)="launchCipher($event)"></app-cipher-row>
+                    (launchEvent)="launchCipher($event)" appFocus
+                    [focus]="navType === 'noFolder' && noFolderCiphers[navIndex] === noFolderCipher">
+                </app-cipher-row>
             </div>
         </div>
         <div class="box list" *ngIf="deletedCount">
@@ -150,7 +160,9 @@
                 <div class="box-content">
                     <app-cipher-row *cdkVirtualFor="let searchedCipher of ciphers" [cipher]="searchedCipher"
                         title="{{'viewItem' | i18n}}" (onSelected)="selectCipher($event)"
-                        (launchEvent)="launchCipher($event)"></app-cipher-row>
+                        (launchEvent)="launchCipher($event)" appFocus
+                        [focus]="navType === 'search' && ciphers[navIndex] === searchedCipher">
+                    </app-cipher-row>
                 </div>
             </div>
         </cdk-virtual-scroll-viewport>

--- a/src/popup/vault/groupings.component.ts
+++ b/src/popup/vault/groupings.component.ts
@@ -373,10 +373,10 @@ export class GroupingsComponent extends BaseGroupingsComponent implements OnInit
             ]);
         } else {
             this.arrowNav.init([
+                { name: 'favorites', length: this.favoriteCiphers?.length ?? 0 },
                 { name: 'types', length: 4 },
                 { name: 'folders', length: this.nestedFolders?.length ?? 0 },
                 { name: 'collections', length: this.nestedCollections?.length ?? 0 },
-                { name: 'favorites', length: this.favoriteCiphers?.length ?? 0 },
                 { name: 'noFolder', length: this.noFolderCiphers?.length ?? 0 },
                 { name: 'search', length: 1 },
             ]);

--- a/src/popup/vault/groupings.component.ts
+++ b/src/popup/vault/groupings.component.ts
@@ -342,6 +342,11 @@ export class GroupingsComponent extends BaseGroupingsComponent implements OnInit
         }
     }
 
+    navReset() {
+        this.navIndex = -1;
+        this.navType = null;
+    }
+
     private getNextNavType() {
         if (this.showSearching())
             return 'search';

--- a/src/popup/vault/groupings.component.ts
+++ b/src/popup/vault/groupings.component.ts
@@ -314,14 +314,11 @@ export class GroupingsComponent extends BaseGroupingsComponent implements OnInit
             this.navType = this.getNextNavType();
 
         while (this.navIndex >= this.getNavLength()) {
-            const nextType = this.getNextNavType();
-            if (this.navType === nextType) {
-                this.navReset();
-                return;
-            }
-
-            this.navType = nextType;
+            const navType = this.navType;
+            this.navType = this.getNextNavType();
             this.navIndex = 0;
+            if (this.navType === navType)
+                return;
         }
     }
 
@@ -332,14 +329,11 @@ export class GroupingsComponent extends BaseGroupingsComponent implements OnInit
             this.navType = this.getPrevNavType();
 
         while (this.navIndex < 0) {
-            const prevType = this.getPrevNavType();
-            if (this.navType === prevType) {
-                this.navReset();
-                return;
-            }
-
-            this.navType = prevType;
+            const navType = this.navType;
+            this.navType = this.getPrevNavType();
             this.navIndex = this.getNavLength() - 1;
+            if (this.navType === navType)
+                return;
         }
     }
 

--- a/src/popup/vault/groupings.component.ts
+++ b/src/popup/vault/groupings.component.ts
@@ -37,6 +37,7 @@ import { PopupUtilsService } from '../services/popup-utils.service';
 
 const ComponentId = 'GroupingsComponent';
 const ScopeStateId = ComponentId + 'Scope';
+const NavTypes = ['types', 'folders', 'collections', 'favorites', 'noFolder'];
 
 @Component({
     selector: 'app-vault-groupings',
@@ -65,6 +66,8 @@ export class GroupingsComponent extends BaseGroupingsComponent implements OnInit
     searchPending = false;
     searchTypeSearch = false;
     deletedCount = 0;
+    navType: string = null;
+    navIndex: number = -1;
 
     private loadedTimeout: number;
     private selectedTimeout: number;
@@ -300,6 +303,83 @@ export class GroupingsComponent extends BaseGroupingsComponent implements OnInit
         // If input not empty, use browser default behavior of clearing input instead
 		if (e.key === 'Escape' && (this.searchText == null || this.searchText === '')) {
             BrowserApi.closePopup(window);
+        }
+    }
+
+    navDown() {
+        this.navIndex++;
+
+        if (!this.navType)
+            this.navType = this.getNextNavType();
+
+        while (this.navIndex >= this.getNavLength()) {
+            const nextType = this.getNextNavType();
+            if (this.navType === nextType) {
+                this.navReset();
+                return;
+            }
+
+            this.navType = nextType;
+            this.navIndex = 0;
+        }
+    }
+
+    navUp() {
+        this.navIndex--;
+
+        if (!this.navType)
+            this.navType = this.getPrevNavType();
+
+        while (this.navIndex < 0) {
+            const prevType = this.getPrevNavType();
+            if (this.navType === prevType) {
+                this.navReset();
+                return;
+            }
+
+            this.navType = prevType;
+            this.navIndex = this.getNavLength() - 1;
+        }
+    }
+
+    private getNextNavType() {
+        if (this.showSearching())
+            return 'search';
+
+        let nextIndex = NavTypes.indexOf(this.navType) + 1;
+        if (nextIndex >= NavTypes.length)
+            nextIndex = 0;
+
+        return NavTypes[nextIndex];
+    }
+
+    private getPrevNavType() {
+        if (this.showSearching())
+            return 'search';
+
+        let prevIndex = NavTypes.indexOf(this.navType) - 1;
+        if (prevIndex < 0)
+            prevIndex = NavTypes.length - 1;
+
+        return NavTypes[prevIndex];
+    }
+
+    private getNavLength() {
+        switch (this.navType) {
+            case 'types':
+                return 4;
+            case 'folders':
+                return this.nestedFolders?.length ?? 0;
+            case 'collections':
+                return this.nestedCollections?.length ?? 0;
+            case 'favorites':
+                return this.favoriteCiphers?.length ?? 0;
+            case 'noFolder':
+                return this.noFolderCiphers?.length ?? 0;
+            case 'search':
+                return this.ciphers?.length ?? 0;
+            default:
+                return 0;
         }
     }
 

--- a/src/popup/vault/groupings.component.ts
+++ b/src/popup/vault/groupings.component.ts
@@ -224,6 +224,7 @@ export class GroupingsComponent extends BaseGroupingsComponent implements OnInit
     }
 
     async search(timeout: number = null) {
+        this.navReset();
         this.searchPending = false;
         if (this.searchTimeout != null) {
             clearTimeout(this.searchTimeout);

--- a/src/popup/vault/groupings.component.ts
+++ b/src/popup/vault/groupings.component.ts
@@ -378,6 +378,7 @@ export class GroupingsComponent extends BaseGroupingsComponent implements OnInit
                 { name: 'folders', length: this.nestedFolders?.length ?? 0 },
                 { name: 'collections', length: this.nestedCollections?.length ?? 0 },
                 { name: 'noFolder', length: this.noFolderCiphers?.length ?? 0 },
+                { name: 'trash', length: 1 },
                 { name: 'search', length: 1 },
             ]);
         }

--- a/src/popup/vault/groupings.component.ts
+++ b/src/popup/vault/groupings.component.ts
@@ -369,6 +369,7 @@ export class GroupingsComponent extends BaseGroupingsComponent implements OnInit
         if (this.showSearching()) {
             this.arrowNav.init([
                 { name: 'searchCiphers', length: this.ciphers?.length ?? 0 },
+                { name: 'search', length: 1 },
             ]);
         } else {
             this.arrowNav.init([
@@ -377,6 +378,7 @@ export class GroupingsComponent extends BaseGroupingsComponent implements OnInit
                 { name: 'collections', length: this.nestedCollections?.length ?? 0 },
                 { name: 'favorites', length: this.favoriteCiphers?.length ?? 0 },
                 { name: 'noFolder', length: this.noFolderCiphers?.length ?? 0 },
+                { name: 'search', length: 1 },
             ]);
         }
     }


### PR DESCRIPTION
This adds keyboard navigation using up/down arrow keys to navigate the lists.

Similar functionality is available by using the "tab" key, however, this is a precursor for my next addition, which is to add support left/right navigation to select the action buttons on a cipher row.

Tab functionality is unchanged with this pull request.
