### PR TITLE
Do not autofill inputs meant for password recovery

### DIFF
--- a/src/services/autofill.service.ts
+++ b/src/services/autofill.service.ts
@@ -945,7 +945,7 @@ export default class AutofillService implements AutofillServiceInterface {
                     return false;
                 }
 
-                const ignoreList = ['onetimepassword', 'captcha', 'findanything'];
+                const ignoreList = ['onetimepassword', 'captcha', 'findanything', 'forgot'];
                 if (ignoreList.some(i => cleanedValue.indexOf(i) > -1)) {
                     return false;
                 }


### PR DESCRIPTION
This adds the fix I suggested in issue #1956 . I have tested it and it works.

Some websites have a form to recover forgotten password in the same page as the login form. Bitwarden incorrectly autofills that form when the input is named "forgotpassword", because it contains the word "password".

Here's an example: https://demo.phplist.org/lists/admin/