### PR TITLE
Don't use deprecated initKeyEvent() for autofill

### DIFF
--- a/src/content/autofill.js
+++ b/src/content/autofill.js
@@ -835,12 +835,14 @@
 
         document.elementForOPID = getElementByOpId;
 
-        // normalize the event since firefox handles events differently than others
+        // normalize the event based on API support
         function normalizeEvent(el, eventName) {
             var ev;
-            if (isFirefox) {
-                ev = document.createEvent('KeyboardEvent');
-                ev.initKeyEvent(eventName, true, false, null, false, false, false, false, 0, 0);
+            if ('KeyboardEvent' in window) {
+                ev = new window.KeyboardEvent(eventName, {
+                    bubbles: true,
+                    cancelable: false,
+                });
             }
             else {
                 ev = el.ownerDocument.createEvent('Events');


### PR DESCRIPTION
This fixes #2000