### PR TITLE
Add iframe allow to initial load

### DIFF
--- a/src/popup/accounts/two-factor.component.html
+++ b/src/popup/accounts/two-factor.component.html
@@ -60,7 +60,7 @@
             </div>
         </ng-container>
         <ng-container *ngIf="selectedProviderType === providerType.WebAuthn && !webAuthnNewTab">
-            <div id="web-authn-frame"><iframe id="webauthn_iframe"></iframe></div>
+            <div id="web-authn-frame"><iframe id="webauthn_iframe" [allow]="webAuthnAllow"></iframe></div>
             <div class="box">
                 <div class="box-content">
                     <div class="box-content-row box-content-row-checkbox" appBoxRow>


### PR DESCRIPTION
# Overview

Fixes: https://app.asana.com/0/0/1200719554428331/f

Chrome seems to balk at this attribute being added after the fact. It may be a race condition or an intentional block, but adding to the template fixes our missing allow attribute problem.

# Draft reason
depends on bitwarden/jslib#455

>Note: this will be cherry picked to `rc`
