### PR TITLE
Fix Send Options Toggling

### DIFF
--- a/src/popup/send/send-add-edit.component.html
+++ b/src/popup/send/send-add-edit.component.html
@@ -116,7 +116,7 @@
                 <i *ngIf="showOptions" class="fa fa-chevron-up fa-sm icon"></i>
             </div>
         </div>
-        <ng-container *ngIf="showOptions">
+        <div [hidden]="!showOptions">
             <app-send-efflux-dates
                 [initialDeletionDate]="send.deletionDate" [initialExpirationDate]="send.expirationDate" 
                 [editMode]="editMode" [disabled]="disableSend" (datesChanged)="setDates($event)" (popOutWindow)="popOutWindow()">
@@ -200,7 +200,7 @@
                     </div>
                 </div>
             </div>
-        </ng-container>
+        </div>
         <!-- Delete -->
         <div class="box list" *ngIf="editMode">
             <div class="box-content single-line">


### PR DESCRIPTION
Resolves https://app.asana.com/0/1200578627114106/1200719554428334/f

### Issue
In web and desktop we use the HTML attribute `hidden` to toggle optional Send fields in and out of view. In browser we anomalously achieve this same functionality with an `*ngIf`. `*ngIf` not loading content into the DOM until its condition is met is causing the `efflux-dates-component` to not emit the initial deletion date value, resulting in an error.

### Solution
Change the `*ngIf` to `[hidden]` for toggling Send optional fields on and off so form content is not added to or removed from the DOM dynamically.

