### PR TITLE
Revert CSP change

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -94,7 +94,7 @@
   "optional_permissions": [
     "nativeMessaging"
   ],
-  "content_security_policy": "script-src 'self'; object-src 'self'",
+  "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
   "commands": {
     "_execute_browser_action": {
       "suggested_key": {


### PR DESCRIPTION
## Objective

PR #1873 suggested that we remove `unsafe-inline` from our browser CSP, because it didn't look like we had any code that would require it. I double checked this and merged it.

I've now realised that:
* these CSP options are removed entirely for FF, Chrome, Opera and Edge builds - so this change did not have the effect I intended
* when running a dev build using `npm run build`, the extension has started throwing errors about code being blocked by the CSP. I'm not yet sure what practical effect this has.
* it looks like CSP options are kept for Safari dist builds, which makes me concerned about the effect in prod.

It seems safest to revert this change pending further investigation. This should be cherry-picked to `rc`.