### PR TITLE
Fixed order of supportedLocales to have 'en' as fallback again

### DIFF
--- a/src/services/i18n.service.ts
+++ b/src/services/i18n.service.ts
@@ -8,8 +8,9 @@ export default class I18nService extends BaseI18nService {
             return await file.json();
         });
 
+        // Please leave 'en' where it is, as it's our fallback language in case no translation can be found
         this.supportedTranslationLocales = [
-            'az', 'en', 'be', 'bg', 'bn', 'ca', 'cs', 'da', 'de', 'el', 'en-GB', 'en-IN', 'es', 'et', 'fa', 'fi', 'fr', 'he', 'hr', 'hu',
+            'en', 'az', 'be', 'bg', 'bn', 'ca', 'cs', 'da', 'de', 'el', 'en-GB', 'en-IN', 'es', 'et', 'fa', 'fi', 'fr', 'he', 'hr', 'hu',
             'id', 'it', 'ja', 'kn', 'ko', 'lv', 'ml', 'nb', 'nl', 'pl', 'pt-BR', 'pt-PT', 'ro', 'ru', 'sk', 'sr', 'sv', 'th', 'tr', 'uk',
             'vi', 'zh-CN', 'zh-TW',
         ];


### PR DESCRIPTION
With #1949 the AZ language was added. Unfortunately it was set on the first position of the supportedTranslationLocales[]. The first entry is used as a fallback in case the selected locale (browser/system) is not found. This results in users getting for example the login or register site displayed in Azerbaijani.

As can be seen here: https://community.bitwarden.com/t/bitwarden-registration-in-wrong-language/32642