### PR TITLE
Add new context menu item: Copy Custom Field Name

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -89,7 +89,7 @@
     "message": "Generate Password (copied)"
   },
   "copyElementIdentifier": {
-    "message": "Copy custom field name"
+    "message": "Copy Custom Field Name"
   },
   "noMatchingLogins": {
     "message": "No matching logins."

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -88,6 +88,9 @@
   "generatePasswordCopied": {
     "message": "Generate Password (copied)"
   },
+  "copyElementIdentifier": {
+    "message": "Copy custom field name"
+  },
   "noMatchingLogins": {
     "message": "No matching logins."
   },

--- a/src/background/contextMenus.background.ts
+++ b/src/background/contextMenus.background.ts
@@ -29,6 +29,8 @@ export default class ContextMenusBackground {
         this.contextMenus.onClicked.addListener(async (info: any, tab: any) => {
             if (info.menuItemId === 'generate-password') {
                 await this.generatePasswordToClipboard();
+            } else if (info.menuItemId === 'copy-identifier') {
+                await this.getClickedElement();
             } else if (info.parentMenuItemId === 'autofill' ||
                 info.parentMenuItemId === 'copy-username' ||
                 info.parentMenuItemId === 'copy-password' ||
@@ -38,11 +40,24 @@ export default class ContextMenusBackground {
         });
     }
 
+    copyClickedElement(msg: any) {
+        this.platformUtilsService.copyToClipboard(msg.identifier, { window: window });
+    }
+
     private async generatePasswordToClipboard() {
         const options = (await this.passwordGenerationService.getOptions())[0];
         const password = await this.passwordGenerationService.generatePassword(options);
         this.platformUtilsService.copyToClipboard(password, { window: window });
         this.passwordGenerationService.addHistory(password);
+    }
+
+    private async getClickedElement() {
+        const tab = await BrowserApi.getTabFromCurrentWindow();
+        if (tab == null) {
+            return;
+        }
+
+        BrowserApi.tabSendMessageData(tab, 'getClickedElement');
     }
 
     private async cipherAction(info: any) {

--- a/src/background/contextMenus.background.ts
+++ b/src/background/contextMenus.background.ts
@@ -40,10 +40,6 @@ export default class ContextMenusBackground {
         });
     }
 
-    copyClickedElement(msg: any) {
-        this.platformUtilsService.copyToClipboard(msg.identifier, { window: window });
-    }
-
     private async generatePasswordToClipboard() {
         const options = (await this.passwordGenerationService.getOptions())[0];
         const password = await this.passwordGenerationService.generatePassword(options);

--- a/src/background/main.background.ts
+++ b/src/background/main.background.ts
@@ -244,8 +244,7 @@ export default class MainBackground {
         this.runtimeBackground = new RuntimeBackground(this, this.autofillService, this.cipherService,
             this.platformUtilsService as BrowserPlatformUtilsService, this.storageService, this.i18nService,
             this.notificationsService, this.systemService, this.vaultTimeoutService,
-            this.environmentService, this.policyService, this.userService, this.messagingService,
-            () => this.contextMenusBackground);
+            this.environmentService, this.policyService, this.userService, this.messagingService);
         this.nativeMessagingBackground = new NativeMessagingBackground(this.storageService, this.cryptoService, this.cryptoFunctionService,
             this.vaultTimeoutService, this.runtimeBackground, this.i18nService, this.userService, this.messagingService, this.appIdService,
             this.platformUtilsService);

--- a/src/background/main.background.ts
+++ b/src/background/main.background.ts
@@ -244,7 +244,8 @@ export default class MainBackground {
         this.runtimeBackground = new RuntimeBackground(this, this.autofillService, this.cipherService,
             this.platformUtilsService as BrowserPlatformUtilsService, this.storageService, this.i18nService,
             this.notificationsService, this.systemService, this.vaultTimeoutService,
-            this.environmentService, this.policyService, this.userService, this.messagingService);
+            this.environmentService, this.policyService, this.userService, this.messagingService,
+            () => this.contextMenusBackground);
         this.nativeMessagingBackground = new NativeMessagingBackground(this.storageService, this.cryptoService, this.cryptoFunctionService,
             this.vaultTimeoutService, this.runtimeBackground, this.i18nService, this.userService, this.messagingService, this.appIdService,
             this.platformUtilsService);
@@ -510,6 +511,14 @@ export default class MainBackground {
             parentId: 'root',
             contexts: ['all'],
             title: this.i18nService.t('generatePasswordCopied'),
+        });
+
+        await this.contextMenusCreate({
+            type: 'normal',
+            id: 'copy-identifier',
+            parentId: 'root',
+            contexts: ['all'],
+            title: this.i18nService.t('copyElementIdentifier'),
         });
 
         this.buildingContextMenu = false;

--- a/src/background/runtime.background.ts
+++ b/src/background/runtime.background.ts
@@ -18,6 +18,8 @@ import { ConstantsService } from 'jslib-common/services/constants.service';
 import { AutofillService } from '../services/abstractions/autofill.service';
 import BrowserPlatformUtilsService from '../services/browserPlatformUtils.service';
 
+import ContextMenusBackground from './contextMenus.background';
+
 import { BrowserApi } from '../browser/browserApi';
 
 import MainBackground from './main.background';
@@ -39,7 +41,8 @@ export default class RuntimeBackground {
         private notificationsService: NotificationsService,
         private systemService: SystemService, private vaultTimeoutService: VaultTimeoutService,
         private environmentService: EnvironmentService, private policyService: PolicyService,
-        private userService: UserService, private messagingService: MessagingService) {
+        private userService: UserService, private messagingService: MessagingService,
+        private contextMenusBackground: () => ContextMenusBackground) {
 
         // onInstalled listener must be wired up before anything else, so we do it in the ctor
         chrome.runtime.onInstalled.addListener((details: any) => {
@@ -195,6 +198,8 @@ export default class RuntimeBackground {
                     type: 'info',
                 });
                 break;
+            case 'getClickedElementResponse':
+                this.contextMenusBackground().copyClickedElement(msg);
             default:
                 break;
         }

--- a/src/background/runtime.background.ts
+++ b/src/background/runtime.background.ts
@@ -18,8 +18,6 @@ import { ConstantsService } from 'jslib-common/services/constants.service';
 import { AutofillService } from '../services/abstractions/autofill.service';
 import BrowserPlatformUtilsService from '../services/browserPlatformUtils.service';
 
-import ContextMenusBackground from './contextMenus.background';
-
 import { BrowserApi } from '../browser/browserApi';
 
 import MainBackground from './main.background';
@@ -41,8 +39,7 @@ export default class RuntimeBackground {
         private notificationsService: NotificationsService,
         private systemService: SystemService, private vaultTimeoutService: VaultTimeoutService,
         private environmentService: EnvironmentService, private policyService: PolicyService,
-        private userService: UserService, private messagingService: MessagingService,
-        private contextMenusBackground: () => ContextMenusBackground) {
+        private userService: UserService, private messagingService: MessagingService) {
 
         // onInstalled listener must be wired up before anything else, so we do it in the ctor
         chrome.runtime.onInstalled.addListener((details: any) => {
@@ -199,7 +196,7 @@ export default class RuntimeBackground {
                 });
                 break;
             case 'getClickedElementResponse':
-                this.contextMenusBackground().copyClickedElement(msg);
+                this.platformUtilsService.copyToClipboard(msg.identifier, { window: window });
             default:
                 break;
         }

--- a/src/content/contextMenuHandler.ts
+++ b/src/content/contextMenuHandler.ts
@@ -1,0 +1,39 @@
+let clickedEl: HTMLElement = null;
+let identifier: string = null;
+const inputTags = ['input', 'textarea', 'select'];
+
+function getClickedElementIdentifier(event: Event) {
+    clickedEl = event.target as HTMLElement;
+
+    if (!inputTags.includes(clickedEl.nodeName.toLowerCase())) {
+        identifier = null;
+        return;
+    }
+
+    const name = clickedEl.getAttribute('name');
+    const id = clickedEl.getAttribute('id');
+
+    if (!isNullOrEmpty(name) && !isNullOrEmpty(id)) {
+        identifier = document.getElementsByName(name)?.length === 1 ? name : id;
+    } else {
+        identifier = isNullOrEmpty(name) ? id : name;
+    }
+}
+
+function isNullOrEmpty(s: string) {
+    return s == null || s === '';
+}
+
+document.addEventListener('contextmenu', event => {
+    getClickedElementIdentifier(event);
+});
+
+chrome.runtime.onMessage.addListener(event => {
+    if (event.command === 'getClickedElement' && clickedEl != null) {
+        chrome.runtime.sendMessage({
+            command: 'getClickedElementResponse',
+            sender: 'contextMenuHandler',
+            identifier: identifier,
+        });
+    }
+});

--- a/src/content/contextMenuHandler.ts
+++ b/src/content/contextMenuHandler.ts
@@ -1,6 +1,7 @@
+const inputTags = ['input', 'textarea', 'select'];
+const attributes = ['id', 'name', 'label-aria', 'placeholder'];
 let clickedEl: HTMLElement = null;
 let identifier: string = null;
-const inputTags = ['input', 'textarea', 'select'];
 
 function getClickedElementIdentifier(event: Event) {
     clickedEl = event.target as HTMLElement;
@@ -10,13 +11,14 @@ function getClickedElementIdentifier(event: Event) {
         return;
     }
 
-    const name = clickedEl.getAttribute('name');
-    const id = clickedEl.getAttribute('id');
-
-    if (!isNullOrEmpty(name) && !isNullOrEmpty(id)) {
-        identifier = document.getElementsByName(name)?.length === 1 ? name : id;
-    } else {
-        identifier = isNullOrEmpty(name) ? id : name;
+    for (let attr of attributes) {
+        const attributeValue = clickedEl.getAttribute(attr);
+        if (!isNullOrEmpty(attributeValue)) {
+            identifier = attributeValue;
+            if (document.querySelectorAll('[' + attr + '="' + attributeValue + '"]')?.length === 1) {
+                break;
+            }
+        }
     }
 }
 

--- a/src/content/contextMenuHandler.ts
+++ b/src/content/contextMenuHandler.ts
@@ -8,7 +8,7 @@ function getClickedElementIdentifier() {
         return 'Invalid element type.';
     }
 
-    for (let attr of attributes) {
+    for (const attr of attributes) {
         const attributeValue = clickedEl.getAttribute(attr);
         const selector = '[' + attr + '="' + attributeValue + '"]';
         if (!isNullOrEmpty(attributeValue) && document.querySelectorAll(selector)?.length === 1) {
@@ -28,7 +28,7 @@ document.addEventListener('contextmenu', event => {
     clickedEl = event.target as HTMLElement;
 });
 
-// Runs when the 'Copy Custom Field Name' is actually clicked
+// Runs when the 'Copy Custom Field Name' context menu item is actually clicked
 chrome.runtime.onMessage.addListener(event => {
     if (event.command === 'getClickedElement' && clickedEl != null) {
         const identifier = getClickedElementIdentifier();

--- a/src/content/contextMenuHandler.ts
+++ b/src/content/contextMenuHandler.ts
@@ -1,37 +1,37 @@
 const inputTags = ['input', 'textarea', 'select'];
 const attributes = ['id', 'name', 'label-aria', 'placeholder'];
 let clickedEl: HTMLElement = null;
-let identifier: string = null;
 
-function getClickedElementIdentifier(event: Event) {
-    clickedEl = event.target as HTMLElement;
-
+// Find the best attribute to be used as the Name for an element in a custom field
+function getClickedElementIdentifier() {
     if (!inputTags.includes(clickedEl.nodeName.toLowerCase())) {
-        identifier = null;
-        return;
+        return 'Invalid element type.';
     }
 
     for (let attr of attributes) {
         const attributeValue = clickedEl.getAttribute(attr);
-        if (!isNullOrEmpty(attributeValue)) {
-            identifier = attributeValue;
-            if (document.querySelectorAll('[' + attr + '="' + attributeValue + '"]')?.length === 1) {
-                break;
-            }
+        const selector = '[' + attr + '="' + attributeValue + '"]';
+        if (!isNullOrEmpty(attributeValue) && document.querySelectorAll(selector)?.length === 1) {
+            return attributeValue;
         }
     }
+    return 'No unique identifier found.';
 }
 
 function isNullOrEmpty(s: string) {
     return s == null || s === '';
 }
 
+// We only have access to the element that's been clicked when the context menu is first opened.
+// Remember it for use later.
 document.addEventListener('contextmenu', event => {
-    getClickedElementIdentifier(event);
+    clickedEl = event.target as HTMLElement;
 });
 
+// Runs when the 'Copy Custom Field Name' is actually clicked
 chrome.runtime.onMessage.addListener(event => {
     if (event.command === 'getClickedElement' && clickedEl != null) {
+        const identifier = getClickedElementIdentifier();
         chrome.runtime.sendMessage({
             command: 'getClickedElementResponse',
             sender: 'contextMenuHandler',

--- a/src/content/contextMenuHandler.ts
+++ b/src/content/contextMenuHandler.ts
@@ -2,7 +2,7 @@ const inputTags = ['input', 'textarea', 'select'];
 const attributes = ['id', 'name', 'label-aria', 'placeholder'];
 let clickedEl: HTMLElement = null;
 
-// Find the best attribute to be used as the Name for an element in a custom field
+// Find the best attribute to be used as the Name for an element in a custom field.
 function getClickedElementIdentifier() {
     if (!inputTags.includes(clickedEl.nodeName.toLowerCase())) {
         return 'Invalid element type.';
@@ -28,7 +28,7 @@ document.addEventListener('contextmenu', event => {
     clickedEl = event.target as HTMLElement;
 });
 
-// Runs when the 'Copy Custom Field Name' context menu item is actually clicked
+// Runs when the 'Copy Custom Field Name' context menu item is actually clicked.
 chrome.runtime.onMessage.addListener(event => {
     if (event.command === 'getClickedElement' && clickedEl != null) {
         const identifier = getClickedElementIdentifier();

--- a/src/content/contextMenuHandler.ts
+++ b/src/content/contextMenuHandler.ts
@@ -4,6 +4,10 @@ let clickedEl: HTMLElement = null;
 
 // Find the best attribute to be used as the Name for an element in a custom field.
 function getClickedElementIdentifier() {
+    if (clickedEl == null) {
+        return 'Unable to identify clicked element.'
+    }
+
     if (!inputTags.includes(clickedEl.nodeName.toLowerCase())) {
         return 'Invalid element type.';
     }
@@ -30,7 +34,7 @@ document.addEventListener('contextmenu', event => {
 
 // Runs when the 'Copy Custom Field Name' context menu item is actually clicked.
 chrome.runtime.onMessage.addListener(event => {
-    if (event.command === 'getClickedElement' && clickedEl != null) {
+    if (event.command === 'getClickedElement') {
         const identifier = getClickedElementIdentifier();
         chrome.runtime.sendMessage({
             command: 'getClickedElementResponse',

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -20,7 +20,8 @@
       "js": [
         "content/autofill.js",
         "content/autofiller.js",
-        "content/notificationBar.js"
+        "content/notificationBar.js",
+        "content/contextMenuHandler.js"
       ],
       "matches": [
         "http://*/*",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -130,6 +130,7 @@ const config = {
         'content/autofill': './src/content/autofill.js',
         'content/autofiller': './src/content/autofiller.ts',
         'content/notificationBar': './src/content/notificationBar.ts',
+        'content/contextMenuHandler': './src/content/contextMenuHandler.ts',
         'content/shortcuts': './src/content/shortcuts.ts',
         'content/message_handler': './src/content/message_handler.ts',
         'notification/bar': './src/notification/bar.js',


### PR DESCRIPTION
## Objective

It's bad UX to require users to open up dev tools and read the HTML just to create custom fields. This adds a new right-click option that will copy the best identifier to the clipboard, which the user can then paste into custom field Name.

I had originally included this in the [Linked Custom Fields PR](https://github.com/bitwarden/browser/pull/1963), but decided that it should be broken out into its own ticket. I've made some slight improvements to the logic since that PR.

The identifier that is copied to the clipboard is the html `id`, `name`, `aria-label` or `placeholder`. The script checks these attributes, in that order, and uses the first value it comes across which is valid (not null/blank) and unique. This is the same order that the autofill service tries to fill custom fields.

## Screenshots
<img width="414" alt="Screen Shot 2021-08-26 at 12 59 09 pm" src="https://user-images.githubusercontent.com/31796059/130893380-533c6516-d147-4da0-93db-b5d7a519e37a.png">

## Code changes
* `contextMenus.background.ts` and `main.background.ts` - add "Copy custom field name" to the context menu
* `contextMenuHandler.ts` - a content script that keeps track of the element that has been right-clicked to open the context menu. It also figures out the best identifier to use and provides it to the background scripts on request.
* `runtime.background.ts` - wire up the messaging service
* `webpack.config` - include the new content script