### PR TITLE
[SSO/Auto Enroll] Set Password banner

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1761,5 +1761,11 @@
   },
   "updateMasterPasswordWarning": {
     "message": "Your Master Password was recently changed by an administrator in your organization. In order to access the vault, you must update it now. Proceeding will log you out of your current session, requiring you to log back in. Active sessions on other devices may continue to remain active for up to one hour."
+  },
+  "resetPasswordPolicyAutoEnroll": {
+    "message": "Automatic Enrollment"
+  },
+  "resetPasswordAutoEnrollInviteWarning": {
+    "message": "This organization has an enterprise policy that will automatically enroll you in password reset. Enrollment will allow organization administrators to change your master password."
   }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1765,15 +1765,13 @@
   "updateMasterPasswordWarning": {
     "message": "Your Master Password was recently changed by an administrator in your organization. In order to access the vault, you must update it now. Proceeding will log you out of your current session, requiring you to log back in. Active sessions on other devices may continue to remain active for up to one hour."
   },
-<<<<<<< HEAD
   "resetPasswordPolicyAutoEnroll": {
     "message": "Automatic Enrollment"
   },
   "resetPasswordAutoEnrollInviteWarning": {
     "message": "This organization has an enterprise policy that will automatically enroll you in password reset. Enrollment will allow organization administrators to change your master password."
-=======
+  },
   "selectFolder": {
     "message": "Select folder..."
->>>>>>> master
   }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1773,5 +1773,8 @@
   },
   "selectFolder": {
     "message": "Select folder..."
+  },
+  "ssoCompleteRegistration": {
+    "message": "In order to complete logging in with SSO, please set a master password to access and protect your vault."
   }
 }

--- a/src/popup/accounts/set-password.component.html
+++ b/src/popup/accounts/set-password.component.html
@@ -20,6 +20,10 @@
         <div *ngIf="!syncLoading">
             <div class="box">
                 <app-callout type="tip">{{'ssoCompleteRegistration' | i18n}}</app-callout>
+                <app-callout type="warning" title="{{'resetPasswordPolicyAutoEnroll' | i18n}}"
+                    *ngIf="resetPassswordAutoEnroll">
+                    {{'resetPasswordAutoEnrollInviteWarning' | i18n}}
+                </app-callout>
                 <app-callout type="info" [enforcedPolicyOptions]="enforcedPolicyOptions" *ngIf="enforcedPolicyOptions">
                 </app-callout>
             </div>

--- a/src/popup/scss/misc.scss
+++ b/src/popup/scss/misc.scss
@@ -339,6 +339,11 @@ app-vault-icon {
             }
         }
     }
+
+    .enforced-policy-options ul {
+        padding-left: 30px;
+        margin: 0;
+    }
 }
 
 input[type="password"]::-ms-reveal {


### PR DESCRIPTION
## Objective
> Add callout banner during SSO Set password flow when a user will be automatically enrolled in Reset Password program.

## Code Changes
- **set-password.component.html**: Added `callout` banner with information regarding auto enrollment
- **messages.json**: Added new strings for `callout` and missing sso string
- **misc.sass**: Added `ul` style

## Screenshot
<img width="390" alt="browser-set-password-auto-enroll" src="https://user-images.githubusercontent.com/26154748/132106503-c8fb38b8-bbc8-46b6-9f70-eebfba5b5c23.png">

## Prereqs
- [jslib: [SSO] Set password auto enroll update](https://github.com/bitwarden/jslib/pull/472)