### PR TITLE
Fix QA feedback: notificationBar save button not working

### DIFF
--- a/src/notification/bar.js
+++ b/src/notification/bar.js
@@ -53,9 +53,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
             addButton.addEventListener('click', (e) => {
                 e.preventDefault();
+                const folderId = document.querySelector('#template-add-clone .select-folder').value;
                 sendPlatformMessage({
                     command: 'bgAddSave',
-                    folder: document.getElementById("select-folder").value,
+                    folder: folderId,
                 });
             });
 


### PR DESCRIPTION
## Objective

Fix QA feedback for the "Select folder in save prompt" feature. I'd changed the `id` and `class` of the select folder dropdown, but hadn't updated all querySelectors.