### PR TITLE
Automatic biometrics prompt

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -777,10 +777,7 @@
     "message": "If your login has an authenticator key attached to it, the TOTP verification code is automatically copied to your clipboard whenever you auto-fill the login."
   },
   "disableAutoBiometricsPrompt": {
-    "message": "Disable Automatic Biometrics Prompt"
-  },
-  "disableAutoBiometricsPromptDesc": {
-    "message": "The \"Automatic Biometrics Prompt\" tries to automatically request your system for biometrics-based authentication whenever you access a locked vault."
+    "message": "Do not prompt for biometrics on launch"
   },
   "premiumRequired": {
     "message": "Premium Required"

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -776,6 +776,12 @@
   "disableAutoTotpCopyDesc": {
     "message": "If your login has an authenticator key attached to it, the TOTP verification code is automatically copied to your clipboard whenever you auto-fill the login."
   },
+  "disableAutoBiometricsPrompt": {
+    "message": "Disable Automatic Biometrics Prompt"
+  },
+  "disableAutoBiometricsPromptDesc": {
+    "message": "The \"Automatic Biometrics Prompt\" tries to automatically request your system for biometrics-based authentication whenever you access a locked vault."
+  },
   "premiumRequired": {
     "message": "Premium Required"
   },

--- a/src/popup/accounts/lock.component.ts
+++ b/src/popup/accounts/lock.component.ts
@@ -1,6 +1,8 @@
 import { Component } from '@angular/core';
 import { Router } from '@angular/router';
 
+import { ConstantsService } from 'jslib-common/services/constants.service';
+
 import { ApiService } from 'jslib-common/abstractions/api.service';
 import { CryptoService } from 'jslib-common/abstractions/crypto.service';
 import { EnvironmentService } from 'jslib-common/abstractions/environment.service';
@@ -20,6 +22,8 @@ import Swal from 'sweetalert2';
     templateUrl: 'lock.component.html',
 })
 export class LockComponent extends BaseLockComponent {
+    private isInitialLockScreen: boolean;
+
     constructor(router: Router, i18nService: I18nService,
         platformUtilsService: PlatformUtilsService, messagingService: MessagingService,
         userService: UserService, cryptoService: CryptoService,
@@ -29,6 +33,7 @@ export class LockComponent extends BaseLockComponent {
         super(router, i18nService, platformUtilsService, messagingService, userService, cryptoService,
             storageService, vaultTimeoutService, environmentService, stateService, apiService);
         this.successRoute = '/tabs/current';
+        this.isInitialLockScreen = (window as any).previousPopupUrl == null;
     }
 
     async ngOnInit() {
@@ -36,6 +41,16 @@ export class LockComponent extends BaseLockComponent {
         window.setTimeout(() => {
             document.getElementById(this.pinLock ? 'pin' : 'masterPassword').focus();
         }, 100);
+
+        const disableAutoBiometricsPrompt = await this.storageService.get<boolean>(
+            ConstantsService.disableAutoBiometricsPromptKey);
+        if (this.biometricLock && !disableAutoBiometricsPrompt && this.isInitialLockScreen) {
+            window.setTimeout(async () => {
+                if (await this.vaultTimeoutService.isLocked()) {
+                    await this.unlockBiometric();
+                }
+            }, 100);
+        }
     }
 
     async unlockBiometric() {

--- a/src/popup/accounts/lock.component.ts
+++ b/src/popup/accounts/lock.component.ts
@@ -38,19 +38,17 @@ export class LockComponent extends BaseLockComponent {
 
     async ngOnInit() {
         await super.ngOnInit();
-        window.setTimeout(() => {
-            document.getElementById(this.pinLock ? 'pin' : 'masterPassword').focus();
-        }, 100);
-
         const disableAutoBiometricsPrompt = await this.storageService.get<boolean>(
             ConstantsService.disableAutoBiometricsPromptKey);
-        if (this.biometricLock && !disableAutoBiometricsPrompt && this.isInitialLockScreen) {
-            window.setTimeout(async () => {
+
+        window.setTimeout(async () => {
+            document.getElementById(this.pinLock ? 'pin' : 'masterPassword').focus();
+            if (this.biometricLock && !disableAutoBiometricsPrompt && this.isInitialLockScreen) {
                 if (await this.vaultTimeoutService.isLocked()) {
                     await this.unlockBiometric();
                 }
-            }, 100);
-        }
+            }
+        }, 100);
     }
 
     async unlockBiometric() {

--- a/src/popup/accounts/lock.component.ts
+++ b/src/popup/accounts/lock.component.ts
@@ -39,7 +39,7 @@ export class LockComponent extends BaseLockComponent {
     async ngOnInit() {
         await super.ngOnInit();
         const disableAutoBiometricsPrompt = await this.storageService.get<boolean>(
-            ConstantsService.disableAutoBiometricsPromptKey);
+            ConstantsService.disableAutoBiometricsPromptKey) ?? true;
 
         window.setTimeout(async () => {
             document.getElementById(this.pinLock ? 'pin' : 'masterPassword').focus();

--- a/src/popup/settings/options.component.html
+++ b/src/popup/settings/options.component.html
@@ -55,6 +55,16 @@
         <div class="box">
             <div class="box-content">
                 <div class="box-content-row box-content-row-checkbox" appBoxRow>
+                    <label for="autoBiometricsPrompt">{{'disableAutoBiometricsPrompt' | i18n}}</label>
+                    <input id="autoBiometricsPrompt" type="checkbox" (change)="updateAutoBiometricsPrompt()"
+                        [(ngModel)]="disableAutoBiometricsPrompt">
+                </div>
+            </div>
+            <div class="box-footer">{{'disableAutoBiometricsPromptDesc' | i18n}}</div>
+        </div>
+        <div class="box">
+            <div class="box-content">
+                <div class="box-content-row box-content-row-checkbox" appBoxRow>
                     <label for="addlogin-notification-bar">{{'disableAddLoginNotification' | i18n}}</label>
                     <input id="addlogin-notification-bar" type="checkbox" (change)="updateAddLoginNotification()"
                         [(ngModel)]="disableAddLoginNotification">

--- a/src/popup/settings/options.component.html
+++ b/src/popup/settings/options.component.html
@@ -55,16 +55,6 @@
         <div class="box">
             <div class="box-content">
                 <div class="box-content-row box-content-row-checkbox" appBoxRow>
-                    <label for="autoBiometricsPrompt">{{'disableAutoBiometricsPrompt' | i18n}}</label>
-                    <input id="autoBiometricsPrompt" type="checkbox" (change)="updateAutoBiometricsPrompt()"
-                        [(ngModel)]="disableAutoBiometricsPrompt">
-                </div>
-            </div>
-            <div class="box-footer">{{'disableAutoBiometricsPromptDesc' | i18n}}</div>
-        </div>
-        <div class="box">
-            <div class="box-content">
-                <div class="box-content-row box-content-row-checkbox" appBoxRow>
                     <label for="addlogin-notification-bar">{{'disableAddLoginNotification' | i18n}}</label>
                     <input id="addlogin-notification-bar" type="checkbox" (change)="updateAddLoginNotification()"
                         [(ngModel)]="disableAddLoginNotification">

--- a/src/popup/settings/options.component.ts
+++ b/src/popup/settings/options.component.ts
@@ -24,7 +24,6 @@ export class OptionsComponent implements OnInit {
     autoFillOnPageLoadDefault = false;
     autoFillOnPageLoadOptions: any[];
     disableAutoTotpCopy = false;
-    disableAutoBiometricsPrompt = true;
     disableContextMenuItem = false;
     disableAddLoginNotification = false;
     disableChangedPasswordNotification = false;
@@ -93,8 +92,6 @@ export class OptionsComponent implements OnInit {
         this.dontShowIdentities = await this.storageService.get<boolean>(ConstantsService.dontShowIdentitiesCurrentTab);
 
         this.disableAutoTotpCopy = !(await this.totpService.isAutoCopyEnabled());
-        this.disableAutoBiometricsPrompt = await this.storageService.get<boolean>(
-            ConstantsService.disableAutoBiometricsPromptKey) ?? true;
 
         this.disableFavicon = await this.storageService.get<boolean>(ConstantsService.disableFaviconKey);
 
@@ -126,10 +123,6 @@ export class OptionsComponent implements OnInit {
 
     async updateAutoTotpCopy() {
         await this.storageService.save(ConstantsService.disableAutoTotpCopyKey, this.disableAutoTotpCopy);
-    }
-
-    async updateAutoBiometricsPrompt() {
-        await this.storageService.save(ConstantsService.disableAutoBiometricsPromptKey, this.disableAutoBiometricsPrompt);
     }
 
     async updateAutoFillOnPageLoad() {

--- a/src/popup/settings/options.component.ts
+++ b/src/popup/settings/options.component.ts
@@ -24,7 +24,7 @@ export class OptionsComponent implements OnInit {
     autoFillOnPageLoadDefault = false;
     autoFillOnPageLoadOptions: any[];
     disableAutoTotpCopy = false;
-    disableAutoBiometricsPrompt = false;
+    disableAutoBiometricsPrompt = true;
     disableContextMenuItem = false;
     disableAddLoginNotification = false;
     disableChangedPasswordNotification = false;
@@ -94,7 +94,7 @@ export class OptionsComponent implements OnInit {
 
         this.disableAutoTotpCopy = !(await this.totpService.isAutoCopyEnabled());
         this.disableAutoBiometricsPrompt = await this.storageService.get<boolean>(
-            ConstantsService.disableAutoBiometricsPromptKey);
+            ConstantsService.disableAutoBiometricsPromptKey) ?? true;
 
         this.disableFavicon = await this.storageService.get<boolean>(ConstantsService.disableFaviconKey);
 

--- a/src/popup/settings/options.component.ts
+++ b/src/popup/settings/options.component.ts
@@ -130,7 +130,6 @@ export class OptionsComponent implements OnInit {
 
     async updateAutoBiometricsPrompt() {
         await this.storageService.save(ConstantsService.disableAutoBiometricsPromptKey, this.disableAutoBiometricsPrompt);
-        this.callAnalytics('Auto Biometrics Prompt', !this.disableAutoBiometricsPrompt);
     }
 
     async updateAutoFillOnPageLoad() {

--- a/src/popup/settings/options.component.ts
+++ b/src/popup/settings/options.component.ts
@@ -24,6 +24,7 @@ export class OptionsComponent implements OnInit {
     autoFillOnPageLoadDefault = false;
     autoFillOnPageLoadOptions: any[];
     disableAutoTotpCopy = false;
+    disableAutoBiometricsPrompt = false;
     disableContextMenuItem = false;
     disableAddLoginNotification = false;
     disableChangedPasswordNotification = false;
@@ -92,6 +93,8 @@ export class OptionsComponent implements OnInit {
         this.dontShowIdentities = await this.storageService.get<boolean>(ConstantsService.dontShowIdentitiesCurrentTab);
 
         this.disableAutoTotpCopy = !(await this.totpService.isAutoCopyEnabled());
+        this.disableAutoBiometricsPrompt = await this.storageService.get<boolean>(
+            ConstantsService.disableAutoBiometricsPromptKey);
 
         this.disableFavicon = await this.storageService.get<boolean>(ConstantsService.disableFaviconKey);
 
@@ -123,6 +126,11 @@ export class OptionsComponent implements OnInit {
 
     async updateAutoTotpCopy() {
         await this.storageService.save(ConstantsService.disableAutoTotpCopyKey, this.disableAutoTotpCopy);
+    }
+
+    async updateAutoBiometricsPrompt() {
+        await this.storageService.save(ConstantsService.disableAutoBiometricsPromptKey, this.disableAutoBiometricsPrompt);
+        this.callAnalytics('Auto Biometrics Prompt', !this.disableAutoBiometricsPrompt);
     }
 
     async updateAutoFillOnPageLoad() {

--- a/src/popup/settings/settings.component.html
+++ b/src/popup/settings/settings.component.html
@@ -50,6 +50,10 @@
                 <label for="biometric">{{'unlockWithBiometrics' | i18n}}</label>
                 <input id="biometric" type="checkbox" (change)="updateBiometric()" [(ngModel)]="biometric">
             </div>
+            <div class="box-content-row box-content-row-checkbox" appBoxRow *ngIf="supportsBiometric">
+                <label for="autoBiometricsPrompt">{{'disableAutoBiometricsPrompt' | i18n}}</label>
+                <input id="autoBiometricsPrompt" type="checkbox" (change)="updateAutoBiometricsPrompt()" [(ngModel)]="disableAutoBiometricsPrompt">
+            </div>
             <a class="box-content-row box-content-row-flex text-default" href="#" appStopClick appBlurClick
                 (click)="lock()">
                 <div class="row-main">{{'lockNow' | i18n}}</div>

--- a/src/popup/settings/settings.component.html
+++ b/src/popup/settings/settings.component.html
@@ -46,7 +46,7 @@
             </div>
             <div class="box-content-row box-content-row-checkbox" appBoxRow *ngIf="supportsBiometric">
                 <label for="autoBiometricsPrompt">{{'disableAutoBiometricsPrompt' | i18n}}</label>
-                <input id="autoBiometricsPrompt" type="checkbox" (change)="updateAutoBiometricsPrompt()" [(ngModel)]="disableAutoBiometricsPrompt">
+                <input id="autoBiometricsPrompt" type="checkbox" (change)="updateAutoBiometricsPrompt()" [disabled]="!biometric" [(ngModel)]="disableAutoBiometricsPrompt">
             </div>
             <a class="box-content-row box-content-row-flex text-default" href="#" appStopClick appBlurClick
                 (click)="lock()">

--- a/src/popup/settings/settings.component.ts
+++ b/src/popup/settings/settings.component.ts
@@ -53,6 +53,7 @@ export class SettingsComponent implements OnInit {
     pin: boolean = null;
     supportsBiometric: boolean;
     biometric: boolean = false;
+    disableAutoBiometricsPrompt = true;
     previousVaultTimeout: number = null;
 
     constructor(private platformUtilsService: PlatformUtilsService, private i18nService: I18nService,
@@ -105,6 +106,8 @@ export class SettingsComponent implements OnInit {
 
         this.supportsBiometric = await this.platformUtilsService.supportsBiometric();
         this.biometric = await this.vaultTimeoutService.isBiometricLockSet();
+        this.disableAutoBiometricsPrompt = await this.storageService.get<boolean>(
+            ConstantsService.disableAutoBiometricsPromptKey) ?? true;
     }
 
     async saveVaultTimeout(newValue: number) {
@@ -275,6 +278,10 @@ export class SettingsComponent implements OnInit {
             await this.storageService.remove(ConstantsService.biometricUnlockKey);
             this.vaultTimeoutService.biometricLocked = false;
         }
+    }
+
+    async updateAutoBiometricsPrompt() {
+        await this.storageService.save(ConstantsService.disableAutoBiometricsPromptKey, this.disableAutoBiometricsPrompt);
     }
 
     async lock() {


### PR DESCRIPTION
https://community.bitwarden.com/t/automatic-biometrics-prompt-on-open-popup/17383

This primarily rebases and cleans up the work originally performed by @cho-m (thanks!)

It requires a blocking prompt if the desktop application isn't open. This isn't ideal, but making this more user-friendly (i.e. a toast instead of blocking dialog) would require significant refactoring of the crypto service and should probably be handled as a follow-up.

Requires https://github.com/bitwarden/jslib/pull/483