### PR TITLE
Fix totp copy not working in Chrome

### DIFF
--- a/src/popup/vault/current-tab.component.ts
+++ b/src/popup/vault/current-tab.component.ts
@@ -156,7 +156,8 @@ export class CurrentTabComponent implements OnInit, OnDestroy {
                 this.platformUtilsService.copyToClipboard(this.totpCode, { window: window });
             }
             if (this.popupUtilsService.inPopup(window)) {
-                BrowserApi.closePopup(window);
+                // Slight delay to fix bug in Chrome where popup closes without copying totp to clipboard
+                setTimeout(() => BrowserApi.closePopup(window), 50);
             }
         } catch {
             this.ngZone.run(() => {

--- a/src/popup/vault/current-tab.component.ts
+++ b/src/popup/vault/current-tab.component.ts
@@ -156,8 +156,12 @@ export class CurrentTabComponent implements OnInit, OnDestroy {
                 this.platformUtilsService.copyToClipboard(this.totpCode, { window: window });
             }
             if (this.popupUtilsService.inPopup(window)) {
-                // Slight delay to fix bug in Chrome where popup closes without copying totp to clipboard
-                setTimeout(() => BrowserApi.closePopup(window), 50);
+                if (this.platformUtilsService.isFirefox() || this.platformUtilsService.isSafari()) {
+                    BrowserApi.closePopup(window);
+                } else {
+                    // Slight delay to fix bug in Chromium browsers where popup closes without copying totp to clipboard
+                    setTimeout(() => BrowserApi.closePopup(window), 50);
+                }
             }
         } catch {
             this.ngZone.run(() => {


### PR DESCRIPTION
## Objective

Fix #2053:

> When using the Bitwarden extension from the Chrome Web Store, the extension does not automatically copy the TOTP after clicking on the appropriate login from the extension.

This only affects copying from `current-tab.component`. It appears that the popup closes before the copy-to-clipboard operation finishes - despite that being a completely synchronous operation.

This appeared around Chrome 93. Most affected users were using Chrome 93 on MacOS, which I could reproduce, and there was 1 report on Brave, which I couldn't reproduce. I couldn't find any release notes that indicate what change might have caused this, and it's unclear whether it's a Chrome or upstream Chromium issue.

## Code changes

* `current-tab.component` - add a short (50ms) delay to closing the window.

I don't like using `setTimeout` to avoid race conditions, but I couldn't find any underlying cause to be able to provide a better solution. We should be moving away from these deprecated clipboard APIs anyway, which I've created a tech debt ticket for, so the need for this workaround can be revisited at that time.