### PR TITLE
Prevent the lock component from removing the biometric error message

### DIFF
--- a/src/popup/accounts/lock.component.ts
+++ b/src/popup/accounts/lock.component.ts
@@ -51,7 +51,7 @@ export class LockComponent extends BaseLockComponent {
         }, 100);
     }
 
-    async unlockBiometric() {
+    async unlockBiometric(): Promise<boolean> {
         if (!this.biometricLock) {
             return;
         }

--- a/src/popup/accounts/lock.component.ts
+++ b/src/popup/accounts/lock.component.ts
@@ -68,8 +68,13 @@ export class LockComponent extends BaseLockComponent {
             showConfirmButton: false,
         });
 
-        await super.unlockBiometric();
+        const success = await super.unlockBiometric();
 
-        Swal.close();
+        // Avoid closing the error dialogs
+        if (success) {
+            Swal.close();
+        }
+
+        return success;
     }
 }


### PR DESCRIPTION
## Objective

In the browser extension, primarily on Safari the error message for biometrics sometimes disappears before it can be read. To resolve this, I needed to only close the dialog if the action was successful.

Depends on: https://github.com/bitwarden/jslib/pull/501