### PR TITLE
Fixes for Copy Custom Field Name

### DIFF
--- a/src/background/contextMenus.background.ts
+++ b/src/background/contextMenus.background.ts
@@ -30,7 +30,7 @@ export default class ContextMenusBackground {
             if (info.menuItemId === 'generate-password') {
                 await this.generatePasswordToClipboard();
             } else if (info.menuItemId === 'copy-identifier') {
-                await this.getClickedElement();
+                await this.getClickedElement(info.frameId);
             } else if (info.parentMenuItemId === 'autofill' ||
                 info.parentMenuItemId === 'copy-username' ||
                 info.parentMenuItemId === 'copy-password' ||
@@ -47,13 +47,13 @@ export default class ContextMenusBackground {
         this.passwordGenerationService.addHistory(password);
     }
 
-    private async getClickedElement() {
+    private async getClickedElement(frameId: number) {
         const tab = await BrowserApi.getTabFromCurrentWindow();
         if (tab == null) {
             return;
         }
 
-        BrowserApi.tabSendMessageData(tab, 'getClickedElement');
+        BrowserApi.tabSendMessage(tab, { command: 'getClickedElement' }, { frameId: frameId });
     }
 
     private async cipherAction(info: any) {

--- a/src/content/contextMenuHandler.ts
+++ b/src/content/contextMenuHandler.ts
@@ -4,12 +4,8 @@ let clickedEl: HTMLElement = null;
 
 // Find the best attribute to be used as the Name for an element in a custom field.
 function getClickedElementIdentifier() {
-    if (clickedEl == null) {
-        return 'Unable to identify clicked element.';
-    }
-
-    if (!inputTags.includes(clickedEl.nodeName.toLowerCase())) {
-        return 'Invalid element type.';
+    if (clickedEl == null || !inputTags.includes(clickedEl.nodeName.toLowerCase())) {
+        return 'Unable to identify a valid element. Try inspecting the HTML instead.';
     }
 
     for (const attr of attributes) {

--- a/src/content/contextMenuHandler.ts
+++ b/src/content/contextMenuHandler.ts
@@ -1,15 +1,40 @@
 const inputTags = ['input', 'textarea', 'select'];
+const labelTags = ['label', 'span'];
 const attributes = ['id', 'name', 'label-aria', 'placeholder'];
 let clickedEl: HTMLElement = null;
 
 // Find the best attribute to be used as the Name for an element in a custom field.
 function getClickedElementIdentifier() {
-    if (clickedEl == null || !inputTags.includes(clickedEl.nodeName.toLowerCase())) {
-        return 'Unable to identify a valid element. Try inspecting the HTML instead.';
+    if (clickedEl == null) {
+        return 'Unable to identify the clicked element. Try inspecting the HTML instead.';
+    }
+
+    const tagName = clickedEl.nodeName.toLowerCase();
+    let inputEl = null;
+
+    // Try to identify the input element (which may not be the clicked element)
+    if (inputTags.includes(tagName)) {
+        inputEl = clickedEl;
+    } else if (labelTags.includes(tagName)) {
+        let inputName = null;
+        if (tagName === 'label') {
+            inputName = clickedEl.getAttribute('for');
+        } else {
+            inputName = clickedEl.closest('label')?.getAttribute('for');
+        }
+
+        if (inputName != null) {
+            inputEl = document.querySelector('input[name=' + inputName + '], select[name=' + inputName +
+                '], textarea[name=' + inputName + ']');
+        }
+    }
+
+    if (inputEl == null) {
+        return 'Unable to identify a valid form element. Try inspecting the HTML instead.';
     }
 
     for (const attr of attributes) {
-        const attributeValue = clickedEl.getAttribute(attr);
+        const attributeValue = inputEl.getAttribute(attr);
         const selector = '[' + attr + '="' + attributeValue + '"]';
         if (!isNullOrEmpty(attributeValue) && document.querySelectorAll(selector)?.length === 1) {
             return attributeValue;


### PR DESCRIPTION
## Objective

The Copy Custom Field Name button can work unpredictably on pages containing iframes.

We use a content script to (a) identify the element the user has right-clicked on, and (b) find the best identifier for that element. The content script listens for a message from the background, and responds with the information that needs to be copied to clipboard.

However, if a page contains an iframe, then there will be 2 lots of content scripts running, which will both be fired when the user clicks Copy Custom Field Name. This can cause 1 content script to overwrite the result of the other with a null or garbage value.

Example: try to copy the custom field name for any input on this page in Firefox: https://www.aa.com/loyalty/login?uri=%2floyalty%2flogin&previousPage=%2fhomePage.do&bookingPathStateId=&marketId=

## Bonus change!

Front-end layouts can sometimes position `label` elements over input elements. (e.g. the Remember Me checkbox in the link above.) Currently, trying to right-click a label and click Copy Custom Field Name will just return an error, because a `label` isn't a valid input element.

I've added support for labels so that the user can also right-click the label, click Copy Custom Field Name, and it will try to find the related input by following the `for` attribute.

## Code changes

* `contextMenus.background.ts` - only send the request message to the frame that the user right-clicked on, not every frame within the tab
* `contextMenuHandler` - if the user has right-clicked a label, try to find the input element that is related to the label.