### PR TITLE
Update copyright year in .plist files for safari

### DIFF
--- a/src/safari/desktop/Info.plist
+++ b/src/safari/desktop/Info.plist
@@ -25,7 +25,7 @@
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2021 Bitwarden Inc. All rights reserved.</string>
+	<string>Copyright © 2015-2021 Bitwarden Inc. All rights reserved.</string>
 	<key>NSMainStoryboardFile</key>
 	<string>Main</string>
 	<key>NSPrincipalClass</key>

--- a/src/safari/desktop/Info.plist
+++ b/src/safari/desktop/Info.plist
@@ -25,7 +25,7 @@
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2020 Bitwarden Inc. All rights reserved.</string>
+	<string>Copyright © 2021 Bitwarden Inc. All rights reserved.</string>
 	<key>NSMainStoryboardFile</key>
 	<string>Main</string>
 	<key>NSPrincipalClass</key>

--- a/src/safari/safari/Info.plist
+++ b/src/safari/safari/Info.plist
@@ -30,7 +30,7 @@
 		<string>$(PRODUCT_MODULE_NAME).SafariWebExtensionHandler</string>
 	</dict>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2020 Bitwarden Inc. All rights reserved.</string>
+	<string>Copyright © 2021 Bitwarden Inc. All rights reserved.</string>
 	<key>NSHumanReadableDescription</key>
 	<string>A secure and free password manager for all of your devices.</string>
 	<key>SFSafariAppExtensionBundleIdentifiersToReplace</key>

--- a/src/safari/safari/Info.plist
+++ b/src/safari/safari/Info.plist
@@ -30,7 +30,7 @@
 		<string>$(PRODUCT_MODULE_NAME).SafariWebExtensionHandler</string>
 	</dict>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2021 Bitwarden Inc. All rights reserved.</string>
+	<string>Copyright © 2015-2021 Bitwarden Inc. All rights reserved.</string>
 	<key>NSHumanReadableDescription</key>
 	<string>A secure and free password manager for all of your devices.</string>
 	<key>SFSafariAppExtensionBundleIdentifiersToReplace</key>


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
The copyright of the plist files for safari still had the year set to 2020 

## Code changes
**src/safari/desktop/info.plist:** Change copyright year from 2020 to 2021
**src/safari/safari/info.plist:** Change copyright year from 2020 to 2021

## Before you submit
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (Alert the documentation team in Asana)
- [ ] This change has particular **deployment requirements** (Alert DevOps in Asana)
