### PR TITLE
Even more responsive notification bar

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -558,10 +558,7 @@
     "message": "Should Bitwarden remember this password for you?"
   },
   "notificationAddSave": {
-    "message": "Yes, Save Now"
-  },
-  "notificationNeverSave": {
-    "message": "Never for this website"
+    "message": "Save"
   },
   "disableChangedPasswordNotification": {
     "message": "Disable Changed Password Notification"
@@ -573,7 +570,7 @@
     "message": "Do you want to update this password in Bitwarden?"
   },
   "notificationChangeSave": {
-    "message": "Yes, Update Now"
+    "message": "Update"
   },
   "disableContextMenuItem": {
     "message": "Disable Context Menu Options"

--- a/src/notification/bar.html
+++ b/src/notification/bar.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html>
 
 <head>
@@ -24,15 +24,14 @@
         <div class="inner-wrapper" id="template-add">
             <div class="add-text"></div>
             <div class="add-buttons">
-                <button type="button" class="never-save link"></button>
-                <select class="select-folder"></select>
-                <button type="button" class="add-save"></button>
+                <button type="button" class="never-save link " short-text="" full-text=""></button>
+                <button type="button" class="add-save" short-text="" full-text=""></button>
             </div>
         </div>
         <div class="inner-wrapper" id="template-change">
             <div class="change-text"></div>
             <div class="change-buttons">
-                <button type="button" class="change-save"></button>
+                <button type="button" class="change-save" short-text="" full-text=""></button>
             </div>
         </div>
     </div>

--- a/src/notification/bar.html
+++ b/src/notification/bar.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html>
 
 <head>
@@ -25,6 +25,7 @@
             <div class="add-text"></div>
             <div class="add-buttons">
                 <button type="button" class="never-save link " short-text="" full-text=""></button>
+                <select class="select-folder" isVaultLocked="false"></select>
                 <button type="button" class="add-save" short-text="" full-text=""></button>
             </div>
         </div>

--- a/src/notification/bar.html
+++ b/src/notification/bar.html
@@ -24,15 +24,15 @@
         <div class="inner-wrapper" id="template-add">
             <div class="add-text"></div>
             <div class="add-buttons">
-                <button type="button" class="never-save link " short-text="" full-text=""></button>
+                <button type="button" class="never-save link"></button>
                 <select class="select-folder" isVaultLocked="false"></select>
-                <button type="button" class="add-save" short-text="" full-text=""></button>
+                <button type="button" class="add-save"></button>
             </div>
         </div>
         <div class="inner-wrapper" id="template-change">
             <div class="change-text"></div>
             <div class="change-buttons">
-                <button type="button" class="change-save" short-text="" full-text=""></button>
+                <button type="button" class="change-save"></button>
             </div>
         </div>
     </div>

--- a/src/notification/bar.js
+++ b/src/notification/bar.js
@@ -33,6 +33,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         var selectFolder = document.querySelector('#template-add .select-folder');
         selectFolder.setAttribute('aria-label', i18n.folder);
+        selectFolder.setAttribute('isVaultLocked', isVaultLocked.toString());
 
         var addButton = document.querySelector('#template-add .add-save');
         addButton.setAttribute('short-text', i18n.yes);

--- a/src/notification/bar.js
+++ b/src/notification/bar.js
@@ -25,32 +25,30 @@ document.addEventListener('DOMContentLoaded', () => {
             ? chrome.runtime.getURL('images/icon38_locked.png')
             : chrome.runtime.getURL('images/icon38.png');
 
-        document.getElementById('close').src = chrome.runtime.getURL('images/close.png');
-        document.getElementById('close').alt = i18n.close;
-
-        var closeButton = document.getElementById('close-button'),
-            body = document.querySelector('body'),
-            bodyRect = body.getBoundingClientRect();
-
-        // i18n
-        body.classList.add('lang-' + lang.slice(0, 2));
-
         document.getElementById('logo-link').title = i18n.appName;
+
+        var neverButton = document.querySelector('#template-add .never-save');
+        neverButton.setAttribute('short-text', i18n.never);
+        neverButton.setAttribute('full-text', i18n.notificationNeverSave);
+
+        var selectFolder = document.querySelector('#template-add .select-folder');
+        selectFolder.setAttribute('aria-label', i18n.folder);
+
+        var addButton = document.querySelector('#template-add .add-save');
+        addButton.setAttribute('short-text', i18n.yes);
+        addButton.setAttribute('full-text', i18n.notificationAddSave);
+
+        var changeButton = document.querySelector('#template-change .change-save');
+        changeButton.setAttribute('short-text', i18n.yes);
+        changeButton.setAttribute('full-text', i18n.notificationChangeSave);
+
+        var closeIcon = document.getElementById('close');
+        closeIcon.src = chrome.runtime.getURL('images/close.png');
+        closeIcon.alt = i18n.close;
+
+        var closeButton = document.getElementById('close-button')
         closeButton.title = i18n.close;
         closeButton.setAttribute('aria-label', i18n.close);
-
-        if (bodyRect.width < 768) {
-            document.querySelector('#template-add .add-save').textContent = i18n.yes;
-            document.querySelector('#template-add .never-save').textContent = i18n.never;
-            document.querySelector('#template-add .select-folder').style.display = 'none';
-            document.querySelector('#template-change .change-save').textContent = i18n.yes;
-        } else {
-            document.querySelector('#template-add .add-save').textContent = i18n.notificationAddSave;
-            document.querySelector('#template-add .never-save').textContent = i18n.notificationNeverSave;
-            document.querySelector('#template-add .select-folder').style.display = isVaultLocked ? 'none' : 'initial';
-            document.querySelector('#template-add .select-folder').setAttribute('aria-label', i18n.folder);
-            document.querySelector('#template-change .change-save').textContent = i18n.notificationChangeSave;
-        }
 
         document.querySelector('#template-add .add-text').textContent = i18n.notificationAddDesc;
         document.querySelector('#template-change .change-text').textContent = i18n.notificationChangeDesc;

--- a/src/notification/bar.js
+++ b/src/notification/bar.js
@@ -6,11 +6,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
     i18n.appName = chrome.i18n.getMessage('appName');
     i18n.close = chrome.i18n.getMessage('close');
-    i18n.yes = chrome.i18n.getMessage('yes');
     i18n.never = chrome.i18n.getMessage('never');
     i18n.folder = chrome.i18n.getMessage('folder');
     i18n.notificationAddSave = chrome.i18n.getMessage('notificationAddSave');
-    i18n.notificationNeverSave = chrome.i18n.getMessage('notificationNeverSave');
     i18n.notificationAddDesc = chrome.i18n.getMessage('notificationAddDesc');
     i18n.notificationChangeSave = chrome.i18n.getMessage('notificationChangeSave');
     i18n.notificationChangeDesc = chrome.i18n.getMessage('notificationChangeDesc');
@@ -28,20 +26,17 @@ document.addEventListener('DOMContentLoaded', () => {
         document.getElementById('logo-link').title = i18n.appName;
 
         var neverButton = document.querySelector('#template-add .never-save');
-        neverButton.setAttribute('short-text', i18n.never);
-        neverButton.setAttribute('full-text', i18n.notificationNeverSave);
+        neverButton.textContent = i18n.never;
 
         var selectFolder = document.querySelector('#template-add .select-folder');
         selectFolder.setAttribute('aria-label', i18n.folder);
         selectFolder.setAttribute('isVaultLocked', isVaultLocked.toString());
 
         var addButton = document.querySelector('#template-add .add-save');
-        addButton.setAttribute('short-text', i18n.yes);
-        addButton.setAttribute('full-text', i18n.notificationAddSave);
+        addButton.textContent = i18n.notificationAddSave;
 
         var changeButton = document.querySelector('#template-change .change-save');
-        changeButton.setAttribute('short-text', i18n.yes);
-        changeButton.setAttribute('full-text', i18n.notificationChangeSave);
+        changeButton.textContent = i18n.notificationChangeSave;
 
         var closeIcon = document.getElementById('close');
         closeIcon.src = chrome.runtime.getURL('images/close.png');

--- a/src/notification/bar.scss
+++ b/src/notification/bar.scss
@@ -80,33 +80,7 @@ button.neutral {
     display: none
 }
 
-@media screen and (min-width: 768px) {
-    .never-save::after {
-        content: attr(full-text);
-    }
-
-    .add-save::after {
-        content: attr(full-text);
-    }
-
-    .change-save::after {
-        content: attr(full-text);
-    }
-}
-
 @media screen and (max-width: 768px) {
-    .never-save::after {
-        content: attr(short-text);
-    }
-
-    .add-save::after {
-        content: attr(short-text);
-    }
-
-    .change-save::after {
-        content: attr(short-text);
-    }
-
     .select-folder {
         display: none
     }

--- a/src/notification/bar.scss
+++ b/src/notification/bar.scss
@@ -1,4 +1,4 @@
-﻿body {
+body {
     background-color: #ffffff;
     padding: 0;
     margin: 0;
@@ -23,7 +23,6 @@
     display: grid;
     grid-template-columns: auto max-content;
 }
-
 
 .outer-wrapper > *, .inner-wrapper > * {
     align-self: center;
@@ -74,6 +73,35 @@ button.neutral {
         cursor: pointer;
         background: none;
         text-decoration: underline;
+    }
+}
+
+
+@media screen and (min-width: 768px) {
+    .never-save::after {
+        content: attr(full-text);
+    }
+
+    .add-save::after {
+        content: attr(full-text);
+    }
+
+    .change-save::after {
+        content: attr(full-text);
+    }
+}
+
+@media screen and (max-width: 768px) {
+    .never-save::after {
+        content: attr(short-text);
+    }
+
+    .add-save::after {
+        content: attr(short-text);
+    }
+
+    .change-save::after {
+        content: attr(short-text);
     }
 }
 

--- a/src/notification/bar.scss
+++ b/src/notification/bar.scss
@@ -1,4 +1,4 @@
-body {
+﻿body {
     background-color: #ffffff;
     padding: 0;
     margin: 0;
@@ -76,6 +76,9 @@ button.neutral {
     }
 }
 
+.select-folder[isVaultLocked="true"] {
+    display: none
+}
 
 @media screen and (min-width: 768px) {
     .never-save::after {
@@ -102,6 +105,10 @@ button.neutral {
 
     .change-save::after {
         content: attr(short-text);
+    }
+
+    .select-folder {
+        display: none
     }
 }
 


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Remove the handling of different window sizes, with modifying text and styles from bar.js and instead do everything with CSS.

Asana ticket: https://app.asana.com/0/1169444489336079/1200912318004726/f

## Code changes
* **src/notification/bar.html:** 
  * Added html attributes `short-text` and `full-text`, added an attribute to contain `isVaultLocked` state
  
* **src/notification/bar.js:** 
  * Removed the logic to differentiate between window sizes and setting textContent with different translations
  * Fill new attributes `short-text` and `full-text` with the translations pulled from i18n
  * Pass `isVaultLocked` value as a string into the isVaultLocked attribute of the select-folder dropdown
  
* **src/notification/bar.scss:** 
  * Added media queries to adjust the translations by extracting the attribute value of either `short-text` or `full-text`
  * Hide select folder dropdown on smaller screens
  * Hide the select folder dropdown if the `isVaultLocked` attribute has the value set to `"true"`

## Testing requirements
* Add new login
  * The message "Should Bitwarden remember this password for you?" should always be readable
  * With a window width smaller than 768px
    * Never
    * Yes
    * X
  * With a window width wider than 768px
    * Never for this site
    * Select folder dropdown if vault is unlocked, hidden if locked
    * Yes, Save Now
    * X
    
* Change password
  * The message "Do you want to update this password in Bitwarden?" should always be readable
  * With a window width smaller than 768px
    * Yes
    * X
  * With a window width wider than 768px
    * Yes, Update Now
    * X

## Before you submit
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
