### PR TITLE
When vault is locked also check for personal ownership policy

### DIFF
--- a/src/background/notification.background.ts
+++ b/src/background/notification.background.ts
@@ -192,7 +192,7 @@ export default class NotificationBackground {
         }
 
         if (await this.vaultTimeoutService.isLocked()) {
-            if (!(await this.allowPersonalOwnership())) {
+            if (!await this.allowPersonalOwnership()) {
                 return;
             }
 
@@ -210,7 +210,7 @@ export default class NotificationBackground {
                 return;
             }
 
-            if (!(await this.allowPersonalOwnership())) {
+            if (!await this.allowPersonalOwnership()) {
                 return;
             }
 

--- a/src/background/notification.background.ts
+++ b/src/background/notification.background.ts
@@ -192,6 +192,10 @@ export default class NotificationBackground {
         }
 
         if (await this.vaultTimeoutService.isLocked()) {
+            if (!(await this.allowPersonalOwnership())) {
+                return;
+            }
+
             this.pushAddLoginToQueue(loginDomain, loginInfo, tab, true);
             return;
         }


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
If the vault is locked and a user tries to log-in to a new site, we will check for the DisablePersonalOwnership policy (no private vault) and not show the prompt if it is active. This is to ensure the same behaviour as if the vault was unlocked.

In the future we will want to enable users with this policy active to save new credentials to an Org and/or collection. For now though, this fix prevents users from saving new logins in a vault they shouldn't have.

Asana ticket: https://app.asana.com/0/1200804338582616/1201295056358742/f

## Code changes
* **src/background/notification.background.ts:** Added the same check for allowPersonalOwnership if the vault is locked

## Testing requirements
All users of an organizations that have the DisablePersonalOwernship policy active, should not be shown a prompt to save new logins.

## Before you submit
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [X] This change requires a **documentation update** (notify the documentation team) - **Done in parent Asana ticket : https://app.asana.com/0/0/1201284867742659/f**
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
