### PR TITLE
Prevent passphrase words from breaking over two lines (when using `-` separator)

### DIFF
--- a/src/popup/scss/misc.scss
+++ b/src/popup/scss/misc.scss
@@ -146,7 +146,7 @@ p.lead {
 }
 
 .password-wrapper {
-    word-break: break-all;
+    overflow-wrap: break-word;
     white-space: pre-wrap;
     min-width: 0;
 }


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Prevent passphrase words in the password generator from breaking over two lines when they're too long. Unfortunately only works when the word separator is left on the default `-`, as in other cases the browser doesn't seem to see the passphrase as being made up of words for CSS to break/unbreak (since the words themselves are broken up into `<span>`s by the highlighter).

Closes https://github.com/bitwarden/browser/issues/1096

## Screenshots

Before, showing passphrase words changing

![password-generator-before](https://user-images.githubusercontent.com/895831/139916214-cde3438e-ca80-48c0-bc4b-e46aa4cccd0c.png)

After - words remain intact and line breaks only happen on the hyphens



## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

![password-generator-after](https://user-images.githubusercontent.com/895831/139917735-df823613-00cc-4ca5-9dfd-bf19d6d81543.png)

## Before you submit
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
