### PR TITLE
Change Release workflow to allow releases from 'rc' and 'hotfix' branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,20 +12,19 @@ jobs:
     runs-on: ubuntu-20.04
     outputs:
       release-version: ${{ steps.version.outputs.package-version }}
+      branch-name: ${{ steps.branch.outputs.branch-name }}
     steps:
       - name: Branch check
         run: |
-          if [[ "$GITHUB_REF" != "refs/heads/release" ]]; then
+          if [[ "$GITHUB_REF" != "refs/heads/rc" ]] && [[ "$GITHUB_REF" != "refs/heads/hotfix" ]]; then
             echo "==================================="
-            echo "[!] Can only release from the 'release' branch"
+            echo "[!] Can only release from the 'rc' or 'hotfix' branches"
             echo "==================================="
             exit 1
           fi
 
       - name: Checkout repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
-        with:
-          ref: release
 
       - name: Check Release Version
         id: version
@@ -41,6 +40,12 @@ jobs:
           fi
 
           echo "::set-output name=package-version::$version"
+
+      - name: Get branch name
+        id: branch
+        run: |
+          BRANCH_NAME=$(basename ${{ github.ref }})
+          echo "::set-output name=branch-name::$BRANCH_NAME"
 
 
   locales-test:
@@ -88,7 +93,7 @@ jobs:
         with:
           workflow: build.yml
           workflow_conclusion: success
-          branch: release
+          branch: ${{ needs.setup.outputs.branch-name }}
           artifacts: 'browser-source-*.zip,
                       dist-chrome-*.zip,
                       dist-opera-*.zip,


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Changes our `release` workflow to allow releases from only `rc` and `hotfix` branches.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **release.yml:** Adds step to the `setup` job to find the branch name and set it as an output for the job.  Changes the rest of the workflow to use that new branch variable.

## Before you submit
- [X] I have checked for workflow **linting** errors (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
