### PR TITLE
Filter ciphers that have password reprompt set when using unlock on a…

### DIFF
--- a/src/background/contextMenus.background.ts
+++ b/src/background/contextMenus.background.ts
@@ -9,6 +9,7 @@ import { PlatformUtilsService } from 'jslib-common/abstractions/platformUtils.se
 import { TotpService } from 'jslib-common/abstractions/totp.service';
 import { VaultTimeoutService } from 'jslib-common/abstractions/vaultTimeout.service';
 
+import { CipherRepromptType } from 'jslib-common/enums/cipherRepromptType';
 import { EventType } from 'jslib-common/enums/eventType';
 import { CipherView } from 'jslib-common/models/view/cipherView';
 import LockedVaultPendingNotificationsItem from './models/lockedVaultPendingNotificationsItem';
@@ -84,7 +85,7 @@ export default class ContextMenusBackground {
         let cipher: CipherView;
         if (id === this.noopCommandSuffix) {
             const ciphers = await this.cipherService.getAllDecryptedForUrl(tab.url);
-            cipher = ciphers.length > 0 ? ciphers[0] : null;
+            cipher = ciphers.find(x => x.reprompt === CipherRepromptType.None);
         } else {
             const ciphers = await this.cipherService.getAllDecrypted();
             cipher = ciphers.find(c => c.id === id);

--- a/src/background/contextMenus.background.ts
+++ b/src/background/contextMenus.background.ts
@@ -85,7 +85,7 @@ export default class ContextMenusBackground {
         let cipher: CipherView;
         if (id === this.noopCommandSuffix) {
             const ciphers = await this.cipherService.getAllDecryptedForUrl(tab.url);
-            cipher = ciphers.find(x => x.reprompt === CipherRepromptType.None);
+            cipher = ciphers.find(c => c.reprompt === CipherRepromptType.None);
         } else {
             const ciphers = await this.cipherService.getAllDecrypted();
             cipher = ciphers.find(c => c.id === id);


### PR DESCRIPTION
…utofill via contextMenu

## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
When using unlock on autofill, usually the first cipher that matches the current url is taken. If a cipher has a master password reprompt set, this should be skipped, as we currently do not support autofill with master password reprompt. 

Asana task: https://app.asana.com/0/0/1201326308417690/f

## Code changes
* **background/contextMenus.background.ts:** From the list of ciphers that match the current url, find the first that has not set a master password re-prompt set, if any.

## Testing requirements
Having a locked vault and selecting the contextMenu Auto-Fill -> Vault is locked should prompt the user to log-in. Once logged in the extension looks for the first cipher that matches the url.

* With only 1 cipher for url present and password re-prompt set, then no auto-fill should happen
* Having 2 ciphers for url and one of them has password re-prompt set -> Only the one without the password re-prompt should be auto-filled.

## Before you submit
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
