### PR TITLE
Don't save passwords if user is logged out

### DIFF
--- a/src/background/main.background.ts
+++ b/src/background/main.background.ts
@@ -256,7 +256,7 @@ export default class MainBackground {
         this.commandsBackground = new CommandsBackground(this, this.passwordGenerationService,
             this.platformUtilsService, this.vaultTimeoutService);
         this.notificationBackground = new NotificationBackground(this, this.autofillService, this.cipherService,
-            this.storageService, this.vaultTimeoutService, this.policyService, this.folderService);
+            this.storageService, this.vaultTimeoutService, this.policyService, this.folderService, this.userService);
 
         this.tabsBackground = new TabsBackground(this, this.notificationBackground);
         this.contextMenusBackground = new ContextMenusBackground(this, this.cipherService, this.passwordGenerationService,

--- a/src/background/notification.background.ts
+++ b/src/background/notification.background.ts
@@ -8,8 +8,11 @@ import { CipherService } from 'jslib-common/abstractions/cipher.service';
 import { FolderService } from 'jslib-common/abstractions/folder.service';
 import { PolicyService } from 'jslib-common/abstractions/policy.service';
 import { StorageService } from 'jslib-common/abstractions/storage.service';
+import { UserService } from 'jslib-common/abstractions/user.service';
 import { VaultTimeoutService } from 'jslib-common/abstractions/vaultTimeout.service';
+
 import { ConstantsService } from 'jslib-common/services/constants.service';
+
 import { AutofillService } from '../services/abstractions/autofill.service';
 
 import { BrowserApi } from '../browser/browserApi';
@@ -34,7 +37,7 @@ export default class NotificationBackground {
     constructor(private main: MainBackground, private autofillService: AutofillService,
         private cipherService: CipherService, private storageService: StorageService,
         private vaultTimeoutService: VaultTimeoutService, private policyService: PolicyService,
-        private folderService: FolderService) {
+        private folderService: FolderService, private userService: UserService) {
     }
 
     async init() {
@@ -191,7 +194,7 @@ export default class NotificationBackground {
             normalizedUsername = normalizedUsername.toLowerCase();
         }
 
-        if (await this.vaultTimeoutService.isLocked()) {
+        if (await this.userService.isAuthenticated() && await this.vaultTimeoutService.isLocked()) {
             if (!await this.allowPersonalOwnership()) {
                 return;
             }

--- a/src/background/notification.background.ts
+++ b/src/background/notification.background.ts
@@ -184,6 +184,10 @@ export default class NotificationBackground {
     }
 
     private async addLogin(loginInfo: AddLoginRuntimeMessage, tab: chrome.tabs.Tab) {
+        if (!await this.userService.isAuthenticated()) {
+            return;
+        }
+
         const loginDomain = Utils.getDomain(loginInfo.url);
         if (loginDomain == null) {
             return;
@@ -194,7 +198,7 @@ export default class NotificationBackground {
             normalizedUsername = normalizedUsername.toLowerCase();
         }
 
-        if (await this.userService.isAuthenticated() && await this.vaultTimeoutService.isLocked()) {
+        if (await this.vaultTimeoutService.isLocked()) {
             if (!await this.allowPersonalOwnership()) {
                 return;
             }


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Fix a bug where the notificationBar was offering to save credentials even if the user was logged out. This should only occur when the user is logged in (locked or unlocked).

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/background/notification.background.ts** - `vaultTimeoutService.isLocked()` will return true if the vault is locked OR if the user is logged out. This is not intuitive and I think we should change it to avoid this pitfall. In the meantime, just add a call to `userService.isAuthenticated()`.
* update component dependencies

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

* Make sure the bug is fixed and no regressions on saving the password when the vault is locked.

## Before you submit
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
