### PR TITLE
Center login and 2fa entry when login via new tab

### DIFF
--- a/src/popup/scss/base.scss
+++ b/src/popup/scss/base.scss
@@ -347,6 +347,22 @@ app-root {
 }
 
 @media only screen and (min-width: 601px) {
+    app-login header {
+        padding: 0 calc((100% - 500px) / 2);
+    }
+
+    app-login content {
+        padding: 0 calc((100% - 500px) / 2);
+    }
+
+    app-two-factor header {
+        padding: 0 calc((100% - 500px) / 2);
+    }
+
+    app-two-factor content {
+        padding: 0 calc((100% - 500px) / 2);
+    }
+
     app-lock header {
         padding: 0 calc((100% - 500px) / 2);
     }


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
With the new feature added to prompt for login if vault is locked, I did some CSS changes to center the fields. They should not be spread across the whole width. As the prompt for login is also possible when logged out of a vault, a different screen appears. This PR fixes the UI of those 2 screens (app-login/app-two-factor)

## Code changes
* **src\popup\scss\base.scss:** 
    - Added padding to `app-login` `header `and `content` inside of media-queries
    - Added padding to `app-two-factor` `header` and `content` inside of media-queries

## Screenshots
**LOGIN**
![login_before](https://user-images.githubusercontent.com/2670567/141989373-2b02fa77-7111-4858-8c85-02f15f27f8a6.PNG)
![login_after](https://user-images.githubusercontent.com/2670567/141989422-22232cba-3dd3-4746-99e6-81e82aa06c21.PNG)

**2FA**

![2fa_before](https://user-images.githubusercontent.com/2670567/141989283-e63dca49-50a9-4f7a-a0c2-16b9fdacaa63.PNG)
![2fa_after](https://user-images.githubusercontent.com/2670567/141989305-5615da55-f474-4258-9d67-5403a9d683bb.PNG)

## Testing requirements
1. Log out of Bitwarden extension
1. Use the shortcut (Cmd/Ctrl+Shift+L) or contextmenu to trigger auto-fill
1.  A new tab should open to prompt for login. 
1. The fields should not be spread across the whole width (see screenshots)



## Before you submit
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
