### PR TITLE
[Key Connector] Hide "Master Pass On Restart" prompt when setting pin

### DIFF
--- a/src/popup/components/set-pin.component.html
+++ b/src/popup/components/set-pin.component.html
@@ -23,7 +23,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="checkbox">
+                <div class="checkbox" *ngIf="showMasterPassOnRestart">
                     <label for="masterPasswordOnRestart">
                         <input type="checkbox" id="masterPasswordOnRestart" name="MasterPasswordOnRestart"
                             [(ngModel)]="masterPassOnRestart">


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

If the user is using Key Connector and sets an unlock pin, do not ask them whether they want to "require unlocking with master password when the application is restarted". Instead, hide this checkbox and default it to false because they do not have a master password.

Requires https://github.com/bitwarden/jslib/pull/556.

## Before you submit
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
