### PR TITLE
Fixing cards autofill for russian bank and payment provider Sberbank

### DIFF
--- a/src/services/autofill.service.ts
+++ b/src/services/autofill.service.ts
@@ -496,7 +496,8 @@ export default class AutofillService implements AutofillServiceInterface {
                     break;
                 } else if (!fillFields.number && this.isFieldMatch(f[attr],
                     ['cc-number', 'cc-num', 'card-number', 'card-num', 'number', 'cc', 'cc-no', 'card-no',
-                        'credit-card', 'numero-carte', 'carte', 'carte-credit', 'num-carte', 'cb-num'],
+                        'credit-card', 'numero-carte', 'carte', 'carte-credit', 'num-carte', 'cb-num',
+                        'pan'],
                     ['cc-number', 'cc-num', 'card-number', 'card-num', 'cc-no', 'card-no', 'numero-carte',
                         'num-carte', 'cb-num'])) {
                     fillFields.number = f;
@@ -669,6 +670,11 @@ export default class AutofillService implements AutofillServiceInterface {
                 if (exp != null) {
                     break;
                 }
+            }
+
+            // Edge case for Sberbank
+            if (exp == null && this.fieldAttrsContain(fillFields.exp, "месяц/год") && partYear) {
+                exp = fullMonth + '/' + partYear;
             }
 
             if (exp == null) {


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Fixing cards autofill for Russian bank and payment provider Sberbank. Card number autofill wasn't working and expiration date format was wrong.



## Code changes
For card number it uses `pan` id. Here how input field looks like this:
```html
<input id="pan"
class="styles_input__3Lzh2" data-test-id="pan" placeholder="Номер карты"
name="pan" maxlength="23" type="tel" autocomplete="off" autocorrect="off"
spellcheck="off" aria-label="Номер карты">
```

For expiration date input field looks like this:
```html
<input id="expiry" class="styles_input__3Lzh2"
data-test-id="expiry" placeholder="Месяц/Год" name="expiry" type="tel"
autocomplete="off" autocorrect="off" spellcheck="off" maxlength="5"
aria-label="Срок действия карты">
```
As you can see there are no values in this field that contains in this lists:
https://github.com/bitwarden/browser/blob/ec502c06a57f537915ec34842dd6134d810bec77/src/services/autofill.service.ts#L54-L58

I wanted to add `Месяц/Год` to that lists, but based on the comment each value there corresponds to specific language, so I added if statement for that edge case. If you don't like this workaround, please tell me how you want it implemented. 


## Before you submit
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
