### PR TITLE
Hide password input when using key connector

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1332,12 +1332,6 @@
   "invalidPin": {
     "message": "Invalid PIN code."
   },
-  "verifyPin": {
-    "message": "Verify PIN"
-  },
-  "yourVaultIsLockedPinCode": {
-    "message": "Your vault is locked. Verify your PIN code to continue."
-  },
   "unlockWithBiometrics": {
     "message": "Unlock with biometrics"
   },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -320,11 +320,11 @@
   "browserNotSupportClipboard": {
     "message": "Your web browser does not support easy clipboard copying. Copy it manually instead."
   },
-  "verifyMasterPassword": {
-    "message": "Verify Master Password"
+  "verifyIdentity": {
+    "message": "Verify Identity"
   },
   "yourVaultIsLocked": {
-    "message": "Your vault is locked. Verify your master password to continue."
+    "message": "Your vault is locked. Verify your identity to continue."
   },
   "unlock": {
     "message": "Unlock"

--- a/src/popup/accounts/lock.component.html
+++ b/src/popup/accounts/lock.component.html
@@ -2,7 +2,7 @@
     <header>
         <div class="left"></div>
         <div class="center">
-            <span class="title">{{(pinLock ? 'verifyPin' : 'verifyIdentity') | i18n}}</span>
+            <span class="title">{{'verifyIdentity' | i18n}}</span>
         </div>
         <div class="right">
             <button type="submit" appBlurClick *ngIf="!hideInput">{{'unlock' | i18n}}</button>
@@ -32,7 +32,7 @@
                 </div>
             </div>
             <div class="box-footer">
-                <p>{{(pinLock ? 'yourVaultIsLockedPinCode' : 'yourVaultIsLocked') | i18n}}</p>
+                <p>{{'yourVaultIsLocked' | i18n}}</p>
                 {{'loggedInAsOn' | i18n : email : webVaultHostname}}
             </div>
         </div>

--- a/src/popup/accounts/lock.component.html
+++ b/src/popup/accounts/lock.component.html
@@ -2,16 +2,16 @@
     <header>
         <div class="left"></div>
         <div class="center">
-            <span class="title">{{(pinLock ? 'verifyPin' : 'verifyMasterPassword') | i18n}}</span>
+            <span class="title">{{(pinLock ? 'verifyPin' : 'verifyIdentity') | i18n}}</span>
         </div>
         <div class="right">
-            <button type="submit" appBlurClick>{{'unlock' | i18n}}</button>
+            <button type="submit" appBlurClick *ngIf="!hideInput">{{'unlock' | i18n}}</button>
         </div>
     </header>
     <content>
         <div class="box">
             <div class="box-content">
-                <div class="box-content-row box-content-row-flex" appBoxRow>
+                <div class="box-content-row box-content-row-flex" appBoxRow *ngIf="!hideInput">
                     <div class="row-main" *ngIf="pinLock">
                         <label for="pin">{{'pin' | i18n}}</label>
                         <input id="pin" type="{{showPassword ? 'text' : 'password'}}" name="PIN" class="monospaced"
@@ -38,7 +38,8 @@
         </div>
         <div class="box" *ngIf="biometricLock">
             <div class="box-footer">
-                <button type="button" class="btn primary block" (click)="unlockBiometric()" appStopClick>{{'unlockWithBiometrics' | i18n}}</button>
+                <button type="button" class="btn primary block" (click)="unlockBiometric()"
+                    appStopClick>{{'unlockWithBiometrics' | i18n}}</button>
             </div>
         </div>
         <p class="text-center">


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Hides the password input when using key connector.

Resolves https://app.asana.com/0/1201363553288890/1201394615545876/f

## Code changes
* **jslib:** Updated jslib
* **src/popup/accounts/lock.component.html:** 
    * Use `identity` instead of `master password` in header/labels 
    * Use hideInput from baseComponent to hide submit button(Unlock, top right corner) and master password field

## Screenshots
**Without KeyConnector**
![NoKeyConnector_MP](https://user-images.githubusercontent.com/2670567/142761615-e41e3716-54a4-4874-9bf1-56a9d1e50512.PNG)
PIN
![NoKeyConnector_Pin](https://user-images.githubusercontent.com/2670567/142761621-fe367b98-6c7c-406c-a95f-ffc7318f6770.PNG)
Biometrics enabled
![NoKeyConnector_Biometric](https://user-images.githubusercontent.com/2670567/142761627-88ac6b4a-62de-442c-a3c2-2394d2284778.PNG)

**With KeyConnector**
![OnlyKeyConnector](https://user-images.githubusercontent.com/2670567/142761659-d1c8c234-3886-4fd2-9e51-10d491386001.PNG)
PIN
![WithKeyConnector_Pin](https://user-images.githubusercontent.com/2670567/142761666-a5309d51-dcdf-4259-9515-d4695b5703a1.PNG)
Biometrics enabled
![WithKeyConnector_Biometric](https://user-images.githubusercontent.com/2670567/142761674-b03ef430-1a59-467c-97b2-de7adc947200.PNG)

## Before you submit
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
