### PR TITLE
Revert hack to fix appearance in FF sidebar

### DIFF
--- a/src/popup/scss/misc.scss
+++ b/src/popup/scss/misc.scss
@@ -360,14 +360,6 @@ input[type="password"]::-ms-reveal {
     }
 }
 
-// Workaround for rendering error in Firefox sidebar
-// option elements will not render background-color correctly if identical to parent background-color
-select option {
-    @include themify($themes) {
-        background-color: darken(themed('inputBackgroundColor'), +1);
-    }
-}
-
 // Workaround for slow performance on external monitors on Chrome + MacOS
 // See: https://bugs.chromium.org/p/chromium/issues/detail?id=971701#c64
 @keyframes redraw {


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Firefox was experiencing a rendering issue in sidebar dropdown lists - see the original bug here: https://github.com/bitwarden/browser/issues/1700. To fix this, I inserted some CSS which offset the `<select>` background color by 1.

I reported this bug upstream and it was fixed in FF 90: https://bugzilla.mozilla.org/show_bug.cgi?id=1702940.

We support the last 2 major releases, and the current stable release is FF 95. We can now revert the fix.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/popup/scss/misc.scss**: delete the CSS hack

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

See the original bug in #1700 and make sure that it cannot be reproduced.

## Before you submit
- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
