### PR TITLE
Bump node to v16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,11 +91,11 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea
         with:
-          node-version: '14'
+          node-version: '16'
 
       - name: Update NPM
         run: |
-          npm install -g npm@7
+          npm install -g npm@8
 
       - name: Print environment
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,10 +93,6 @@ jobs:
         with:
           node-version: '16'
 
-      - name: Update NPM
-        run: |
-          npm install -g npm@8
-
       - name: Print environment
         run: |
           node --version

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ The Bitwarden browser extension is written using the Web Extension API and Angul
 
 **Requirements**
 
-- [Node.js](https://nodejs.org) v14.17 or greater
-- NPM v7
+- [Node.js](https://nodejs.org) v16.13.1 or greater
+- NPM v8
 - [Gulp](https://gulpjs.com/) (`npm install --global gulp-cli`)
 - Chrome (preferred), Opera, or Firefox browser
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@types/firefox-webext-browser": "^82.0.0",
         "@types/jasmine": "^3.7.6",
         "@types/mousetrap": "^1.6.8",
-        "@types/node": "^14.17.2",
+        "@types/node": "^16.11.12",
         "buffer": "^6.0.3",
         "clean-webpack-plugin": "^4.0.0",
         "copy-webpack-plugin": "^10.0.0",
@@ -131,12 +131,6 @@
         "rimraf": "^3.0.2",
         "typescript": "4.3.5"
       }
-    },
-    "jslib/common/node_modules/@types/node": {
-      "version": "16.11.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.12.tgz",
-      "integrity": "sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw==",
-      "dev": true
     },
     "node_modules/@angular/animations": {
       "version": "12.2.14",
@@ -909,9 +903,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.18.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.0.tgz",
-      "integrity": "sha512-0GeIl2kmVMXEnx8tg1SlG6Gg8vkqirrW752KqolYo1PHevhhZN3bhJ67qHj+bQaINhX0Ra3TlWwRvMCd9iEfNQ==",
+      "version": "16.11.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.12.tgz",
+      "integrity": "sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw==",
       "dev": true
     },
     "node_modules/@types/node-forge": {
@@ -4971,6 +4965,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/gulp-replace/node_modules/@types/node": {
+      "version": "14.18.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.0.tgz",
+      "integrity": "sha512-0GeIl2kmVMXEnx8tg1SlG6Gg8vkqirrW752KqolYo1PHevhhZN3bhJ67qHj+bQaINhX0Ra3TlWwRvMCd9iEfNQ==",
+      "dev": true
     },
     "node_modules/gulp-zip": {
       "version": "5.1.0",
@@ -11161,14 +11161,6 @@
         "tldjs": "^2.3.1",
         "typescript": "4.3.5",
         "zxcvbn": "^4.4.2"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "16.11.12",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.12.tgz",
-          "integrity": "sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw==",
-          "dev": true
-        }
       }
     },
     "@discoveryjs/json-ext": {
@@ -11381,9 +11373,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.18.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.0.tgz",
-      "integrity": "sha512-0GeIl2kmVMXEnx8tg1SlG6Gg8vkqirrW752KqolYo1PHevhhZN3bhJ67qHj+bQaINhX0Ra3TlWwRvMCd9iEfNQ==",
+      "version": "16.11.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.12.tgz",
+      "integrity": "sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw==",
       "dev": true
     },
     "@types/node-forge": {
@@ -14624,6 +14616,14 @@
         "istextorbinary": "^3.0.0",
         "replacestream": "^4.0.3",
         "yargs-parser": ">=5.0.0-security.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "14.18.0",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.0.tgz",
+          "integrity": "sha512-0GeIl2kmVMXEnx8tg1SlG6Gg8vkqirrW752KqolYo1PHevhhZN3bhJ67qHj+bQaINhX0Ra3TlWwRvMCd9iEfNQ==",
+          "dev": true
+        }
       }
     },
     "gulp-zip": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,8 +75,8 @@
         "webpack-cli": "^4.9.1"
       },
       "engines": {
-        "node": "~14",
-        "npm": "~7"
+        "node": "~16",
+        "npm": "~8"
       }
     },
     "jslib/angular": {
@@ -123,7 +123,7 @@
       },
       "devDependencies": {
         "@types/lunr": "^2.3.3",
-        "@types/node": "^14.17.1",
+        "@types/node": "^16.11.12",
         "@types/node-forge": "^0.9.7",
         "@types/papaparse": "^5.2.5",
         "@types/tldjs": "^2.3.0",
@@ -131,6 +131,12 @@
         "rimraf": "^3.0.2",
         "typescript": "4.3.5"
       }
+    },
+    "jslib/common/node_modules/@types/node": {
+      "version": "16.11.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.12.tgz",
+      "integrity": "sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw==",
+      "dev": true
     },
     "node_modules/@angular/animations": {
       "version": "12.2.14",
@@ -11140,7 +11146,7 @@
         "@microsoft/signalr": "5.0.10",
         "@microsoft/signalr-protocol-msgpack": "5.0.10",
         "@types/lunr": "^2.3.3",
-        "@types/node": "^14.17.1",
+        "@types/node": "^16.11.12",
         "@types/node-forge": "^0.9.7",
         "@types/papaparse": "^5.2.5",
         "@types/tldjs": "^2.3.0",
@@ -11155,6 +11161,14 @@
         "tldjs": "^2.3.1",
         "typescript": "4.3.5",
         "zxcvbn": "^4.4.2"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "16.11.12",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.12.tgz",
+          "integrity": "sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw==",
+          "dev": true
+        }
       }
     },
     "@discoveryjs/json-ext": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "web-animations-js": "^2.3.2"
   },
   "engines": {
-    "node": "~14",
-    "npm": "~7"
+    "node": "~16",
+    "npm": "~8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@types/firefox-webext-browser": "^82.0.0",
     "@types/jasmine": "^3.7.6",
     "@types/mousetrap": "^1.6.8",
-    "@types/node": "^14.17.2",
+    "@types/node": "^16.11.12",
     "buffer": "^6.0.3",
     "clean-webpack-plugin": "^4.0.0",
     "copy-webpack-plugin": "^10.0.0",


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
With our plan to bump electron soon, we need to upgrade Node to v16 (LTS) as newer version of electron require it.

Depends on https://github.com/bitwarden/jslib/pull/575
Asana task: https://app.asana.com/0/1200804338582616/1201498644188841/f

## Code changes
* **jslib:** Bump jslib from https://github.com/bitwarden/jslib/pull/575
* **package.json:** Updated engine requirements and bumped @types/node to 16.11.12
* **package-lock.json:** Updates after running `npm i`
* **build.yml:** Setting the build to require node v16 and npm v8
* **README.md:** Updated requirements

## Testing requirements
Will require running regression testing.

## Before you submit
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [X] This change has particular **deployment requirements** (notify the DevOps team)
