### PR TITLE
Fix save prompt showing when disabled by user

### DIFF
--- a/src/background/notification.background.ts
+++ b/src/background/notification.background.ts
@@ -198,7 +198,12 @@ export default class NotificationBackground {
             normalizedUsername = normalizedUsername.toLowerCase();
         }
 
+        const disabledAddLogin = await this.storageService.get<boolean>(ConstantsService.disableAddLoginNotificationKey);
         if (await this.vaultTimeoutService.isLocked()) {
+            if (disabledAddLogin) {
+                return;
+            }
+
             if (!await this.allowPersonalOwnership()) {
                 return;
             }
@@ -211,8 +216,6 @@ export default class NotificationBackground {
         const usernameMatches = ciphers.filter(c =>
             c.login.username != null && c.login.username.toLowerCase() === normalizedUsername);
         if (usernameMatches.length === 0) {
-            const disabledAddLogin = await this.storageService.get<boolean>(
-                ConstantsService.disableAddLoginNotificationKey);
             if (disabledAddLogin) {
                 return;
             }


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
In the latest release we display the save prompt, even if the vault is locked to aid users to save their just entered credentials. We did not respect the user setting `Disable AddLoginNotification` to true. 

Asana task: https://app.asana.com/0/1169444489336079/1201519992309109/f

## Code changes
* **src/background/notification.background.ts:** Load `Disable AddLoginNotification` setting via StorageService and do not prompt user if it has been disabled (locked/unlocked vault).

## Testing requirements
If the user has set Disable AddLoginNotification, then the prompt to save should never appear. 

## Before you submit
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
