### PR TITLE
A11y: make expandable box headers keyboard-operable, expose correct role/state

### DIFF
--- a/src/popup/scss/box.scss
+++ b/src/popup/scss/box.scss
@@ -20,9 +20,12 @@
     }
 
     .box-header-expandable {
-        margin: 0 10px 5px 10px;
+        padding: 0 10px;
+        margin-bottom: 5px;
         text-transform: uppercase;
         display: flex;
+        width: 100%;
+        box-sizing: border-box;
 
         @include themify($themes) {
             color: themed('headingColor');

--- a/src/popup/send/send-add-edit.component.html
+++ b/src/popup/send/send-add-edit.component.html
@@ -110,10 +110,12 @@
         </div>
         <!-- Options -->
         <div class="box">
-            <h2 class="box-header-expandable" (click)="showOptions = !showOptions">
-                {{'options' | i18n}}
-                <i *ngIf="!showOptions" class="fa fa-chevron-down fa-sm icon"></i>
-                <i *ngIf="showOptions" class="fa fa-chevron-up fa-sm icon"></i>
+            <h2>
+                <button type="button" class="box-header-expandable" (click)="showOptions = !showOptions" [attr.aria-expanded]="showOptions">
+                    {{'options' | i18n}}
+                    <i *ngIf="!showOptions" class="fa fa-chevron-down fa-sm icon" aria-hidden="true"></i>
+                    <i *ngIf="showOptions" class="fa fa-chevron-up fa-sm icon" aria-hidden="true"></i>
+                </button>
             </h2>
         </div>
         <div [hidden]="!showOptions">

--- a/src/popup/settings/options.component.html
+++ b/src/popup/settings/options.component.html
@@ -12,10 +12,12 @@
 </header>
 <content>
     <div class="box">
-        <h2 class="box-header-expandable" (click)="showGeneral = !showGeneral">
-            General
-            <i *ngIf="!showGeneral" class="fa fa-chevron-down fa-sm icon"></i>
-            <i *ngIf="showGeneral" class="fa fa-chevron-up fa-sm icon"></i>
+        <h2>
+            <button type="button" class="box-header-expandable" (click)="showGeneral = !showGeneral" [attr.aria-expanded]="showGeneral">
+                General
+                <i *ngIf="!showGeneral" class="fa fa-chevron-down fa-sm icon" aria-hidden="true"></i>
+                <i *ngIf="showGeneral" class="fa fa-chevron-up fa-sm icon" aria-hidden="true"></i>
+            </button>
         </h2>
     </div>
     <ng-container *ngIf="showGeneral">
@@ -84,10 +86,12 @@
         </div>
     </ng-container>
     <div class="box box-section-divider">
-        <h2 class="box-header-expandable" (click)="showDisplay = !showDisplay">
-            Display
-            <i *ngIf="!showDisplay" class="fa fa-chevron-down fa-sm icon"></i>
-            <i *ngIf="showDisplay" class="fa fa-chevron-up fa-sm icon"></i>
+        <h2>
+            <button type="button" class="box-header-expandable" (click)="showDisplay = !showDisplay" [attr.aria-expanded]="showDisplay">
+                Display
+                <i *ngIf="!showDisplay" class="fa fa-chevron-down fa-sm icon" aria-hidden="true"></i>
+                <i *ngIf="showDisplay" class="fa fa-chevron-up fa-sm icon" aria-hidden="true"></i>
+            </button>
         </h2>
     </div>
     <ng-container *ngIf="showDisplay">
@@ -141,10 +145,12 @@
         </div>
     </ng-container>
     <div class="box box-section-divider">
-        <h2 class="box-header-expandable" (click)="showAutofill = !showAutofill">
-            Autofill
-            <i *ngIf="!showAutofill" class="fa fa-chevron-down fa-sm icon"></i>
-            <i *ngIf="showAutofill" class="fa fa-chevron-up fa-sm icon"></i>
+        <h2>
+            <button type="button" class="box-header-expandable" (click)="showAutofill = !showAutofill" [attr.aria-expanded]="showAutofill">
+                Autofill
+                <i *ngIf="!showAutofill" class="fa fa-chevron-down fa-sm icon" aria-hidden="true"></i>
+                <i *ngIf="showAutofill" class="fa fa-chevron-up fa-sm icon" aria-hidden="true"></i>
+            </button>
         </h2>
     </div>
     <ng-container *ngIf="showAutofill">


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Currently the `box-header-expandable` controls (one in Send, three in Settings > Options) are not keyboard-operable (can't focus nor activate them using the keyboard), and they don't programmatically expose any particular interactive role nor do they convey their current state (whether the content they control is expanded or collapsed).

This PR changes these controls (currently generic `<div>` elements) to proper `<button>` elements (which, out of the box, are keyboard-focusable/operable). It also adds the `aria-expanded` attribute that conveys the state.

Closes https://github.com/bitwarden/browser/issues/1983

## Code changes

* **box.scss:** Change to the styles to make sure the `button` that is now used spans the entire width of its parent, and does not lead to awkward horizontal scrolling/overflow to the right
* **send-add-edit.component.html** and **options.component.html:** add a `button` inside the existing `h2` (see https://github.com/bitwarden/browser/pull/2223), move the click action and class to this, add `attr.aria-expanded` that changes dynamically based on state

## Screenshots

No UI changes.



## Testing requirements

* test using a keyboard - try to set focus to the expand/collapse control using `Tab`, toggling it using `Enter` or `Space`
* test with a screen reader (e.g. NVDA). same as above - set focus using `Tab`, toggle using `Enter` or `Space`. Note that the controls are now announced as buttons, and that they convey their state (expanded, collapsed). note also that the controls will further announce that they're part of a "heading level 2" - this is expected following #2223 

One aside: the "Options" control in the Send sometimes does not immediately announce when it's changing from expanded to collapsed and vice-versa. It's unclear why, but sometimes assistive tech / NVDA don't immediately announce changes like these...that's an AT bug/shortcoming rather than anything wrong here. leaving and then returning to the control (e.g. tabbing away and back) announces the state correctly though.


## Before you submit
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
