### PR TITLE
Send deletedCipher message to messagingService so badge and menu refresh. Fixes #1708

### DIFF
--- a/src/popup/vault/view.component.ts
+++ b/src/popup/vault/view.component.ts
@@ -240,6 +240,7 @@ export class ViewComponent extends BaseViewComponent {
 
   async delete() {
     if (await super.delete()) {
+      this.messagingService.send("deletedCipher");
       this.close();
       return true;
     }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Previously, deleting a password for a site would not update the badge for the extension.  So if you had 3 logins for a site and deleted one, it would still show 2.  I searched for an answer to this bug and saw it was reported in #1708 back in March.  I decided to see what it involved and found it was quite simple.

## Code changes

I added a call to the `messagingService` with the subscriber string "deletedCipher" since I saw in `runtime.background.ts` that this calls `this.main.refreshBadgeAndMenu()`.  This resolved the issue.

When comparing against an existing flow that properly refreshed the badge (adding a login), I noticed that this messaging code was added to the jslib `add-edit-components.ts` file.  However, the `view-component.ts` file in jslib did not have the MessagingService imported, while the `view-components.ts` file in `src/popup/vault` already had it as a private member from work related to #1784.

Given this context, the change still seemed appropriate.  But if it would be better placed in jslib, I'd be happy to make that change (although I believe it would require some changes to the constructor which would affect both projects).

- **src/popup/vault/view-components.ts** See above for changes to this file.

## Screenshots (Click to Enlarge)

Before (Notice that after deleting, the badge shows "2" when there is only one item)
<image src="https://user-images.githubusercontent.com/17534437/147065104-cd6d2ca7-5515-4aaa-bf1b-3faf249f4d84.png" height="125px" />

After (Notice that after deleting, the badge and number of items match)
<image src="https://user-images.githubusercontent.com/17534437/147064614-ff099a79-a99f-4f3a-90b9-7cc8654d8cbb.png" height="125px" />

## Testing requirements

Consider testing that deleting properly decrements the badge counter.  Meanwhile, confirm that deleting continues to work as expected.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [N/A] This change requires a **documentation update** (notify the documentation team)
- [N/A] This change has particular **deployment requirements** (notify the DevOps team)
