### PR TITLE
Update year in copyright

### DIFF
--- a/src/safari/desktop/Info.plist
+++ b/src/safari/desktop/Info.plist
@@ -25,7 +25,7 @@
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2015-2021 Bitwarden Inc. All rights reserved.</string>
+	<string>Copyright © 2015-2022 Bitwarden Inc. All rights reserved.</string>
 	<key>NSMainStoryboardFile</key>
 	<string>Main</string>
 	<key>NSPrincipalClass</key>

--- a/src/safari/safari/Info.plist
+++ b/src/safari/safari/Info.plist
@@ -30,7 +30,7 @@
 		<string>$(PRODUCT_MODULE_NAME).SafariWebExtensionHandler</string>
 	</dict>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2015-2021 Bitwarden Inc. All rights reserved.</string>
+	<string>Copyright © 2015-2022 Bitwarden Inc. All rights reserved.</string>
 	<key>NSHumanReadableDescription</key>
 	<string>A secure and free password manager for all of your devices.</string>
 	<key>SFSafariAppExtensionBundleIdentifiersToReplace</key>


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other

## Objective

As the year 2022 has arrived it's time to update our copyright in various places.

Asana task: https://app.asana.com/0/1200804338582616/1201609982295249/f

## Code changes
- **src/safari/desktop/Info.plist:** Update year in copyright to 2022
- **src/safari/safari/Info.plist:** Update year in copyright to 2022

## Testing requirements
Nothing really to test here other than to verify we show the current year in the copyright.

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
