### PR TITLE
Update badge number when saving a new entry

### DIFF
--- a/src/background/models/notificationQueueMessageType.ts
+++ b/src/background/models/notificationQueueMessageType.ts
@@ -1,4 +1,4 @@
 export enum NotificationQueueMessageType {
-  AddLogin = "addLogin",
-  ChangePassword = "changePassword",
+  AddLogin = 0,
+  ChangePassword = 1,
 }

--- a/src/background/models/notificationQueueMessageType.ts
+++ b/src/background/models/notificationQueueMessageType.ts
@@ -1,4 +1,4 @@
 export enum NotificationQueueMessageType {
-  addLogin = "addLogin",
-  changePassword = "changePassword",
+  AddLogin = "addLogin",
+  ChangePassword = "changePassword",
 }

--- a/src/background/notification.background.ts
+++ b/src/background/notification.background.ts
@@ -359,6 +359,7 @@ export default class NotificationBackground {
 
       if (!queueMessage.wasVaultLocked) {
         await this.createNewCipher(queueMessage as AddLoginQueueMessage, folderId);
+        BrowserApi.tabSendMessageData(tab, "addedCipher");
         return;
       }
 
@@ -376,6 +377,7 @@ export default class NotificationBackground {
       }
 
       await this.createNewCipher(addLoginMessage, folderId);
+      BrowserApi.tabSendMessageData(tab, "addedCipher");
     }
   }
 

--- a/src/background/notification.background.ts
+++ b/src/background/notification.background.ts
@@ -348,12 +348,12 @@ export default class NotificationBackground {
       BrowserApi.tabSendMessageData(tab, "closeNotificationBar");
 
       if (queueMessage.type === NotificationQueueMessageType.changePassword) {
-        const message = queueMessage as AddChangePasswordQueueMessage;
-        const cipher = await this.getDecryptedCipherById(message.cipherId);
+        const changePasswordMessage = queueMessage as AddChangePasswordQueueMessage;
+        const cipher = await this.getDecryptedCipherById(changePasswordMessage.cipherId);
         if (cipher == null) {
           return;
         }
-        await this.updateCipher(cipher, message.newPassword);
+        await this.updateCipher(cipher, changePasswordMessage.newPassword);
         return;
       }
 

--- a/src/background/notification.background.ts
+++ b/src/background/notification.background.ts
@@ -366,18 +366,19 @@ export default class NotificationBackground {
         queueMessage.type === NotificationQueueMessageType.addLogin &&
         queueMessage.wasVaultLocked === true
       ) {
-        const message = queueMessage as AddLoginQueueMessage;
-        const ciphers = await this.cipherService.getAllDecryptedForUrl(message.uri);
+        const addLoginMessage = queueMessage as AddLoginQueueMessage;
+        const ciphers = await this.cipherService.getAllDecryptedForUrl(addLoginMessage.uri);
         const usernameMatches = ciphers.filter(
-          (c) => c.login.username != null && c.login.username.toLowerCase() === message.username
+          (c) =>
+            c.login.username != null && c.login.username.toLowerCase() === addLoginMessage.username
         );
 
         if (usernameMatches.length >= 1) {
-          await this.updateCipher(usernameMatches[0], message.password);
+          await this.updateCipher(usernameMatches[0], addLoginMessage.password);
           return;
         }
 
-        await this.createNewCipher(message, folderId);
+        await this.createNewCipher(addLoginMessage, folderId);
       }
     }
   }

--- a/src/background/notification.background.ts
+++ b/src/background/notification.background.ts
@@ -359,27 +359,23 @@ export default class NotificationBackground {
 
       if (!queueMessage.wasVaultLocked) {
         await this.createNewCipher(queueMessage as AddLoginQueueMessage, folderId);
+        return;
       }
 
       // If the vault was locked, check if a cipher needs updating instead of creating a new one
-      if (
-        queueMessage.type === NotificationQueueMessageType.addLogin &&
-        queueMessage.wasVaultLocked === true
-      ) {
-        const addLoginMessage = queueMessage as AddLoginQueueMessage;
-        const ciphers = await this.cipherService.getAllDecryptedForUrl(addLoginMessage.uri);
-        const usernameMatches = ciphers.filter(
-          (c) =>
-            c.login.username != null && c.login.username.toLowerCase() === addLoginMessage.username
-        );
+      const addLoginMessage = queueMessage as AddLoginQueueMessage;
+      const ciphers = await this.cipherService.getAllDecryptedForUrl(addLoginMessage.uri);
+      const usernameMatches = ciphers.filter(
+        (c) =>
+          c.login.username != null && c.login.username.toLowerCase() === addLoginMessage.username
+      );
 
-        if (usernameMatches.length >= 1) {
-          await this.updateCipher(usernameMatches[0], addLoginMessage.password);
-          return;
-        }
-
-        await this.createNewCipher(addLoginMessage, folderId);
+      if (usernameMatches.length >= 1) {
+        await this.updateCipher(usernameMatches[0], addLoginMessage.password);
+        return;
       }
+
+      await this.createNewCipher(addLoginMessage, folderId);
     }
   }
 

--- a/src/background/notification.background.ts
+++ b/src/background/notification.background.ts
@@ -170,14 +170,14 @@ export default class NotificationBackground {
         continue;
       }
 
-      if (this.notificationQueue[i].type === NotificationQueueMessageType.addLogin) {
+      if (this.notificationQueue[i].type === NotificationQueueMessageType.AddLogin) {
         BrowserApi.tabSendMessageData(tab, "openNotificationBar", {
           type: "add",
           typeData: {
             isVaultLocked: this.notificationQueue[i].wasVaultLocked,
           },
         });
-      } else if (this.notificationQueue[i].type === NotificationQueueMessageType.changePassword) {
+      } else if (this.notificationQueue[i].type === NotificationQueueMessageType.ChangePassword) {
         BrowserApi.tabSendMessageData(tab, "openNotificationBar", {
           type: "change",
           typeData: {
@@ -265,7 +265,7 @@ export default class NotificationBackground {
     // remove any old messages for this tab
     this.removeTabFromNotificationQueue(tab);
     const message: AddLoginQueueMessage = {
-      type: NotificationQueueMessageType.addLogin,
+      type: NotificationQueueMessageType.AddLogin,
       username: loginInfo.username,
       password: loginInfo.password,
       domain: loginDomain,
@@ -316,7 +316,7 @@ export default class NotificationBackground {
     // remove any old messages for this tab
     this.removeTabFromNotificationQueue(tab);
     const message: AddChangePasswordQueueMessage = {
-      type: NotificationQueueMessageType.changePassword,
+      type: NotificationQueueMessageType.ChangePassword,
       cipherId: cipherId,
       newPassword: newPassword,
       domain: loginDomain,
@@ -333,8 +333,8 @@ export default class NotificationBackground {
       const queueMessage = this.notificationQueue[i];
       if (
         queueMessage.tabId !== tab.id ||
-        (queueMessage.type !== NotificationQueueMessageType.addLogin &&
-          queueMessage.type !== NotificationQueueMessageType.changePassword)
+        (queueMessage.type !== NotificationQueueMessageType.AddLogin &&
+          queueMessage.type !== NotificationQueueMessageType.ChangePassword)
       ) {
         continue;
       }
@@ -347,7 +347,7 @@ export default class NotificationBackground {
       this.notificationQueue.splice(i, 1);
       BrowserApi.tabSendMessageData(tab, "closeNotificationBar");
 
-      if (queueMessage.type === NotificationQueueMessageType.changePassword) {
+      if (queueMessage.type === NotificationQueueMessageType.ChangePassword) {
         const changePasswordMessage = queueMessage as AddChangePasswordQueueMessage;
         const cipher = await this.getDecryptedCipherById(changePasswordMessage.cipherId);
         if (cipher == null) {
@@ -426,7 +426,7 @@ export default class NotificationBackground {
       const queueMessage = this.notificationQueue[i];
       if (
         queueMessage.tabId !== tab.id ||
-        queueMessage.type !== NotificationQueueMessageType.addLogin
+        queueMessage.type !== NotificationQueueMessageType.AddLogin
       ) {
         continue;
       }

--- a/src/content/message_handler.ts
+++ b/src/content/message_handler.ts
@@ -28,6 +28,7 @@ const forwardCommands = [
   "promptForLogin",
   "addToLockedVaultPendingNotifications",
   "unlockCompleted",
+  "addedCipher",
 ];
 
 chrome.runtime.onMessage.addListener((event) => {


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
When saving a new entry via the Add Login prompt (Bar) the badge number  did not get updated. Only after a page refresh the updated badge appears.

Asana task: https://app.asana.com/0/1169444489336079/1201703036655950/f
## Code changes

- **src/background/notification.background.ts:** 
  - Minor refactoring to use early return and renamed message variables
  - Send message `addedCipher` when a new entry was added so `refreshBadgeAndMenu` is called
- **src/content/message_handler.ts:** Add `addedCipher` to `forwardCommands` so that the message is passed on to main

## Testing requirements
The badge number should update when saving a new entry. This should be happening even if the vault was locked beforehand

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
