### PR TITLE
[UX] Change menu items for unauthed and locked vault

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -98,7 +98,7 @@
     "message": "Unlock your vault"
   },
   "loginToVaultMenu": {
-    "message": "Login to your vault"
+    "message": "Log in to your vault"
   },
   "autoFillInfo": {
     "message": "There are no logins available to auto-fill for the current browser tab."

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -94,11 +94,11 @@
   "noMatchingLogins": {
     "message": "No matching logins."
   },
-  "vaultLocked": {
-    "message": "Vault is locked."
+  "unlockVaultMenu": {
+    "message": "Unlock your vault"
   },
-  "vaultLoggedOut": {
-    "message": "Vault is logged out."
+  "loginToVaultMenu": {
+    "message": "Login to your vault"
   },
   "autoFillInfo": {
     "message": "There are no logins available to auto-fill for the current browser tab."

--- a/src/background/main.background.ts
+++ b/src/background/main.background.ts
@@ -751,7 +751,7 @@ export default class MainBackground {
     if (contextMenuEnabled) {
       const authed = await this.userService.isAuthenticated();
       await this.loadNoLoginsContextMenuOptions(
-        this.i18nService.t(authed ? "vaultLocked" : "vaultLoggedOut")
+        this.i18nService.t(authed ? "unlockVaultMenu" : "loginToVaultMenu")
       );
     }
 


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
With https://github.com/bitwarden/browser/pull/2132 I added the ability to login/unlock your vault via the context menu. What I missed though was to change the text on the menu items to indicate that a user can login/unlock their vault when clicking on that item.

Asana task: https://app.asana.com/0/1169444489336079/1201703036655956/f
## Code changes

- **src/_locales/en/messages.json:** 
  - Removed `vaultLocked` and `vaultLoggedOut`
  - Added `unlockVaultMenu` and `loginToVaultMenu`
- **src/background/main.background.ts :** Use new menu items text

## Screenshots
- **BEFORE:**
![before_login](https://user-images.githubusercontent.com/2670567/150635753-c8b89139-dd98-4066-812a-5766c86cec9b.PNG)
![before_unlock](https://user-images.githubusercontent.com/2670567/150635754-4cdcf86b-d6ec-455e-bda2-1b183e65a9c8.PNG)

- **AFTER:**
![after_login](https://user-images.githubusercontent.com/2670567/150635763-3dbbb059-41c8-49eb-b777-cb557857f688.PNG)
![after_unlock](https://user-images.githubusercontent.com/2670567/150635766-266e689d-4f90-4cd4-b2e8-9c2ae6852535.PNG)

## Testing requirements
When no user is logged in, the menu should show -> Login to your vault
When a user is logged in but the vault is locked the menu should show -> Unlock your vault

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
