### PR TITLE
[bug] Update gulp and webpack to include new font sheet

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,8 +23,9 @@ const filters = {
   fonts: [
     "!build/popup/fonts/*",
     "build/popup/fonts/Open_Sans*.woff",
-    "build/popup/fonts/fontawesome*.woff2",
-    "build/popup/fonts/fontawesome*.woff",
+    "build/popup/fonts/bwi-font.woff2",
+    "build/popup/fonts/bwi-font.woff",
+    "build/popup/fonts/bwi-font.ttf",
   ],
   safari: ["!build/safari/**/*"],
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,7 +31,7 @@ const moduleRules = [
   },
   {
     test: /\.(jpe?g|png|gif|svg)$/i,
-    exclude: /.*(fontawesome-webfont|glyphicons-halflings-regular)\.svg/,
+    exclude: /.*(bwi-font|glyphicons-halflings-regular)\.svg/,
     generator: {
       filename: "popup/images/[name][ext]",
     },


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
> `dist` builds were not copying over the new font sheets. Merge fix to both `master` and `rc`

## Code changes
- **gulpfile.js:** Updated fonts filter with new font sheets
- **webpack.config.js:** Updated exclusion image list with new font sheets

## Testing requirements

- Make sure `dist` builds are showing the new icons

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
