### PR TITLE
Fix regressions in notificationBar (NeverDomains, Save new login/update password prompt)

### DIFF
--- a/src/content/notificationBar.ts
+++ b/src/content/notificationBar.ts
@@ -48,23 +48,32 @@ document.addEventListener("DOMContentLoaded", (event) => {
   let disabledAddLoginNotification = false;
   let disabledChangedPasswordNotification = false;
 
-  chrome.storage.local.get("neverDomains", (ndObj: any) => {
-    const domains = ndObj.neverDomains;
+  const activeUserIdKey = "activeUserId";
+  let activeUserId: string;
+  chrome.storage.local.get(activeUserIdKey, (obj: any) => {
+    if (obj == null || obj[activeUserIdKey] == null) {
+      return;
+    }
+    activeUserId = obj[activeUserIdKey];
+  });
+
+  chrome.storage.local.get(activeUserId, (obj: any) => {
+    if (obj === null) {
+      return;
+    }
+
+    const domains = obj[activeUserId].settings.neverDomains;
     if (domains != null && domains.hasOwnProperty(window.location.hostname)) {
       return;
     }
 
-    chrome.storage.local.get("disableAddLoginNotification", (disAddObj: any) => {
-      disabledAddLoginNotification =
-        disAddObj != null && disAddObj.disableAddLoginNotification === true;
-      chrome.storage.local.get("disableChangedPasswordNotification", (disChangedObj: any) => {
-        disabledChangedPasswordNotification =
-          disChangedObj != null && disChangedObj.disableChangedPasswordNotification === true;
-        if (!disabledAddLoginNotification || !disabledChangedPasswordNotification) {
-          collectIfNeededWithTimeout();
-        }
-      });
-    });
+    disabledAddLoginNotification = obj[activeUserId].settings.disableAddLoginNotification;
+    disabledChangedPasswordNotification =
+      obj[activeUserId].settings.disableChangedPasswordNotification;
+
+    if (!disabledAddLoginNotification || !disabledChangedPasswordNotification) {
+      collectIfNeededWithTimeout();
+    }
   });
 
   chrome.runtime.onMessage.addListener((msg: any, sender: any, sendResponse: Function) => {


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
With a fix that @addisonbeck has prepared, I realized that we also had an issue reading the `neverDomains`, the `disableAddLoginNotification` and the `disableChangePasswordNotification` settings within the notificationBar.

In prep for account switching the storage can have multiple userId's and the format of the storage has changed.

The reads for the browsers local storage would always return empty as the storage was migrated.

These changes will need to be 🍒 ⛏️ 

Asana tasks: https://app.asana.com/0/1169444489336079/1201771027990401/f and https://app.asana.com/0/1169444489336079/1201774155981522/f
## Code changes
- **src/content/notificationBar.ts:** Grab the activeUserId from storage and use that, to retrieve the neverDomains, disableAddLoginNotification and disableChangePasswordNotification setting.

## Testing requirements
- Setting up a domain, that you do not want get a Save new login/update password prompt for, should not sow the notificationBar. Regardless how the other two settings are set.

**After changing one of these settings, please re-load the page, as the noticationBar is part of a content script**
- The disableAddLoginNotification setting should behave as expected when activated or de-activated.
- The disableChangePasswordNotification setting should behave as expected when activated or de-activated.

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
