### PR TITLE
Fix possible null ref within reloadProcess

### DIFF
--- a/src/background/main.background.ts
+++ b/src/background/main.background.ts
@@ -996,10 +996,13 @@ export default class MainBackground {
   }
 
   private async reloadProcess(): Promise<void> {
-    const accounts = Object.keys(this.stateService.accounts.getValue());
-    for (const userId of accounts) {
-      if (!(await this.vaultTimeoutService.isLocked(userId))) {
-        return;
+    const accounts = this.stateService.accounts.getValue();
+    if (accounts != null) {
+      const accountKeys = Object.keys(accounts);
+      for (const userId of accountKeys) {
+        if (!(await this.vaultTimeoutService.isLocked(userId))) {
+          return;
+        }
       }
     }
 


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
When reloading the process we retrieve the accounts from stateService. If all accounts have been logged out this will return null. This results in the call to `Object.keys()` to throw a NullRef.

This will need to be 🍒 ⛏️ to `rc`

## Code changes
- **src/background/main.background.ts:** Check accounts if null before calling `Object.keys()`

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
