### PR TITLE
[bug] Dont block redirecting on logout

### DIFF
--- a/src/background/main.background.ts
+++ b/src/background/main.background.ts
@@ -556,10 +556,6 @@ export default class MainBackground {
   }
 
   async logout(expired: boolean, userId?: string) {
-    if (!userId) {
-      userId = await this.stateService.getUserId();
-    }
-
     await this.eventService.uploadEvents(userId);
 
     await Promise.all([
@@ -577,7 +573,7 @@ export default class MainBackground {
       this.keyConnectorService.clear(),
     ]);
 
-    await this.stateService.clean();
+    await this.stateService.clean({ userId: userId });
 
     if (userId == null || userId === (await this.stateService.getUserId())) {
       this.searchService.clearIndex();
@@ -996,13 +992,14 @@ export default class MainBackground {
   }
 
   private async reloadProcess(): Promise<void> {
-    const accounts = Object.keys(this.stateService.accounts.getValue());
-    for (const userId of accounts) {
-      if (!(await this.vaultTimeoutService.isLocked(userId))) {
-        return;
+    const accounts = this.stateService.accounts.getValue();
+    if (accounts != null) {
+      for (const userId of Object.keys(accounts)) {
+        if (!(await this.vaultTimeoutService.isLocked(userId))) {
+          return;
+        }
       }
     }
-
     await this.systemService.startProcessReload();
   }
 }

--- a/src/popup/app.component.ts
+++ b/src/popup/app.component.ts
@@ -75,8 +75,6 @@ export class AppComponent implements OnInit {
               });
             }
 
-            await this.stateService.clean({ userId: msg.userId });
-
             if (this.stateService.activeAccount.getValue() == null) {
               this.router.navigate(["home"]);
             }


### PR DESCRIPTION
https://app.asana.com/0/inbox/1183359552741416/1201784235738526/1201782081866250

This will need to be cherry picked to rc

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Manually logging out of the extension is clearing state, but not redirecting, leading to bad application behavior.

## Code changes
1. Don't manually grab a `userId` in `logout()`. Doing this makes it impossible for the conditional that sends the "doneLoggingOut" message to be met, since it only fires if userId is null (logging out the active user) or an inactive user is being logged out. 
2. Remove the `stateService.clean()` call from `"doneLoggingOut"`, this is redundant as it is called in the logout function, and results in errors that stop execution of the redirect.

Some unrelated changes I made while in the area:
1. Passing `userId` to `stateService.clean()` in `logout()`. This won't matter until account switching is implemented for browser, but will save us a bug when we get there.
2. Wrapping `reloadProcess` logic in a conditional. I noticed console errors on logout because `stateService.accounts.getValue` was null.

## Screenshots
https://user-images.githubusercontent.com/15897251/153010988-b7abc0ee-2506-4145-a329-9d785753876b.mov

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
