### PR TITLE
Chunk out jslib and large modules to separate caches

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -140,6 +140,36 @@ const config = {
             return chunk.name === "popup/main";
           },
         },
+        jslib: {
+          test(module, chunks) {
+            return (
+              module.resource != null &&
+              module.resource.startsWith(`${process.cwd() + path.sep}jslib`)
+            );
+          },
+          name: "jslib",
+          chunks: "all",
+        },
+        angularBundles: {
+          test(module, chunks) {
+            return (
+              module.resource != null &&
+              module.resource.includes(`${path.sep}@angular${path.sep}`) &&
+              module.resource.includes(`${path.sep}bundles${path.sep}`)
+            );
+          },
+          name: "angular-bundles",
+          chunks: "all",
+        },
+        zxcvbn: {
+          test(module, chunks) {
+            return (
+              module.resource != null && module.resource.includes(`${path.sep}zxcvbn${path.sep}`)
+            );
+          },
+          name: "zxcvbn",
+          chunks: "all",
+        },
         angular: {
           test(module, chunks) {
             return (

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -83,9 +83,6 @@ const plugins = [
       { from: "./src/content/autofill.css", to: "content" },
     ],
   }),
-  new webpack.SourceMapDevToolPlugin({
-    include: ["popup/main.js", "background.js"],
-  }),
   new MiniCssExtractPlugin({
     filename: "[name].css",
     chunkFilename: "chunk-[id].css",
@@ -110,7 +107,7 @@ const plugins = [
 
 const config = {
   mode: ENV,
-  devtool: false,
+  devtool: ENV === "development" ? "eval-source-map" : "source-map",
   entry: {
     "popup/polyfills": "./src/popup/polyfills.ts",
     "popup/main": "./src/popup/main.ts",
@@ -124,7 +121,7 @@ const config = {
     "notification/bar": "./src/notification/bar.js",
   },
   optimization: {
-    minimize: false,
+    minimize: true,
     splitChunks: {
       cacheGroups: {
         commons: {
@@ -139,36 +136,6 @@ const config = {
           chunks: (chunk) => {
             return chunk.name === "popup/main";
           },
-        },
-        jslib: {
-          test(module, chunks) {
-            return (
-              module.resource != null &&
-              module.resource.startsWith(`${process.cwd() + path.sep}jslib`)
-            );
-          },
-          name: "jslib",
-          chunks: "all",
-        },
-        angularBundles: {
-          test(module, chunks) {
-            return (
-              module.resource != null &&
-              module.resource.includes(`${path.sep}@angular${path.sep}`) &&
-              module.resource.includes(`${path.sep}bundles${path.sep}`)
-            );
-          },
-          name: "angular-bundles",
-          chunks: "all",
-        },
-        zxcvbn: {
-          test(module, chunks) {
-            return (
-              module.resource != null && module.resource.includes(`${path.sep}zxcvbn${path.sep}`)
-            );
-          },
-          name: "zxcvbn",
-          chunks: "all",
         },
         angular: {
           test(module, chunks) {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

We can't submit our most recent release for Firefox because some files exceed the 4MB hard limit (popup/main.js and vendor.js). This PR adds further chunking rules to create three new caches
1. jslib
2. @angular ngcc compiled bundles
3. zxcvbn (the frequency list is large)

## Screenshots

### Old
<img width="1536" alt="image" src="https://user-images.githubusercontent.com/18214891/153513121-791554b1-c605-4f64-81c3-6f6d974676c5.png">


### New
<img width="1536" alt="image" src="https://user-images.githubusercontent.com/18214891/153512659-fa1df173-ee97-4b19-9b56-2015076fdfdc.png">

<!--Required for any UI changes. Delete if not applicable-->

## Testing requirements

Smoke test should be sufficient

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
