### PR TITLE
Fix search bar position when using sr-only

### DIFF
--- a/src/popup/scss/base.scss
+++ b/src/popup/scss/base.scss
@@ -271,7 +271,8 @@ header {
     }
   }
 
-  .left + .search {
+  .left + .search,
+  .left + .sr-only + .search {
     padding-left: 0;
 
     .bwi {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Resolves the search bar being slightly off when there is a `sr-only` header.

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
