### PR TITLE
Add missing transition to excluded domains

### DIFF
--- a/src/popup/app-routing.animations.ts
+++ b/src/popup/app-routing.animations.ts
@@ -194,6 +194,9 @@ export const routerTransition = trigger("routerTransition", [
   transition("tabs => sync", inSlideLeft),
   transition("sync => tabs", outSlideRight),
 
+  transition("tabs => excluded-domains", inSlideLeft),
+  transition("excluded-domains => tabs", outSlideRight),
+
   transition("tabs => options", inSlideLeft),
   transition("options => tabs", outSlideRight),
 

--- a/src/popup/settings/excluded-domains.component.html
+++ b/src/popup/settings/excluded-domains.component.html
@@ -1,7 +1,7 @@
 <form #form (ngSubmit)="submit()">
   <header>
     <div class="left">
-      <a routerLink="/tabs/settings">{{ "cancel" | i18n }}</a>
+      <a routerLink="/tabs/settings">{{ "back" | i18n }}</a>
     </div>
     <h1 class="center">
       <span class="title">{{ "excludedDomains" | i18n }}</span>


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
When opening the excluded domains there was not transition (animation) from the settings screen. It was also missing

Asana task: https://app.asana.com/0/1169444489336079/1201807071623119/f

## Code changes

- **src/popup/app-routing.animations.ts:** Add missing transition from and to excluded domains
- **src/popup/settings/excluded-domains.component.html:** Change caption on cancel button to back

## Testing requirements
When opening the settings screen and then clicking on the excluded domains, it should show slide in from the right.
When clicking on the top back button or saving a new domain it should slide out from left to right

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
