### PR TITLE
Display separator between ngFor'ed cipher components

### DIFF
--- a/src/popup/components/cipher-row.component.html
+++ b/src/popup/components/cipher-row.component.html
@@ -5,6 +5,7 @@
   appStopClick
   title="{{ title }} - {{ cipher.name }}"
   class="box-content-row box-content-row-flex virtual-scroll-item"
+  [ngClass]="{ 'override-last': !last }"
 >
   <div class="row-main">
     <app-vault-icon [cipher]="cipher"></app-vault-icon>

--- a/src/popup/components/cipher-row.component.ts
+++ b/src/popup/components/cipher-row.component.ts
@@ -11,6 +11,7 @@ export class CipherRowComponent {
   @Output() launchEvent = new EventEmitter<CipherView>();
   @Output() onView = new EventEmitter<CipherView>();
   @Input() cipher: CipherView;
+  @Input() last: boolean;
   @Input() showView = false;
   @Input() title: string;
 

--- a/src/popup/scss/box.scss
+++ b/src/popup/scss/box.scss
@@ -211,6 +211,13 @@
     }
   }
 
+  &.override-last:last-child:before {
+    border-bottom: 1px solid #000000;
+    @include themify($themes) {
+      border-bottom-color: themed("boxBorderColor");
+    }
+  }
+
   &.last:last-child:before {
     border-bottom: 1px solid #000000;
     @include themify($themes) {

--- a/src/popup/vault/ciphers.component.html
+++ b/src/popup/vault/ciphers.component.html
@@ -97,8 +97,9 @@
         </h2>
         <div class="box-content">
           <app-cipher-row
-            *cdkVirtualFor="let c of ciphers"
+            *cdkVirtualFor="let c of ciphers; let last = last"
             [cipher]="c"
+            [last]="last"
             title="{{ 'viewItem' | i18n }}"
             (onSelected)="selectCipher($event)"
             (launchEvent)="launchCipher($event)"


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

We currently remove the separator element when a `box-content-row` is the last child. However, when we create these rows from ng templates each row gets a separate template element wrapping it. This PR tells the cipher-row component whether it is the last child

## Code changes
* **cipher-row**: apply override-last class to element it it's not _actually_ last
* **box.scss**: add rules for `override-last`. They're the same as the `.last` selector right under it, but that name makes no sense here
* **ciphers**: send in last to compoenent

## Screenshots

### Before
<img width="547" alt="image" src="https://user-images.githubusercontent.com/18214891/153627222-bbf0bf49-c73b-4c4f-b9ed-69ce4c9cbf17.png">

### After
<img width="547" alt="image" src="https://user-images.githubusercontent.com/18214891/153626785-b371b3cc-4443-4a54-b871-da1bc253467e.png">


## Testing requirements

Verify, no further risk

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
