### PR TITLE
Make vault URL check more concise

### DIFF
--- a/src/content/notificationBar.ts
+++ b/src/content/notificationBar.ts
@@ -2,7 +2,7 @@ import AddLoginRuntimeMessage from "src/background/models/addLoginRuntimeMessage
 import ChangePasswordRuntimeMessage from "src/background/models/changePasswordRuntimeMessage";
 
 document.addEventListener("DOMContentLoaded", (event) => {
-  if (window.location.hostname.indexOf("vault.bitwarden.com") > -1) {
+  if (window.location.hostname.endsWith("vault.bitwarden.com")) {
     return;
   }
 


### PR DESCRIPTION
This PR concludes #1932 and the subsequent [Twitter thread](https://twitter.com/_atjn/status/1486299137180151809).

When the notification bar checks whether it is currently running on the Bitwarden vault URL, it has a minor issue that means it will also think that URLs like `https://vault.bitwarden.com.evil.com/` are valid vault URLs. This is a minor issue, but it is still good to fix. See #1932 for more details.

