### PR TITLE
[feature] Implement scope warning for exports

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1866,5 +1866,17 @@
   },
   "leftOrganization": {
     "message": "You have left the organization."
+  },
+  "exportingPersonalVaultTitle": {
+    "message": "Exporting Personal Vault"
+  },
+  "exportingPersonalVaultDescription": {
+    "message": "Only the personal vault items associated with $EMAIL$ will be exported. Organization vault items will not be included.",
+    "placeholders": {
+      "email": {
+        "content": "$1",
+        "example": "name@example.com"
+      }
+    }
   }
 }

--- a/src/popup/app.module.ts
+++ b/src/popup/app.module.ts
@@ -83,6 +83,7 @@ import { SetPinComponent } from "./components/set-pin.component";
 import { VerifyMasterPasswordComponent } from "./components/verify-master-password.component";
 
 import { CalloutComponent } from "jslib-angular/components/callout.component";
+import { ExportScopeCalloutComponent } from "jslib-angular/components/export-scope-callout.component";
 import { IconComponent } from "jslib-angular/components/icon.component";
 import { BitwardenToastModule } from "jslib-angular/components/toastr.component";
 
@@ -212,6 +213,7 @@ registerLocaleData(localeZhTw, "zh-TW");
     EnvironmentComponent,
     ExcludedDomainsComponent,
     ExportComponent,
+    ExportScopeCalloutComponent,
     FallbackSrcDirective,
     FolderAddEditComponent,
     FoldersComponent,

--- a/src/popup/settings/export.component.html
+++ b/src/popup/settings/export.component.html
@@ -19,6 +19,7 @@
     <app-callout type="warning" title="{{ 'vaultExportDisabled' | i18n }}" *ngIf="disabledByPolicy">
       {{ "personalVaultExportPolicyInEffect" | i18n }}
     </app-callout>
+    <app-export-scope-callout *ngIf="!disabledByPolicy"></app-export-scope-callout>
 
     <div class="box">
       <div class="box-content">


### PR DESCRIPTION
https://app.asana.com/0/1183359552741420/1200074829339233

Depends on https://github.com/bitwarden/jslib/pull/688

## Type of change

- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Exports are often confusing to users in organizations because there is no indication on screen that a personal export won't include organization items and vice versa. We should add an information panel to this screen noting what exactly is being exported.

## Code changes
- **app.module.ts:** Added an import for the `ExportScopeCalloutComponent` added to facilitate this information in `jslib`.
- **export.component.html:** Added an `<app-export-scope-callout>` element if the "Disable Personal Vault Export" policy is not enabled. 
- **messages.json:** Added strings used by the `ExportScopeCalloutComponent` in jslib.

## Screenshots
![Screen Shot 2022-02-17 at 3 23 29 PM](https://user-images.githubusercontent.com/15897251/154564612-171f9019-6edd-4346-9b71-9f625b7016f7.png)

## Testing requirements
We expect this warning to clearly label what is being exported. It should not appear if the user is not a part of any organizations.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
