### PR TITLE
BEEEP: Colorize hidden custom field when value visible

### DIFF
--- a/src/popup/vault/view-custom-fields.component.html
+++ b/src/popup/vault/view-custom-fields.component.html
@@ -11,9 +11,11 @@
         </div>
         <div *ngIf="field.type === fieldType.Hidden">
           <span *ngIf="!field.showValue" class="monospaced">{{ field.maskedValue }}</span>
-          <span *ngIf="field.showValue && !field.showCount" class="monospaced show-whitespace">{{
-            field.value
-          }}</span>
+          <span
+            *ngIf="field.showValue && !field.showCount"
+            class="monospaced show-whitespace"
+            [innerHTML]="field.value | colorPassword"
+          ></span>
           <span
             *ngIf="field.showValue && field.showCount"
             [innerHTML]="field.value | colorPasswordCount"


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
The standard password field displays number and special characters in a different color for better readability. A hidden custom-field currently does not colorize it's value when shown.

Asana task: https://app.asana.com/0/1200804338582616/1201884248598923/f

## Code changes
- **src/popup/vault/view-custom-fields.component.html:** Pass value into ColorPasswordPipe when hidden value is shown

## Screenshots
**BEFORE:**
![image](https://user-images.githubusercontent.com/2670567/155714082-05e3e161-1e69-4c0f-92ab-6d3dda741f80.png)

**AFTER:**
![image](https://user-images.githubusercontent.com/2670567/155713709-68a1e171-561c-46e1-8eab-e01f8fd91a8c.png)

## Testing requirements
When the value of a hidden custom field is shown, it should be colorized as the standard password field

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
