### PR TITLE
Bug/fix icon status

### DIFF
--- a/src/background/main.background.ts
+++ b/src/background/main.background.ts
@@ -87,7 +87,7 @@ import VaultTimeoutService from "../services/vaultTimeout.service";
 import CommandsBackground from "./commands.background";
 import ContextMenusBackground from "./contextMenus.background";
 import IdleBackground from "./idle.background";
-import IconDetails from "./models/IconDetails";
+import IconDetails from "./models/iconDetails";
 import { NativeMessagingBackground } from "./nativeMessaging.background";
 import NotificationBackground from "./notification.background";
 import RuntimeBackground from "./runtime.background";

--- a/src/background/main.background.ts
+++ b/src/background/main.background.ts
@@ -87,6 +87,7 @@ import VaultTimeoutService from "../services/vaultTimeout.service";
 import CommandsBackground from "./commands.background";
 import ContextMenusBackground from "./contextMenus.background";
 import IdleBackground from "./idle.background";
+import IconDetails from "./models/IconDetails";
 import { NativeMessagingBackground } from "./nativeMessaging.background";
 import NotificationBackground from "./notification.background";
 import RuntimeBackground from "./runtime.background";
@@ -938,15 +939,15 @@ export default class MainBackground {
       return;
     }
 
-    const options = {
+    const options: IconDetails = {
       path: {
         19: "images/icon19" + suffix + ".png",
         38: "images/icon38" + suffix + ".png",
       },
-      windowId: windowId,
     };
 
     if (this.platformUtilsService.isFirefox()) {
+      options.windowId = windowId;
       await theAction.setIcon(options);
     } else if (this.platformUtilsService.isSafari()) {
       // Workaround since Safari 14.0.3 returns a pending promise

--- a/src/background/models/iconDetails.ts
+++ b/src/background/models/iconDetails.ts
@@ -3,6 +3,6 @@ export default class IconDetails {
     19: string;
     38: string;
   };
-  // Chrome does not support windowId, only FireFox
+  // Chrome does not support windowId, only Firefox
   windowId?: number;
 }

--- a/src/background/models/iconDetails.ts
+++ b/src/background/models/iconDetails.ts
@@ -1,0 +1,8 @@
+export default class IconDetails {
+  path: {
+    19: string;
+    38: string;
+  };
+  // Chrome does not support windowId, only FireFox
+  windowId?: number;
+}

--- a/src/background/models/iconDetails.ts
+++ b/src/background/models/iconDetails.ts
@@ -1,4 +1,4 @@
-export default class IconDetails {
+export default interface IconDetails {
   path: {
     19: string;
     38: string;


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Fix icon status not refreshing when vault is locked/unlocked in Chrome.
Chrome doesn't support the `windowId` property, so it was puking when it would set the object.

## Code changes

- **src/background/main.background.ts:** Remove windowId initial assignment of options
- **src/background/models/iconDetails.ts:** Add IconDetails class

## Testing requirements

Ensure that the icon responds to status updates correctly in Chrome.
In Firefox private mode, the icon should be set to the default blue shield icon at all times.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
