### PR TITLE
Add support for no intrusive biometric

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1494,7 +1494,7 @@
     "message": "Start the Bitwarden Desktop application"
   },
   "startDesktopDesc": {
-    "message": "The Bitwarden Desktop application needs to be started before this function can be used."
+    "message": "The Bitwarden Desktop application needs to be started before unlock with biometrics can be used."
   },
   "errorEnableBiometricTitle": {
     "message": "Unable to enable biometrics"
@@ -1884,5 +1884,8 @@
         "example": "name@example.com"
       }
     }
+  },
+  "error": {
+    "message": "Error"
   }
 }

--- a/src/background/nativeMessaging.background.ts
+++ b/src/background/nativeMessaging.background.ts
@@ -115,13 +115,7 @@ export class NativeMessagingBackground {
             break;
           case "disconnected":
             if (this.connecting) {
-              this.messagingService.send("showDialog", {
-                text: this.i18nService.t("startDesktopDesc"),
-                title: this.i18nService.t("startDesktopTitle"),
-                confirmText: this.i18nService.t("ok"),
-                type: "error",
-              });
-              reject();
+              reject("startDesktop");
             }
             this.connected = false;
             this.port.disconnect();
@@ -192,18 +186,12 @@ export class NativeMessagingBackground {
           error = chrome.runtime.lastError.message;
         }
 
-        if (error != null) {
-          this.messagingService.send("showDialog", {
-            text: this.i18nService.t("desktopIntegrationDisabledDesc"),
-            title: this.i18nService.t("desktopIntegrationDisabledTitle"),
-            confirmText: this.i18nService.t("ok"),
-            type: "error",
-          });
-        }
         this.sharedSecret = null;
         this.privateKey = null;
         this.connected = false;
-        reject();
+
+        const reason = error != null ? "desktopIntegrationDisabled" : null;
+        reject(reason);
       });
     });
   }

--- a/src/models/biometricErrors.ts
+++ b/src/models/biometricErrors.ts
@@ -1,0 +1,17 @@
+type BiometricError = {
+  title: string;
+  description: string;
+};
+
+export type BiometricErrorTypes = "startDesktop" | "desktopIntegrationDisabled";
+
+export const BiometricErrors: Record<BiometricErrorTypes, BiometricError> = {
+  startDesktop: {
+    title: "startDesktopTitle",
+    description: "startDesktopDesc",
+  },
+  desktopIntegrationDisabled: {
+    title: "desktopIntegrationDisabledTitle",
+    description: "desktopIntegrationDisabledDesc",
+  },
+};

--- a/src/popup/accounts/lock.component.html
+++ b/src/popup/accounts/lock.component.html
@@ -71,5 +71,9 @@
       <button type="button" appStopClick (click)="logOut()">{{ "logOut" | i18n }}</button>
     </p>
     <app-private-mode-warning></app-private-mode-warning>
+    <p class="text-center text-danger" *ngIf="biometricError">{{ biometricError }}</p>
+    <p class="text-center text-muted" *ngIf="pendingBiometric">
+      <i class="bwi bwi-spinner bwi-spin" aria-hidden="true"></i> {{ "awaitDesktop" | i18n }}
+    </p>
   </content>
 </form>

--- a/src/popup/accounts/lock.component.html
+++ b/src/popup/accounts/lock.component.html
@@ -62,7 +62,13 @@
     </div>
     <div class="box" *ngIf="biometricLock">
       <div class="box-footer">
-        <button type="button" class="btn primary block" (click)="unlockBiometric()" appStopClick>
+        <button
+          type="button"
+          class="btn primary block"
+          (click)="unlockBiometric()"
+          appStopClick
+          [disabled]="pendingBiometric"
+        >
           {{ "unlockWithBiometrics" | i18n }}
         </button>
       </div>
@@ -71,7 +77,7 @@
       <button type="button" appStopClick (click)="logOut()">{{ "logOut" | i18n }}</button>
     </p>
     <app-private-mode-warning></app-private-mode-warning>
-    <p class="text-center text-danger" *ngIf="biometricError">{{ biometricError }}</p>
+    <app-callout *ngIf="biometricError" type="error">{{ biometricError }}</app-callout>
     <p class="text-center text-muted" *ngIf="pendingBiometric">
       <i class="bwi bwi-spinner bwi-spin" aria-hidden="true"></i> {{ "awaitDesktop" | i18n }}
     </p>

--- a/src/popup/accounts/lock.component.ts
+++ b/src/popup/accounts/lock.component.ts
@@ -106,8 +106,8 @@ export class LockComponent extends BaseLockComponent {
 
       if (userInitiated) {
         this.platformUtilsService.showDialog(
-          this.i18nService.t(error.title),
           this.i18nService.t(error.description),
+          this.i18nService.t(error.title),
           this.i18nService.t("ok"),
           null,
           "error"

--- a/src/popup/app.component.ts
+++ b/src/popup/app.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectorRef, Component, NgZone, OnInit, SecurityContext } from "@
 import { DomSanitizer } from "@angular/platform-browser";
 import { NavigationEnd, Router, RouterOutlet } from "@angular/router";
 import { IndividualConfig, ToastrService } from "ngx-toastr";
-import Swal, { SweetAlertIcon } from "sweetalert2/src/sweetalert2.js";
+import Swal, { SweetAlertIcon } from "sweetalert2";
 
 import { AuthService } from "jslib-common/abstractions/auth.service";
 import { BroadcasterService } from "jslib-common/abstractions/broadcaster.service";

--- a/src/popup/scss/plugins.scss
+++ b/src/popup/scss/plugins.scss
@@ -1,5 +1,5 @@
 @import "~ngx-toastr/toastr";
-@import "~sweetalert2/src/sweetalert2.scss";
+@import "~#sweetalert2";
 
 @import "variables.scss";
 @import "buttons.scss";

--- a/src/popup/settings/settings.component.ts
+++ b/src/popup/settings/settings.component.ts
@@ -1,7 +1,7 @@
 import { Component, ElementRef, OnInit, ViewChild } from "@angular/core";
 import { FormControl } from "@angular/forms";
 import { Router } from "@angular/router";
-import Swal from "sweetalert2/src/sweetalert2.js";
+import Swal from "sweetalert2";
 
 import { ModalService } from "jslib-angular/services/modal.service";
 import { CryptoService } from "jslib-common/abstractions/crypto.service";

--- a/src/popup/settings/settings.component.ts
+++ b/src/popup/settings/settings.component.ts
@@ -15,6 +15,7 @@ import { VaultTimeoutService } from "jslib-common/abstractions/vaultTimeout.serv
 import { DeviceType } from "jslib-common/enums/deviceType";
 
 import { BrowserApi } from "../../browser/browserApi";
+import { BiometricErrors, BiometricErrorTypes } from "../../models/biometricErrors";
 import { SetPinComponent } from "../components/set-pin.component";
 import { PopupUtilsService } from "../services/popup-utils.service";
 
@@ -269,6 +270,16 @@ export class SettingsComponent implements OnInit {
           .catch((e) => {
             // Handle connection errors
             this.biometric = false;
+
+            const error = BiometricErrors[e as BiometricErrorTypes];
+
+            this.platformUtilsService.showDialog(
+              this.i18nService.t(error.title),
+              this.i18nService.t(error.description),
+              this.i18nService.t("ok"),
+              null,
+              "error"
+            );
           }),
       ]);
     } else {

--- a/src/popup/settings/settings.component.ts
+++ b/src/popup/settings/settings.component.ts
@@ -274,8 +274,8 @@ export class SettingsComponent implements OnInit {
             const error = BiometricErrors[e as BiometricErrorTypes];
 
             this.platformUtilsService.showDialog(
-              this.i18nService.t(error.title),
               this.i18nService.t(error.description),
+              this.i18nService.t(error.title),
               this.i18nService.t("ok"),
               null,
               "error"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -168,6 +168,10 @@ const config = {
     extensions: [".ts", ".js"],
     symlinks: false,
     modules: [path.resolve("node_modules")],
+    alias: {
+      sweetalert2: require.resolve("sweetalert2/dist/sweetalert2.js"),
+      "#sweetalert2": require.resolve("sweetalert2/src/sweetalert2.scss"),
+    },
     fallback: {
       assert: false,
       buffer: require.resolve("buffer/"),


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

The previous release accidentally enabled automatic biometric prompt for everyone. Since the current way is fairly intrusive I've reworked the logic and it now has a non user initiated mode which shows the error message below the text.

Depends on https://github.com/bitwarden/jslib/pull/703

Resolves https://app.asana.com/0/1201804463288267/1201889029543601

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **src/background/nativeMessaging.background.ts:** Changed some errors to propagate up the promise chain instead of creating a message. (We should do these for every message in the long term)
- **src/models/biometricErrors.ts**: Holds the error messages.
- **src/popup/accounts/lock.component.ts**: Added logic for non user initiated biometric triggers.
- **src/popup/settings/settings.component.ts**: Handle the new way of showing errors.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

Pending confirmation.
![image](https://user-images.githubusercontent.com/137855/156594274-4688b658-3a39-4932-91fc-97e406c7c564.png)

Failed
![image](https://user-images.githubusercontent.com/137855/156738340-dcadf203-8169-44c1-bfe9-e6082353ad27.png)

Old:
![image](https://user-images.githubusercontent.com/137855/156606313-0ebf43b6-acb9-448b-951d-7f22909036fc.png)

## Testing requirements

<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

Regression test errors for both non user initiated and user initiated actions.

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
