### PR TITLE
[FF Private Mode] Set icon for Private Mode windows that are already open

### DIFF
--- a/src/background/main.background.ts
+++ b/src/background/main.background.ts
@@ -498,7 +498,13 @@ export default class MainBackground {
     await this.windowsBackground.init();
 
     if (this.platformUtilsService.isFirefox() && !this.isPrivateMode) {
-      // Set new Private Mode windows to the default icon - they do not share state with the background page
+      // Set Private Mode windows to the default icon - they do not share state with the background page
+      const privateWindows = await BrowserApi.getPrivateModeWindows();
+      privateWindows.forEach(async (win) => {
+        await this.actionSetIcon(chrome.browserAction, "", win.id);
+        await this.actionSetIcon(this.sidebarAction, "", win.id);
+      });
+
       BrowserApi.onWindowCreated(async (win) => {
         if (win.incognito) {
           await this.actionSetIcon(chrome.browserAction, "", win.id);


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix bug in FF Private Mode: there are some edge cases that reload the extension while Private Mode windows are open, which breaks the Bitwarden icon in Private Mode windows (which should be locked to the blue icon and should not respond to state). This can happen, for example, if the user enables biometric unlock.

**Note:** will be cherry-picked to `rc`

Asana: https://app.asana.com/0/1169444489336079/1201916867174072/f
## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **src/background/main.background.ts** - when the (non-private mode) background page first starts, check and set the icon for any existing Private Mode windows. Previously we only had the event listener to handle new windows, but that missed any that were already open.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Testing requirements

<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
Confirm bug is fixed and no regressions on icon behaviour generally.
## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
