### PR TITLE
Fix infinite spinner when trying to restore Send state

### DIFF
--- a/src/popup/app.component.ts
+++ b/src/popup/app.component.ts
@@ -41,7 +41,11 @@ export class AppComponent implements OnInit {
     private platformUtilsService: PlatformUtilsService
   ) {}
 
-  ngOnInit() {
+  async ngOnInit() {
+    // Component states must not persist between closing and reopening the popup, otherwise they become dead objects
+    // Clear them aggressively to make sure this doesn't occur
+    await this.clearComponentStates();
+
     this.stateService.activeAccount.subscribe((userId) => {
       this.activeUserId = userId;
     });
@@ -125,10 +129,7 @@ export class AppComponent implements OnInit {
           (window as any).previousPopupUrl != null &&
           (window as any).previousPopupUrl.startsWith("/tabs/")
         ) {
-          await this.stateService.setBrowserGroupingComponentState(null);
-          await this.stateService.setBrowserCipherComponentState(null);
-          await this.stateService.setBrowserSendComponentState(null);
-          await this.stateService.setBrowserSendTypeComponentState(null);
+          await this.clearComponentStates();
         }
         if (url.startsWith("/tabs/")) {
           await this.stateService.setAddEditCipherInfo(null);
@@ -249,5 +250,14 @@ export class AppComponent implements OnInit {
       dialogId: msg.dialogId,
       confirmed: confirmed.value,
     });
+  }
+
+  private async clearComponentStates() {
+    await Promise.all([
+      this.stateService.setBrowserGroupingComponentState(null),
+      this.stateService.setBrowserCipherComponentState(null),
+      this.stateService.setBrowserSendComponentState(null),
+      this.stateService.setBrowserSendTypeComponentState(null),
+    ]);
   }
 }

--- a/src/popup/send/send-groupings.component.ts
+++ b/src/popup/send/send-groupings.component.ts
@@ -171,19 +171,11 @@ export class SendGroupingsComponent extends BaseSendComponent {
       sends: this.sends,
       typeCounts: this.typeCounts,
     };
-    const obj = new BrowserSendComponentState();
-    obj.scrollY = this.state.scrollY;
-    obj.searchText = this.state.searchText;
-    obj.sends = this.state.sends;
-    obj.typeCounts = this.state.typeCounts;
-    console.log("saving obj");
-    await this.stateService.setBrowserSendComponentState(obj);
+    await this.stateService.setBrowserSendComponentState(this.state);
   }
 
   private async restoreState(): Promise<boolean> {
-    console.log("here");
     this.state = await this.stateService.getBrowserSendComponentState();
-    console.log(this.state);
     if (this.state == null) {
       return false;
     }

--- a/src/popup/send/send-groupings.component.ts
+++ b/src/popup/send/send-groupings.component.ts
@@ -14,8 +14,7 @@ import { SyncService } from "jslib-common/abstractions/sync.service";
 import { SendType } from "jslib-common/enums/sendType";
 import { SendView } from "jslib-common/models/view/sendView";
 
-import { BrowserSendComponentState } from "src/models/browserSendComponentState";
-
+import { BrowserSendComponentState } from "../../models/browserSendComponentState";
 import { StateService } from "../../services/abstractions/state.service";
 import { PopupUtilsService } from "../services/popup-utils.service";
 
@@ -172,11 +171,19 @@ export class SendGroupingsComponent extends BaseSendComponent {
       sends: this.sends,
       typeCounts: this.typeCounts,
     };
-    await this.stateService.setBrowserSendComponentState(this.state);
+    const obj = new BrowserSendComponentState();
+    obj.scrollY = this.state.scrollY;
+    obj.searchText = this.state.searchText;
+    obj.sends = this.state.sends;
+    obj.typeCounts = this.state.typeCounts;
+    console.log("saving obj");
+    await this.stateService.setBrowserSendComponentState(obj);
   }
 
   private async restoreState(): Promise<boolean> {
+    console.log("here");
     this.state = await this.stateService.getBrowserSendComponentState();
+    console.log(this.state);
     if (this.state == null) {
       return false;
     }

--- a/src/services/state.service.ts
+++ b/src/services/state.service.ts
@@ -78,12 +78,8 @@ export class StateService
     await this.saveAccount(account, this.reconcileOptions(options, this.defaultInMemoryOptions));
   }
   async getBrowserSendTypeComponentState(options?: StorageOptions): Promise<BrowserComponentState> {
-    const result = (
-      await this.getAccount(this.reconcileOptions(options, this.defaultInMemoryOptions))
-    )?.sendType;
-
-    console.log(result);
-    return result;
+    return (await this.getAccount(this.reconcileOptions(options, this.defaultInMemoryOptions)))
+      ?.sendType;
   }
 
   async setBrowserSendTypeComponentState(

--- a/src/services/state.service.ts
+++ b/src/services/state.service.ts
@@ -78,8 +78,12 @@ export class StateService
     await this.saveAccount(account, this.reconcileOptions(options, this.defaultInMemoryOptions));
   }
   async getBrowserSendTypeComponentState(options?: StorageOptions): Promise<BrowserComponentState> {
-    return (await this.getAccount(this.reconcileOptions(options, this.defaultInMemoryOptions)))
-      ?.sendType;
+    const result = (
+      await this.getAccount(this.reconcileOptions(options, this.defaultInMemoryOptions))
+    )?.sendType;
+
+    console.log(result);
+    return result;
   }
 
   async setBrowserSendTypeComponentState(


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix https://app.asana.com/0/1199398283201888/1201964764557907.

1. use FF
2. navigate to create a new Send
3. exit the popup (by clicking out of it) - no need to save the Send
4. open the popup and click the Send tab
5. observe infinite spinner

This is caused by retrieving the `BrowserSendComponentState` from in memory storage. When I try to log the stored value, I get a dead object error:
Dev tools:
![Screen Shot 2022-03-15 at 3 20 00 pm](https://user-images.githubusercontent.com/31796059/158311999-eb716f68-17a5-40e1-895a-70a0034d2acc.png)

The problem appears to be that the component state object is created in the popup and is garbage collected when the popup closes. `StateService` (in the background) tries to hold onto the object but can't.

We don't actually intend for these states to persist after the popup is closed anyway, so we should just clear these values more aggressively to ensure they don't persist between popup sessions.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/popup/app.component.ts** - clear component state as soon as the Angular app initializes
* **src/popup/send/send-groupings.component.ts** - fix non-relative import

## Testing requirements

<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
No special requirements

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
