### PR TITLE
EC-121 Fix box alignment

### DIFF
--- a/src/popup/scss/box.scss
+++ b/src/popup/scss/box.scss
@@ -120,11 +120,6 @@
         }
 
         .action-buttons {
-          &.count {
-            align-self: start;
-            margin-top: 10px;
-          }
-
           .row-btn {
             padding-left: 5px;
             padding-right: 5px;
@@ -260,7 +255,6 @@
     display: block;
     width: 100%;
     margin-bottom: 5px;
-    min-height: 1em;
 
     @include themify($themes) {
       color: themed("mutedColor");
@@ -311,7 +305,6 @@
   .row-main {
     flex-grow: 1;
     min-width: 0;
-    align-self: start;
   }
 
   &.box-content-row-flex,
@@ -462,8 +455,12 @@
 
   .action-buttons {
     display: flex;
-    align-self: start;
     margin-left: 5px;
+
+    &.action-buttons-fixed {
+      align-self: start;
+      margin-top: 2px;
+    }
 
     .row-btn {
       cursor: pointer;

--- a/src/popup/vault/view-custom-fields.component.html
+++ b/src/popup/vault/view-custom-fields.component.html
@@ -38,7 +38,7 @@
           <span>{{ cipher.linkedFieldI18nKey(field.linkedId) | i18n }}</span>
         </div>
       </div>
-      <div class="action-buttons">
+      <div class="action-buttons action-buttons-fixed">
         <button
           type="button"
           class="row-btn"

--- a/src/popup/vault/view.component.html
+++ b/src/popup/vault/view.component.html
@@ -74,7 +74,7 @@
               [innerHTML]="cipher.login.password | colorPasswordCount"
             ></div>
           </div>
-          <div class="action-buttons">
+          <div class="action-buttons action-buttons-fixed">
             <button
               type="button"
               #checkPasswordBtn


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

**May be cherry-picked to rc**

Fix misalignment of box-row content:

![Screen Shot 2022-03-25 at 3 52 05 pm](https://user-images.githubusercontent.com/31796059/160062547-d314b0f8-4014-4cca-ba4a-006f7744809f.png)

This was caused by #1780. The problem was that the character count view takes up a lot of vertical space, and the action buttons are vertically centered. This means that when you show the character count, the box-row expands, and the action buttons jump from under the cursor (to the new vertical center).

To solve this, we set `align-self: start`, but that was applied to the whole box model, so it had unintended consequences elsewhere.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **src/popup/scss/box.scss** - undo the relevant `git blame` changes. Only apply `align-self: start` to those action buttons that we need it for, with a slight margin to align it. The pixel margin feels like a bit of a fudge, but it's only for this specific instance where we can be pretty confident about the height of the box. (compared to the original change which applied across the entire box model)

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

![Screen Shot 2022-03-25 at 3 46 48 pm](https://user-images.githubusercontent.com/31796059/160063632-e2a1dc5b-99d5-4ace-9700-e8a5ef3800d4.png)

![Screen Shot 2022-03-25 at 3 47 09 pm](https://user-images.githubusercontent.com/31796059/160063642-ebfabb05-b530-405b-b524-623b2c3ff241.png)

![Screen Shot 2022-03-25 at 3 47 25 pm](https://user-images.githubusercontent.com/31796059/160064005-e676f8c5-5752-4ba8-8083-83e44a34ca7b.png)

## Testing requirements

<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
Check all box-rows and action buttons throughout the extension and make sure that there are no visual regressions in the UI.
Try to change the height/length of fields and make sure no regressions.
Check on all major browsers, as I experienced this bug in Chrome but not FF.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
