### PR TITLE
[PS-122] Add `aria-label` to password generator length slider, make it non-keyboard-focusable

### DIFF
--- a/src/popup/generator/password-generator.component.html
+++ b/src/popup/generator/password-generator.component.html
@@ -142,6 +142,8 @@
             [(ngModel)]="options.length"
             (change)="sliderChanged()"
             (input)="sliderInput()"
+            attr.aria-label="{{ 'length' | i18n }}"
+            tabindex="-1"
           />
         </div>
         <div class="box-content-row box-content-row-checkbox" appBoxRow>


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Currently the range slider in the password generator options receives keyboard focus when navigating through the modal using `Tab`/`Shift+Tab`, but it lacks a focus indicator. Fundamentally though, the slider is redundant for keyboard users, as they can already operate the number input/spin box that precedes it. This PR removes the range slider from the keyboard focus cycle using `tabindex="-1"`.

Further, the range slider currently lacks an accessible name. Assistive technologies just announce it as a generic unlabelled "slider". This PR adds an explicit `aria-label` that mirrors the label for the preceding number input. This way, assistive tech users that still manage to reach the slider (e.g. using reading keys, rather than `Tab`/`Shift+Tab`) will still hear it announced sensibly/correctly.

This is a clone of https://github.com/bitwarden/desktop/pull/1459

Closes #2477

## Screenshot

Video recording using Chrome and NVDA with Speech Viewer. Current state, showing that the range slider receives focus (and shows no visible focus indication) when navigating using `Tab`/`Shift+Tab` and is announced as generic unlabelled "slider". Then the same dialog after this PR is applied - note that navigating using `Tab`/`Shift+Tab`, the range slider doesn't receive focus at all (focus goes from the length number input directly to the A-Z checkbox). Changing NVDA to get out of forms mode (`NVDA+Space`) and navigating using reading keys (cursor keys), the range slider can be reached, and is announced as "Length slider...".


https://user-images.githubusercontent.com/895831/160379385-05c39338-8329-4313-8fd7-f05f7f07cf79.mp4

## Testing requirements

- test using keyboard navigation first (noting the slider is now not in the focus cycle, so it doesn't receive focus and then disorient users by not actually having a focus indicator)
- test using a screen reader (e.g. NVDA on Windows) - using reading keys (generally, cursor keys), reach the slider and note that it's announced not just as "slider" but as "Length slider"


## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
