### PR TITLE
[PS-199] Check if logged in before clearing grouping state

### DIFF
--- a/src/popup/app.component.ts
+++ b/src/popup/app.component.ts
@@ -253,6 +253,10 @@ export class AppComponent implements OnInit {
   }
 
   private async clearComponentStates() {
+    if (!(await this.stateService.getIsAuthenticated())) {
+      return;
+    }
+
     await Promise.all([
       this.stateService.setBrowserGroupingComponentState(null),
       this.stateService.setBrowserCipherComponentState(null),


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix the following bug:

install extension

select create account

fill out necessary fields

expected:successful account creation

actual:no error message or any UI feedback at all

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

Regression caused by https://github.com/bitwarden/browser/pull/2449. The new logic tries to clear grouping component state even when the user is not logged in, i.e. where `account == null`, and it throws an error about accessing the property of an undefined object.

Fix this by checking that the user is authenticated first.

**This will be picked to rc.**

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Testing requirements

<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->


## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
