### PR TITLE
[PS-266] A11y: change tabbed interface to toggle buttons, correctly announce currently active tab as pressed

### DIFF
--- a/src/popup/scss/base.scss
+++ b/src/popup/scss/base.scss
@@ -316,7 +316,8 @@ header {
       padding: 0;
       margin: 0;
 
-      a {
+      a,
+      button {
         text-align: center;
         display: block;
         padding: 7px 0;
@@ -325,6 +326,7 @@ header {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+        width: 100%;
 
         @include themify($themes) {
           color: themed("mutedColor");
@@ -345,7 +347,8 @@ header {
       }
 
       &.active {
-        a {
+        a,
+        button {
           @include themify($themes) {
             color: themed("primaryColor");
           }

--- a/src/popup/tabs.component.html
+++ b/src/popup/tabs.component.html
@@ -2,28 +2,48 @@
   <router-outlet></router-outlet>
   <nav class="tabs">
     <ul>
-      <li routerLinkActive="active" *ngIf="showCurrentTab">
-        <button routerLink="current" appA11yTitle="{{ 'currentTab' | i18n }}">
+      <li routerLinkActive="active" #rlaCurrentTab="routerLinkActive" *ngIf="showCurrentTab">
+        <button
+          routerLink="current"
+          appA11yTitle="{{ 'currentTab' | i18n }}"
+          [attr.aria-pressed]="rlaCurrentTab.isActive"
+        >
           <i class="bwi bwi-folder-closed-f bwi-2x" aria-hidden="true"></i>{{ "tab" | i18n }}
         </button>
       </li>
-      <li routerLinkActive="active">
-        <button routerLink="vault" appA11yTitle="{{ 'myVault' | i18n }}">
+      <li routerLinkActive="active" #rlaMyVault="routerLinkActive">
+        <button
+          routerLink="vault"
+          appA11yTitle="{{ 'myVault' | i18n }}"
+          [attr.aria-pressed]="rlaMyVault.isActive"
+        >
           <i class="bwi bwi-lock-f bwi-2x" aria-hidden="true"></i>{{ "myVault" | i18n }}
         </button>
       </li>
-      <li routerLinkActive="active">
-        <button routerLink="send" appA11yTitle="{{ 'send' | i18n }}">
+      <li routerLinkActive="active" #rlaSend="routerLinkActive">
+        <button
+          routerLink="send"
+          appA11yTitle="{{ 'send' | i18n }}"
+          [attr.aria-pressed]="rlaSend.isActive"
+        >
           <i class="bwi bwi-send-f bwi-2x" aria-hidden="true"></i>{{ "send" | i18n }}
         </button>
       </li>
-      <li routerLinkActive="active">
-        <button routerLink="generator" appA11yTitle="{{ 'passGen' | i18n }}">
+      <li routerLinkActive="active" #rlaGenerator="routerLinkActive">
+        <button
+          routerLink="generator"
+          appA11yTitle="{{ 'passGen' | i18n }}"
+          [attr.aria-pressed]="rlaGenerator.isActive"
+        >
           <i class="bwi bwi-generate-f bwi-2x" aria-hidden="true"></i>{{ "generator" | i18n }}
         </button>
       </li>
-      <li routerLinkActive="active">
-        <button routerLink="settings" appA11yTitle="{{ 'settings' | i18n }}">
+      <li routerLinkActive="active" #rlaSettings="routerLinkActive">
+        <button
+          routerLink="settings"
+          appA11yTitle="{{ 'settings' | i18n }}"
+          [attr.aria-pressed]="rlaSettings.isActive"
+        >
           <i class="bwi bwi-cog-f bwi-2x" aria-hidden="true"></i>{{ "settings" | i18n }}
         </button>
       </li>

--- a/src/popup/tabs.component.html
+++ b/src/popup/tabs.component.html
@@ -3,29 +3,29 @@
   <nav class="tabs">
     <ul>
       <li routerLinkActive="active" *ngIf="showCurrentTab">
-        <a routerLink="current" appA11yTitle="{{ 'currentTab' | i18n }}">
+        <button routerLink="current" appA11yTitle="{{ 'currentTab' | i18n }}">
           <i class="bwi bwi-folder-closed-f bwi-2x" aria-hidden="true"></i>{{ "tab" | i18n }}
-        </a>
+        </button>
       </li>
       <li routerLinkActive="active">
-        <a routerLink="vault" appA11yTitle="{{ 'myVault' | i18n }}">
+        <button routerLink="vault" appA11yTitle="{{ 'myVault' | i18n }}">
           <i class="bwi bwi-lock-f bwi-2x" aria-hidden="true"></i>{{ "myVault" | i18n }}
-        </a>
+        </button>
       </li>
       <li routerLinkActive="active">
-        <a routerLink="send" appA11yTitle="{{ 'send' | i18n }}">
+        <button routerLink="send" appA11yTitle="{{ 'send' | i18n }}">
           <i class="bwi bwi-send-f bwi-2x" aria-hidden="true"></i>{{ "send" | i18n }}
-        </a>
+        </button>
       </li>
       <li routerLinkActive="active">
-        <a routerLink="generator" appA11yTitle="{{ 'passGen' | i18n }}">
+        <button routerLink="generator" appA11yTitle="{{ 'passGen' | i18n }}">
           <i class="bwi bwi-generate-f bwi-2x" aria-hidden="true"></i>{{ "generator" | i18n }}
-        </a>
+        </button>
       </li>
       <li routerLinkActive="active">
-        <a routerLink="settings" appA11yTitle="{{ 'settings' | i18n }}">
+        <button routerLink="settings" appA11yTitle="{{ 'settings' | i18n }}">
           <i class="bwi bwi-cog-f bwi-2x" aria-hidden="true"></i>{{ "settings" | i18n }}
-        </a>
+        </button>
       </li>
     </ul>
   </nav>


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

The tabs are currently exposed as links, and do not programmatically convey when they're selected/active or not.

This PR changes the tabs to `<button>` elements, and uses `aria-pressed` to programmatically denote when a tab is active (`aria-pressed="true"`) or not (`aria-pressed="false"`).

Closes https://github.com/bitwarden/browser/issues/1982

## Code changes

- **src/popup/tabs.component.html**: change the `<a routerlink="..." ...>` controls to `<button routerlink="..." ...>` (more semantically accurate, as they act as toggles), adds a local variable for each and uses it to set `aria-pressed`
- **src/popup/scss/base.scss**: expand the styles for tabs to apply not just to `a` elements, but both `a` and `button` elements. as by default buttons don't seem to auto-expand to full available width when in a flex container, also adds explicit `width:100%;`

## Screenshots

No visual change to the interface. This video demonstrates the before/after behavior/announcements using Chrome/NVDA screen reader as an example. First, navigating through the current tabs - note that each tab is announced as a link, and the currently active tab is not announced as being active/pressed/any different from the other tabs. Then, navigating through the tabs following this PR. Note how the tabs are all announced as "toggle button", and the currently active one is announced as "pressed", while all inactive ones are announced as "not pressed". To show that this works correctly when changing tabs, in the video we then go to the "Settings" tab. Note how the tabs are correctly announced (with "Settings" being pressed now, and all others "not pressed").


https://user-images.githubusercontent.com/895831/163600426-19f6be28-9070-404d-9a62-a88bb6fad1d0.mp4

## Testing requirements

- use a screen reader (e.g. Chrome/NVDA on Windows)
- navigate through the tabs - verify that all tabs are exposed a toggle buttons
- verify that the currently active tab is announced as being pressed, and all other tabs as not being pressed
- switch between tabs, verify that the new state (which tab is now pressed etc) is correct

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
