### PR TITLE
[PS-329] A11y: make view, copy, etc controls for ciphers/items keyboard focusable/operable, add screen reader improvements

### DIFF
--- a/src/popup/components/action-buttons.component.html
+++ b/src/popup/components/action-buttons.component.html
@@ -1,4 +1,5 @@
-<span
+<button
+  type="button"
   class="row-btn"
   (click)="view()"
   appStopClick
@@ -7,9 +8,10 @@
   *ngIf="showView"
 >
   <i class="bwi bwi-lg bwi-list-alt" aria-hidden="true"></i>
-</span>
+</button>
 <ng-container *ngIf="cipher.type === cipherType.Login">
-  <span
+  <button
+    type="button"
     class="row-btn"
     appStopClick
     appStopProp
@@ -19,8 +21,9 @@
     [ngClass]="{ disabled: !cipher.login.canLaunch }"
   >
     <i class="bwi bwi-lg bwi-share-square" aria-hidden="true"></i>
-  </span>
-  <span
+  </button>
+  <button
+    type="button"
     class="row-btn"
     appStopClick
     appStopProp
@@ -29,8 +32,9 @@
     [ngClass]="{ disabled: !cipher.login.username }"
   >
     <i class="bwi bwi-lg bwi-user" aria-hidden="true"></i>
-  </span>
-  <span
+  </button>
+  <button
+    type="button"
     class="row-btn"
     appStopClick
     appStopProp
@@ -39,8 +43,9 @@
     [ngClass]="{ disabled: !cipher.login.password || !cipher.viewPassword }"
   >
     <i class="bwi bwi-lg bwi-key" aria-hidden="true"></i>
-  </span>
-  <span
+  </button>
+  <button
+    type="button"
     class="row-btn"
     appStopClick
     appStopProp
@@ -49,10 +54,11 @@
     [ngClass]="{ disabled: !displayTotpCopyButton(cipher) }"
   >
     <i class="bwi bwi-lg bwi-clock" aria-hidden="true"></i>
-  </span>
+  </button>
 </ng-container>
 <ng-container *ngIf="cipher.type === cipherType.Card">
-  <span
+  <button
+    type="button"
     class="row-btn"
     appStopClick
     appStopProp
@@ -61,8 +67,9 @@
     [ngClass]="{ disabled: !cipher.card.number }"
   >
     <i class="bwi bwi-lg bwi-hashtag" aria-hidden="true"></i>
-  </span>
-  <span
+  </button>
+  <button
+    type="button"
     class="row-btn"
     appStopClick
     appStopProp
@@ -71,10 +78,11 @@
     [ngClass]="{ disabled: !cipher.card.code }"
   >
     <i class="bwi bwi-lg bwi-key" aria-hidden="true"></i>
-  </span>
+  </button>
 </ng-container>
 <ng-container *ngIf="cipher.type === cipherType.SecureNote">
-  <span
+  <button
+    type="button"
     class="row-btn"
     appStopClick
     appStopProp
@@ -83,5 +91,5 @@
     [ngClass]="{ disabled: !cipher.notes }"
   >
     <i class="bwi bwi-lg bwi-clone" aria-hidden="true"></i>
-  </span>
+  </button>
 </ng-container>

--- a/src/popup/components/action-buttons.component.html
+++ b/src/popup/components/action-buttons.component.html
@@ -19,6 +19,7 @@
     (click)="launchCipher()"
     *ngIf="!showView"
     [ngClass]="{ disabled: !cipher.login.canLaunch }"
+    [attr.disabled]="!cipher.login.canLaunch ? '' : null"
   >
     <i class="bwi bwi-lg bwi-share-square" aria-hidden="true"></i>
   </button>
@@ -30,6 +31,7 @@
     appA11yTitle="{{ 'copyUsername' | i18n }}"
     (click)="copy(cipher, cipher.login.username, 'username', 'Username')"
     [ngClass]="{ disabled: !cipher.login.username }"
+    [attr.disabled]="!cipher.login.username ? '' : null"
   >
     <i class="bwi bwi-lg bwi-user" aria-hidden="true"></i>
   </button>
@@ -41,6 +43,7 @@
     appA11yTitle="{{ 'copyPassword' | i18n }}"
     (click)="copy(cipher, cipher.login.password, 'password', 'Password')"
     [ngClass]="{ disabled: !cipher.login.password || !cipher.viewPassword }"
+    [attr.disabled]="!cipher.login.password ? '' : null"
   >
     <i class="bwi bwi-lg bwi-key" aria-hidden="true"></i>
   </button>
@@ -52,6 +55,7 @@
     appA11yTitle="{{ 'copyVerificationCode' | i18n }}"
     (click)="copy(cipher, cipher.login.totp, 'verificationCodeTotp', 'TOTP')"
     [ngClass]="{ disabled: !displayTotpCopyButton(cipher) }"
+    [attr.disabled]="!displayTotpCopyButton(cipher) ? '' : null"
   >
     <i class="bwi bwi-lg bwi-clock" aria-hidden="true"></i>
   </button>
@@ -65,6 +69,7 @@
     appA11yTitle="{{ 'copyNumber' | i18n }}"
     (click)="copy(cipher, cipher.card.number, 'number', 'Card Number')"
     [ngClass]="{ disabled: !cipher.card.number }"
+    [attr.disabled]="!cipher.card.number ? '' : null"
   >
     <i class="bwi bwi-lg bwi-hashtag" aria-hidden="true"></i>
   </button>
@@ -76,6 +81,7 @@
     appA11yTitle="{{ 'copySecurityCode' | i18n }}"
     (click)="copy(cipher, cipher.card.code, 'securityCode', 'Security Code')"
     [ngClass]="{ disabled: !cipher.card.code }"
+    [attr.disabled]="!cipher.card.code ? '' : null"
   >
     <i class="bwi bwi-lg bwi-key" aria-hidden="true"></i>
   </button>
@@ -89,6 +95,7 @@
     appA11yTitle="{{ 'copyNote' | i18n }}"
     (click)="copy(cipher, cipher.notes, 'note', 'Note')"
     [ngClass]="{ disabled: !cipher.notes }"
+    [attr.disabled]="!cipher.notes ? '' : null"
   >
     <i class="bwi bwi-lg bwi-clone" aria-hidden="true"></i>
   </button>

--- a/src/popup/components/cipher-row.component.html
+++ b/src/popup/components/cipher-row.component.html
@@ -1,4 +1,6 @@
 <div
+  role="group"
+  appA11yTitle="{{ cipher.name }}"
   class="box-content-row box-content-row-flex virtual-scroll-item"
   [ngClass]="{ 'override-last': !last }"
 >

--- a/src/popup/components/cipher-row.component.html
+++ b/src/popup/components/cipher-row.component.html
@@ -1,13 +1,15 @@
-<button
-  type="button"
-  (click)="selectCipher(cipher)"
-  (dblclick)="launchCipher(cipher)"
-  appStopClick
-  title="{{ title }} - {{ cipher.name }}"
+<div
   class="box-content-row box-content-row-flex virtual-scroll-item"
   [ngClass]="{ 'override-last': !last }"
 >
-  <div class="row-main">
+  <button
+    type="button"
+    (click)="selectCipher(cipher)"
+    (dblclick)="launchCipher(cipher)"
+    appStopClick
+    title="{{ title }} - {{ cipher.name }}"
+    class="row-main"
+  >
     <app-vault-icon [cipher]="cipher"></app-vault-icon>
     <div class="row-main-content">
       <span class="text">
@@ -31,7 +33,7 @@
       </span>
       <span class="detail">{{ cipher.subTitle }}</span>
     </div>
-  </div>
+  </button>
   <app-action-buttons
     [cipher]="cipher"
     [showView]="showView"
@@ -40,4 +42,4 @@
     class="action-buttons"
   >
   </app-action-buttons>
-</button>
+</div>

--- a/src/popup/scss/box.scss
+++ b/src/popup/scss/box.scss
@@ -136,6 +136,7 @@
         .row-main {
           display: flex;
           min-width: 0;
+          align-items: normal;
 
           .row-main-content {
             min-width: 0;
@@ -283,6 +284,7 @@
   .text,
   .detail {
     display: block;
+    text-align: left;
 
     @include themify($themes) {
       color: themed("textColor");


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Currently, the various controls for each cipher/item in "Tab" and "My Vault" are not operable using the keyboard. Only the item as a whole receives focus, so a keyboard user can currently only either autofill (in "Tab") or view the item (in "My Vault"). The other controls (e.g. to copy just the username or password, to view - when in "Tab" -, etc) are only operable with the mouse.

This PR makes all controls for each cipher/item actual `<button>` elements, meaning they can be focused and operated using the keyboard. When the control is disabled, the `<button>` also receives an actual `disabled` attribute, making it non-keyboard-focusable and programmatically denoting that it's disabled.

In addition, this PR also adds extra information to each cipher/item, giving it an ARIA group role and an explicit `aria-label`. When navigating through the items, a screen reader user will now get information when they enter a new item/group and what the item's name is - this way, they get more information about what the various copy etc controls refer to.

Closes https://github.com/bitwarden/browser/issues/1986

## Code changes

- **src/popup/components/action-buttons.component.html**: change the various `<span>`s for the action buttons into actual `<button>` elements; conditionally also adds the `disabled` attribute if the control is disabled
- **src/popup/components/cipher-row.component.html**: changes the outer container from `<button>` to a `<div>` (as you can't have nested buttons); adds a `role="group"` and `aria-label` to the item/cipher to give it context for the various controls inside; `.row-main` is changed from `<div>` to `<button>`, taking on the main functionality of each item/cipher
- **src/popup/scss/box.scss**: modifications to maintain the same look and feel for the action buttons and cipher rows, now that the elements have changed per the above

## Screenshots

No visual change to the interface. This video demonstrates the before/after behavior/announcements using Chrome/NVDA screen reader as an example. 

Note that in the current extension, navigating using `Tab` (even without a screen reader), only the items/ciphers as a whole receive focus and can be actioned. It's not possible using the keyboard to specifically reach any of the action buttons.

With the changes from this PR applied (0:28), note how when navigating with `Tab`, each item/cipher's various controls are individually focusable and actionable.

In addition, in the end (0:55) we navigate through the items using reading/cursor keys. Note how each time we enter/leave a group, this is announced. Also note how the disabled controls are announced as "button unavailable"

https://user-images.githubusercontent.com/895831/163687629-76544c18-6758-475e-8b2c-2b23db2b1f45.mp4

## Testing requirements

- navigate through the "Tab" and "My Vault" cipher/item lists using the keyboard (`Tab`/`Shift+Tab`). verify that each control can now be individually focused and activated (using `Space` or `Enter`). verify that disabled action buttons don't receive focus. 
- using a screen reader (e.g. NVDA on Windows), navigate through the cipher/item lists (both using `Tab`/`Shift+Tab` and using reading/cursor keys). verify that all groupings are announced, and that each button announces correctly. when navigating using reading/cursor keys, verify that disabled buttons are announced as disabled/unavailable

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
