### PR TITLE
Remove unnecessary `role="button"` on `<button>` elements

### DIFF
--- a/src/popup/accounts/set-password.component.html
+++ b/src/popup/accounts/set-password.component.html
@@ -65,7 +65,6 @@
                   class="row-btn"
                   appStopClick
                   appBlurClick
-                  role="button"
                   appA11yTitle="{{ 'toggleVisibility' | i18n }}"
                   (click)="togglePassword(false)"
                   [attr.aria-pressed]="showPassword"
@@ -118,7 +117,6 @@
                   class="row-btn"
                   appStopClick
                   appBlurClick
-                  role="button"
                   appA11yTitle="{{ 'toggleVisibility' | i18n }}"
                   (click)="togglePassword(true)"
                   [attr.aria-pressed]="showPassword"

--- a/src/popup/components/password-reprompt.component.html
+++ b/src/popup/components/password-reprompt.component.html
@@ -24,7 +24,6 @@
                   class="row-btn"
                   appStopClick
                   appBlurClick
-                  role="button"
                   appA11yTitle="{{ 'toggleVisibility' | i18n }}"
                   (click)="togglePassword()"
                   [attr.aria-pressed]="showPassword"


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

`<button>` elements already have an implicit button role by default, so `role="button"` is unnecessary

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **src/popup/accounts/set-password.component.html** and **src/popup/components/password-reprompt.component.html**:  remove unnecessary `role="button"`

## Screenshots

No UI/visual change change.

## Testing requirements

None.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
