### PR TITLE
fix disabling of generate type

### DIFF
--- a/src/popup/generator/generator.component.html
+++ b/src/popup/generator/generator.component.html
@@ -79,7 +79,7 @@
             [value]="o.value"
             (change)="typeChanged()"
             [checked]="type === o.value"
-            [disabled]="comingFromAddEdit"
+            [disabled]="comingFromAddEdit && type !== o.value"
           />
           <label for="type_{{ o.value }}">
             {{ o.name }}


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Show current selection as enabled on generator type option when "coming from add/edit" page.

## Code changes

- generator component view - Expended condition in `[disable]` attribute to only include types that are not the current selection.
- 
## Screenshots

![image](https://user-images.githubusercontent.com/1190944/164483635-7db440ab-6d96-4422-bef0-8d3c7b2bae23.png)

## Testing requirements

Test generating usernames and passwords from add/edit page.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
