### PR TITLE
Forwarded email providers to username generator

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1939,5 +1939,21 @@
   },
   "service": {
     "message": "Service"
+  },
+  "forwardedEmail": {
+    "message": "Forwarded Email Alias"
+  },
+  "forwardedEmailDesc": {
+    "message": "Generate an email alias with an external forwarding service."
+  },
+  "hostname": {
+    "message": "Hostname",
+    "description": "Part of a URL."
+  },
+  "apiAccessToken": {
+    "message": "API Access Token"
+  },
+  "apiKey": {
+    "message": "API Key"
   }
 }

--- a/src/popup/generator/generator.component.html
+++ b/src/popup/generator/generator.component.html
@@ -334,6 +334,62 @@
             </label>
           </div>
         </div>
+        <ng-container *ngIf="usernameOptions.forwardedService === 'simplelogin'">
+          <div class="box-content-row" appBoxRow>
+            <label for="simplelogin-apikey">{{ "apiKey" | i18n }}</label>
+            <input
+              id="simplelogin-apikey"
+              type="password"
+              name="SimpleLoginApiKey"
+              [(ngModel)]="usernameOptions.forwardedSimpleLoginApiKey"
+              (blur)="saveUsernameOptions()"
+            />
+          </div>
+          <div class="box-content-row" appBoxRow>
+            <label for="simplelogin-hostname">{{ "hostname" | i18n }}</label>
+            <input
+              id="simplelogin-hostname"
+              type="text"
+              name="SimpleLoginHostname"
+              [(ngModel)]="usernameOptions.forwardedSimpleLoginHostname"
+              (blur)="saveUsernameOptions()"
+            />
+          </div>
+        </ng-container>
+        <ng-container *ngIf="usernameOptions.forwardedService === 'anonaddy'">
+          <div class="box-content-row" appBoxRow>
+            <label for="anonaddy-accessToken">{{ "apiAccessToken" | i18n }}</label>
+            <input
+              id="anonaddy-accessToken"
+              type="password"
+              name="AnonAddyAccessToken"
+              [(ngModel)]="usernameOptions.forwardedAnonAddyApiToken"
+              (blur)="saveUsernameOptions()"
+            />
+          </div>
+          <div class="box-content-row" appBoxRow>
+            <label for="anonaddy-domain">{{ "domainName" | i18n }}</label>
+            <input
+              id="anonaddy-domain"
+              type="text"
+              name="AnonAddyDomain"
+              [(ngModel)]="usernameOptions.forwardedAnonAddyDomain"
+              (blur)="saveUsernameOptions()"
+            />
+          </div>
+        </ng-container>
+        <ng-container *ngIf="usernameOptions.forwardedService === 'firefoxrelay'">
+          <div class="box-content-row" appBoxRow>
+            <label for="firefox-apikey">{{ "apiAccessToken" | i18n }}</label>
+            <input
+              id="firefox-apikey"
+              type="password"
+              name="FirefoxApiKey"
+              [(ngModel)]="usernameOptions.forwardedFirefoxApiToken"
+              (blur)="saveUsernameOptions()"
+            />
+          </div>
+        </ng-container>
       </div>
     </div>
     <div class="box" *ngIf="usernameOptions.type === 'subaddress'">


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Add support for forwarded email generation with SimpleLogin, AnonAddy, and Firefox Relay to the username generator.

## Code changes

- **generator component view:** Added forwarded email provider options.
- **messages:** New translation strings.

## Screenshots

![image](https://user-images.githubusercontent.com/1190944/166258152-06cb24f6-360d-4885-91e2-daa0c03b7e0f.png)


## Testing requirements

Test each email forwarding service to make sure aliases are properly generated.

Test error conditions when service not properly configured.

Test error conditions when errors occur at the service itself (such as exceeding paid/free limits).


## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [x] This change has particular **deployment requirements** (notify the DevOps team)
