### PR TITLE
[PS-517] Normalise/fix button focus outlines

### DIFF
--- a/src/popup/scss/box.scss
+++ b/src/popup/scss/box.scss
@@ -505,7 +505,7 @@
 
   &:not(.box-draggable-row) {
     .action-buttons .row-btn:last-child {
-      padding-right: 2px !important;
+      margin-right: -3px;
     }
   }
 

--- a/src/popup/scss/pages.scss
+++ b/src/popup/scss/pages.scss
@@ -27,8 +27,8 @@ app-generator .generated-block {
     align-self: center;
 
     button {
-      padding-left: 5px;
-      margin-left: 10px;
+      padding: 5px;
+      margin: -5px -5px 5px 5px;
     }
   }
 }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

When navigating with the keyboard, you notice that the padding/margin around various (icon-based) controls is a bit...off-centre and disheveled looking.

This PR fixes the padding/margin so that icons always appear in the centre of their button. Using negative margins, this also tries to keep the overall look mostly the same/balanced.

## Code changes

- **box.scss**: remove the smaller right-hand padding, use negative right-hand margin instead
- **pages.scss**: tweak the padding/margin for the new generator buttons

## Screenshots

Login before:

![bitwarden-outline6](https://user-images.githubusercontent.com/895831/166297711-ffb8c070-16d7-4896-adab-85f09446d4ae.png)

Login after:

![bitwarden-outline6-fixed](https://user-images.githubusercontent.com/895831/166297756-c12a5537-10fc-4cd9-ace1-3bb22b168ace.png)

---

Tab before:

![bitwarden-outline2](https://user-images.githubusercontent.com/895831/166297810-9d5abe77-b23c-4579-96f5-e246a9fe5f0a.png)

Tab after:

![bitwarden-outline2-fixed](https://user-images.githubusercontent.com/895831/166297830-3e8ddad0-39b6-42d4-872c-4b6bef6e6d5f.png)

---

My Vault before:

![bitwarden-outline3-fixed](https://user-images.githubusercontent.com/895831/166297912-915f2e33-c6d0-41e4-9840-c0a7ecc85aa1.png)

My Vault after:

![bitwarden-outline3](https://user-images.githubusercontent.com/895831/166297986-2a8ef3a5-4fd2-4716-b22a-53ddb22e9afa.png)

---

Generator copy before:

![bitwarden-outline4](https://user-images.githubusercontent.com/895831/166298226-7922e69d-7885-4c46-a637-9f52438b8455.png)

Generator copy after: 

![bitwarden-outline4-fixed](https://user-images.githubusercontent.com/895831/166298313-6bb72f3e-e4e4-4617-8b84-c2b54d714b59.png)

Generator refresh before:

![bitwarden-outline5](https://user-images.githubusercontent.com/895831/166298346-6379c061-efdd-466c-a818-5c7b8f7b401a.png)

Generator refresh after:

![bitwarden-outline5-fixed](https://user-images.githubusercontent.com/895831/166298389-4c219799-c8da-473a-bf49-e2f4733b3d72.png)

## Testing requirements

- test using keyboard navigation (`Tab` / `Shift+Tab`)

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
