### PR TITLE
[EC-183] Bump jslib to match the expected version

### DIFF
--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -157,35 +157,35 @@ jobs:
         uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535  # v3.0.0 
         with:
           name: dist-opera-${{ env._BUILD_NUMBER }}.zip
-          path: dist/dist-opera.zip
+          path: apps/browser/dist/dist-opera.zip
           if-no-files-found: error
 
       - name: Upload Chrome artifact
         uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535  # v3.0.0
         with:
           name: dist-chrome-${{ env._BUILD_NUMBER }}.zip
-          path: dist/dist-chrome.zip
+          path: apps/browser/dist/dist-chrome.zip
           if-no-files-found: error
 
       - name: Upload Firefox artifact
         uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535  # v3.0.0
         with:
           name: dist-firefox-${{ env._BUILD_NUMBER }}.zip
-          path: dist/dist-firefox.zip
+          path: apps/browser/dist/dist-firefox.zip
           if-no-files-found: error
 
       - name: Upload Edge artifact
         uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535  # v3.0.0
         with:
           name: dist-edge-${{ env._BUILD_NUMBER }}.zip
-          path: dist/dist-edge.zip
+          path: apps/browser/dist/dist-edge.zip
           if-no-files-found: error
 
       - name: Upload browser source
         uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535  # v3.0.0
         with:
           name: browser-source-${{ env._BUILD_NUMBER }}.zip
-          path: dist/browser-source.zip
+          path: apps/browser/dist/browser-source.zip
           if-no-files-found: error
 
       - name: Upload coverage artifact
@@ -193,7 +193,7 @@ jobs:
         uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535  # v3.0.0
         with:
           name: coverage-${{ env._BUILD_NUMBER }}.zip
-          path: coverage/coverage-${{ env._BUILD_NUMBER }}.zip
+          path: apps/browser/coverage/coverage-${{ env._BUILD_NUMBER }}.zip
           if-no-files-found: error
 
 


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
While doing the last touches up on the mono repository, I forgot to bump jslib to the expected commit.

It also seems we lost the artifact path fixes from #2533.

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
